### PR TITLE
Add PDF/EPS (vector+raster), BMP/ASCII renderers

### DIFF
--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -1,4 +1,5 @@
 using System;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Html;
@@ -30,6 +31,12 @@ public sealed class RendererFormatTests {
         var eps = QrEasy.RenderEps(payload);
         Assert.True(IsEps(eps));
 
+        var pdfRaster = QrEasy.RenderPdf(payload, mode: RenderMode.Raster);
+        Assert.True(IsPdf(pdfRaster));
+
+        var epsRaster = QrEasy.RenderEps(payload, mode: RenderMode.Raster);
+        Assert.True(IsEps(epsRaster));
+
         var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions { QuietZone = 1 });
         Assert.Contains("#", ascii, StringComparison.Ordinal);
     }
@@ -54,6 +61,12 @@ public sealed class RendererFormatTests {
 
         var eps = Barcode.Eps(BarcodeType.Code128, "CODEGLYPH-123");
         Assert.True(IsEps(eps));
+
+        var pdfRaster = Barcode.Pdf(BarcodeType.Code128, "CODEGLYPH-123", mode: RenderMode.Raster);
+        Assert.True(IsPdf(pdfRaster));
+
+        var epsRaster = Barcode.Eps(BarcodeType.Code128, "CODEGLYPH-123", mode: RenderMode.Raster);
+        Assert.True(IsEps(epsRaster));
 
         var ascii = BarcodeAsciiRenderer.Render(barcode, new BarcodeAsciiRenderOptions { QuietZone = 1, Height = 2 });
         Assert.Contains("#", ascii, StringComparison.Ordinal);

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -24,6 +24,12 @@ public sealed class RendererFormatTests {
         var bmp = QrEasy.RenderBmp(payload);
         Assert.True(IsBmp(bmp));
 
+        var pdf = QrEasy.RenderPdf(payload);
+        Assert.True(IsPdf(pdf));
+
+        var eps = QrEasy.RenderEps(payload);
+        Assert.True(IsEps(eps));
+
         var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions { QuietZone = 1 });
         Assert.Contains("#", ascii, StringComparison.Ordinal);
     }
@@ -42,6 +48,12 @@ public sealed class RendererFormatTests {
 
         var bmp = BarcodeBmpRenderer.Render(barcode, new BarcodePngRenderOptions());
         Assert.True(IsBmp(bmp));
+
+        var pdf = Barcode.Pdf(BarcodeType.Code128, "CODEGLYPH-123");
+        Assert.True(IsPdf(pdf));
+
+        var eps = Barcode.Eps(BarcodeType.Code128, "CODEGLYPH-123");
+        Assert.True(IsEps(eps));
 
         var ascii = BarcodeAsciiRenderer.Render(barcode, new BarcodeAsciiRenderOptions { QuietZone = 1, Height = 2 });
         Assert.Contains("#", ascii, StringComparison.Ordinal);
@@ -62,5 +74,19 @@ public sealed class RendererFormatTests {
     private static bool IsBmp(byte[] data) {
         if (data is null || data.Length < 2) return false;
         return data[0] == (byte)'B' && data[1] == (byte)'M';
+    }
+
+    private static bool IsPdf(byte[] data) {
+        if (data is null || data.Length < 5) return false;
+        return data[0] == (byte)'%' &&
+               data[1] == (byte)'P' &&
+               data[2] == (byte)'D' &&
+               data[3] == (byte)'F' &&
+               data[4] == (byte)'-';
+    }
+
+    private static bool IsEps(string text) {
+        if (string.IsNullOrEmpty(text)) return false;
+        return text.StartsWith("%!PS-Adobe", StringComparison.Ordinal);
     }
 }

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -1,4 +1,6 @@
 using System;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
@@ -18,6 +20,12 @@ public sealed class RendererFormatTests {
 
         var html = QrEasy.RenderHtml(payload);
         Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
+
+        var bmp = QrEasy.RenderBmp(payload);
+        Assert.True(IsBmp(bmp));
+
+        var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions { QuietZone = 1 });
+        Assert.Contains("#", ascii, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -31,6 +39,12 @@ public sealed class RendererFormatTests {
 
         var html = HtmlBarcodeRenderer.Render(barcode, new BarcodeHtmlRenderOptions());
         Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
+
+        var bmp = BarcodeBmpRenderer.Render(barcode, new BarcodePngRenderOptions());
+        Assert.True(IsBmp(bmp));
+
+        var ascii = BarcodeAsciiRenderer.Render(barcode, new BarcodeAsciiRenderOptions { QuietZone = 1, Height = 2 });
+        Assert.Contains("#", ascii, StringComparison.Ordinal);
     }
 
     private static bool IsPng(byte[] data) {
@@ -43,5 +57,10 @@ public sealed class RendererFormatTests {
                data[5] == 0x0A &&
                data[6] == 0x1A &&
                data[7] == 0x0A;
+    }
+
+    private static bool IsBmp(byte[] data) {
+        if (data is null || data.Length < 2) return false;
+        return data[0] == (byte)'B' && data[1] == (byte)'M';
     }
 }

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -3,8 +3,10 @@ using System.IO;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pdf;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 
@@ -72,6 +74,24 @@ public static class Barcode {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
         return BarcodeBmpRenderer.Render(barcode, opts);
+    }
+
+    /// <summary>
+    /// Renders a barcode as PDF.
+    /// </summary>
+    public static byte[] Pdf(BarcodeType type, string content, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        return BarcodePdfRenderer.Render(barcode, opts);
+    }
+
+    /// <summary>
+    /// Renders a barcode as EPS.
+    /// </summary>
+    public static string Eps(BarcodeType type, string content, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        return BarcodeEpsRenderer.Render(barcode, opts);
     }
 
     /// <summary>
@@ -173,6 +193,39 @@ public static class Barcode {
     }
 
     /// <summary>
+    /// Renders a barcode as PDF and writes it to a file.
+    /// </summary>
+    public static string SavePdf(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
+        var pdf = Pdf(type, content, options);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Renders a barcode as PDF and writes it to a stream.
+    /// </summary>
+    public static void SavePdf(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        BarcodePdfRenderer.RenderToStream(barcode, opts, stream);
+    }
+
+    /// <summary>
+    /// Renders a barcode as EPS and writes it to a file.
+    /// </summary>
+    public static string SaveEps(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
+        var eps = Eps(type, content, options);
+        return eps.WriteText(path);
+    }
+
+    /// <summary>
+    /// Renders a barcode as EPS and writes it to a stream.
+    /// </summary>
+    public static void SaveEps(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
+        var eps = Eps(type, content, options);
+        eps.WriteText(stream);
+    }
+
+    /// <summary>
     /// Renders a barcode as ASCII text and writes it to a file.
     /// </summary>
     public static string SaveAscii(BarcodeType type, string content, string path, BarcodeAsciiRenderOptions? options = null) {
@@ -181,7 +234,7 @@ public static class Barcode {
     }
 
     /// <summary>
-    /// Saves a barcode to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves a barcode to a file based on the file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
@@ -201,6 +254,11 @@ public static class Barcode {
                 return SaveJpeg(type, content, path, options);
             case ".bmp":
                 return SaveBmp(type, content, path, options);
+            case ".pdf":
+                return SavePdf(type, content, path, options);
+            case ".eps":
+            case ".ps":
+                return SaveEps(type, content, path, options);
             default:
                 // Fallback to PNG for unknown extensions to keep the API forgiving.
                 return SavePng(type, content, path, options);
@@ -492,6 +550,16 @@ public static class Barcode {
         public byte[] Bmp() => Barcode.Bmp(_type, _content, Options);
 
         /// <summary>
+        /// Renders PDF bytes.
+        /// </summary>
+        public byte[] Pdf() => Barcode.Pdf(_type, _content, Options);
+
+        /// <summary>
+        /// Renders EPS text.
+        /// </summary>
+        public string Eps() => Barcode.Eps(_type, _content, Options);
+
+        /// <summary>
         /// Renders ASCII text.
         /// </summary>
         public string Ascii(BarcodeAsciiRenderOptions? options = null) => Barcode.Ascii(_type, _content, options);
@@ -547,12 +615,32 @@ public static class Barcode {
         public void SaveBmp(Stream stream) => Barcode.SaveBmp(_type, _content, stream, Options);
 
         /// <summary>
+        /// Saves PDF to a file.
+        /// </summary>
+        public string SavePdf(string path) => Barcode.SavePdf(_type, _content, path, Options);
+
+        /// <summary>
+        /// Saves PDF to a stream.
+        /// </summary>
+        public void SavePdf(Stream stream) => Barcode.SavePdf(_type, _content, stream, Options);
+
+        /// <summary>
+        /// Saves EPS to a file.
+        /// </summary>
+        public string SaveEps(string path) => Barcode.SaveEps(_type, _content, path, Options);
+
+        /// <summary>
+        /// Saves EPS to a stream.
+        /// </summary>
+        public void SaveEps(Stream stream) => Barcode.SaveEps(_type, _content, stream, Options);
+
+        /// <summary>
         /// Saves ASCII to a file.
         /// </summary>
         public string SaveAscii(string path, BarcodeAsciiRenderOptions? options = null) => Barcode.SaveAscii(_type, _content, path, options);
 
         /// <summary>
-        /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp). Defaults to PNG when no extension is provided.
+        /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) => Barcode.Save(_type, _content, path, Options, title);
     }

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
@@ -61,6 +63,23 @@ public static class Barcode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 90;
         return BarcodeJpegRenderer.Render(barcode, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders a barcode as BMP.
+    /// </summary>
+    public static byte[] Bmp(BarcodeType type, string content, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        return BarcodeBmpRenderer.Render(barcode, opts);
+    }
+
+    /// <summary>
+    /// Renders a barcode as ASCII text.
+    /// </summary>
+    public static string Ascii(BarcodeType type, string content, BarcodeAsciiRenderOptions? options = null) {
+        var barcode = Encode(type, content);
+        return BarcodeAsciiRenderer.Render(barcode, options);
     }
 
     /// <summary>
@@ -137,7 +156,32 @@ public static class Barcode {
     }
 
     /// <summary>
-    /// Saves a barcode to a file based on the file extension (.png/.svg/.html/.jpg).
+    /// Renders a barcode as BMP and writes it to a file.
+    /// </summary>
+    public static string SaveBmp(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
+        var bmp = Bmp(type, content, options);
+        return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Renders a barcode as BMP and writes it to a stream.
+    /// </summary>
+    public static void SaveBmp(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        BarcodeBmpRenderer.RenderToStream(barcode, opts, stream);
+    }
+
+    /// <summary>
+    /// Renders a barcode as ASCII text and writes it to a file.
+    /// </summary>
+    public static string SaveAscii(BarcodeType type, string content, string path, BarcodeAsciiRenderOptions? options = null) {
+        var ascii = Ascii(type, content, options);
+        return ascii.WriteText(path);
+    }
+
+    /// <summary>
+    /// Saves a barcode to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
@@ -155,6 +199,8 @@ public static class Barcode {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(type, content, path, options);
+            case ".bmp":
+                return SaveBmp(type, content, path, options);
             default:
                 // Fallback to PNG for unknown extensions to keep the API forgiving.
                 return SavePng(type, content, path, options);
@@ -441,6 +487,16 @@ public static class Barcode {
         public byte[] Jpeg() => Barcode.Jpeg(_type, _content, Options);
 
         /// <summary>
+        /// Renders BMP bytes.
+        /// </summary>
+        public byte[] Bmp() => Barcode.Bmp(_type, _content, Options);
+
+        /// <summary>
+        /// Renders ASCII text.
+        /// </summary>
+        public string Ascii(BarcodeAsciiRenderOptions? options = null) => Barcode.Ascii(_type, _content, options);
+
+        /// <summary>
         /// Saves PNG to a file.
         /// </summary>
         public string SavePng(string path) => Barcode.SavePng(_type, _content, path, Options);
@@ -481,7 +537,22 @@ public static class Barcode {
         public void SaveJpeg(Stream stream) => Barcode.SaveJpeg(_type, _content, stream, Options);
 
         /// <summary>
-        /// Saves based on file extension (.png/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
+        /// Saves BMP to a file.
+        /// </summary>
+        public string SaveBmp(string path) => Barcode.SaveBmp(_type, _content, path, Options);
+
+        /// <summary>
+        /// Saves BMP to a stream.
+        /// </summary>
+        public void SaveBmp(Stream stream) => Barcode.SaveBmp(_type, _content, stream, Options);
+
+        /// <summary>
+        /// Saves ASCII to a file.
+        /// </summary>
+        public string SaveAscii(string path, BarcodeAsciiRenderOptions? options = null) => Barcode.SaveAscii(_type, _content, path, options);
+
+        /// <summary>
+        /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) => Barcode.Save(_type, _content, path, Options, title);
     }

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -79,19 +79,19 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as PDF.
     /// </summary>
-    public static byte[] Pdf(BarcodeType type, string content, BarcodeOptions? options = null) {
+    public static byte[] Pdf(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
-        return BarcodePdfRenderer.Render(barcode, opts);
+        return BarcodePdfRenderer.Render(barcode, opts, mode);
     }
 
     /// <summary>
     /// Renders a barcode as EPS.
     /// </summary>
-    public static string Eps(BarcodeType type, string content, BarcodeOptions? options = null) {
+    public static string Eps(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
-        return BarcodeEpsRenderer.Render(barcode, opts);
+        return BarcodeEpsRenderer.Render(barcode, opts, mode);
     }
 
     /// <summary>
@@ -195,33 +195,33 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as PDF and writes it to a file.
     /// </summary>
-    public static string SavePdf(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
-        var pdf = Pdf(type, content, options);
+    public static string SavePdf(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var pdf = Pdf(type, content, options, mode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Renders a barcode as PDF and writes it to a stream.
     /// </summary>
-    public static void SavePdf(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
+    public static void SavePdf(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
-        BarcodePdfRenderer.RenderToStream(barcode, opts, stream);
+        BarcodePdfRenderer.RenderToStream(barcode, opts, stream, mode);
     }
 
     /// <summary>
     /// Renders a barcode as EPS and writes it to a file.
     /// </summary>
-    public static string SaveEps(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
-        var eps = Eps(type, content, options);
+    public static string SaveEps(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var eps = Eps(type, content, options, mode);
         return eps.WriteText(path);
     }
 
     /// <summary>
     /// Renders a barcode as EPS and writes it to a stream.
     /// </summary>
-    public static void SaveEps(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
-        var eps = Eps(type, content, options);
+    public static void SaveEps(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var eps = Eps(type, content, options, mode);
         eps.WriteText(stream);
     }
 
@@ -552,12 +552,12 @@ public static class Barcode {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
-        public byte[] Pdf() => Barcode.Pdf(_type, _content, Options);
+        public byte[] Pdf(RenderMode mode = RenderMode.Vector) => Barcode.Pdf(_type, _content, Options, mode);
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
-        public string Eps() => Barcode.Eps(_type, _content, Options);
+        public string Eps(RenderMode mode = RenderMode.Vector) => Barcode.Eps(_type, _content, Options, mode);
 
         /// <summary>
         /// Renders ASCII text.
@@ -617,22 +617,22 @@ public static class Barcode {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
-        public string SavePdf(string path) => Barcode.SavePdf(_type, _content, path, Options);
+        public string SavePdf(string path, RenderMode mode = RenderMode.Vector) => Barcode.SavePdf(_type, _content, path, Options, mode);
 
         /// <summary>
         /// Saves PDF to a stream.
         /// </summary>
-        public void SavePdf(Stream stream) => Barcode.SavePdf(_type, _content, stream, Options);
+        public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) => Barcode.SavePdf(_type, _content, stream, Options, mode);
 
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
-        public string SaveEps(string path) => Barcode.SaveEps(_type, _content, path, Options);
+        public string SaveEps(string path, RenderMode mode = RenderMode.Vector) => Barcode.SaveEps(_type, _content, path, Options, mode);
 
         /// <summary>
         /// Saves EPS to a stream.
         /// </summary>
-        public void SaveEps(Stream stream) => Barcode.SaveEps(_type, _content, stream, Options);
+        public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) => Barcode.SaveEps(_type, _content, stream, Options, mode);
 
         /// <summary>
         /// Saves ASCII to a file.

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -4,8 +4,10 @@ using CodeGlyphX.DataMatrix;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pdf;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 
@@ -94,6 +96,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Renders Data Matrix as PDF from bytes.
+    /// </summary>
+    public static byte[] Pdf(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as EPS from bytes.
+    /// </summary>
+    public static string Eps(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
     /// Renders Data Matrix as ASCII from bytes.
     /// </summary>
     public static string Ascii(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
@@ -172,6 +190,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix PDF to a file for byte payloads.
+    /// </summary>
+    public static string SavePdf(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var pdf = Pdf(data, mode, options);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix EPS to a file for byte payloads.
+    /// </summary>
+    public static string SaveEps(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var eps = Eps(data, mode, options);
+        return eps.WriteText(path);
+    }
+
+    /// <summary>
     /// Saves Data Matrix JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -190,7 +224,23 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves Data Matrix PDF to a stream for byte payloads.
+    /// </summary>
+    public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix EPS to a stream for byte payloads.
+    /// </summary>
+    public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -210,6 +260,11 @@ public static class DataMatrixCode {
                 return SaveJpeg(data, path, mode, options);
             case ".bmp":
                 return SaveBmp(data, path, mode, options);
+            case ".pdf":
+                return SavePdf(data, path, mode, options);
+            case ".eps":
+            case ".ps":
+                return SaveEps(data, path, mode, options);
             default:
                 return SavePng(data, path, mode, options);
         }
@@ -283,6 +338,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Renders Data Matrix as PDF.
+    /// </summary>
+    public static byte[] Pdf(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as EPS.
+    /// </summary>
+    public static string Eps(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
     /// Renders Data Matrix as ASCII.
     /// </summary>
     public static string Ascii(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
@@ -306,6 +377,22 @@ public static class DataMatrixCode {
     public static byte[] Bmp(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as PDF from bytes.
+    /// </summary>
+    public static byte[] Pdf(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as EPS from bytes.
+    /// </summary>
+    public static string Eps(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options));
     }
 
     /// <summary>
@@ -441,6 +528,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix PDF to a file.
+    /// </summary>
+    public static string SavePdf(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var pdf = Pdf(text, mode, options);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix EPS to a file.
+    /// </summary>
+    public static string SaveEps(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var eps = Eps(text, mode, options);
+        return eps.WriteText(path);
+    }
+
+    /// <summary>
     /// Saves Data Matrix JPEG to a file for byte payloads.
     /// </summary>
     public static string SaveJpeg(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -454,6 +557,22 @@ public static class DataMatrixCode {
     public static string SaveBmp(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var bmp = Bmp(data, mode, options);
         return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix PDF to a file for byte payloads.
+    /// </summary>
+    public static string SavePdf(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var pdf = Pdf(data, mode, options);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix EPS to a file for byte payloads.
+    /// </summary>
+    public static string SaveEps(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var eps = Eps(data, mode, options);
+        return eps.WriteText(path);
     }
 
     /// <summary>
@@ -475,6 +594,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix PDF to a stream.
+    /// </summary>
+    public static void SavePdf(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix EPS to a stream.
+    /// </summary>
+    public static void SaveEps(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
     /// Saves Data Matrix JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -493,7 +628,23 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file based on extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves Data Matrix PDF to a stream for byte payloads.
+    /// </summary>
+    public static void SavePdf(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix EPS to a stream for byte payloads.
+    /// </summary>
+    public static void SaveEps(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file based on extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -513,13 +664,18 @@ public static class DataMatrixCode {
                 return SaveJpeg(text, path, mode, options);
             case ".bmp":
                 return SaveBmp(text, path, mode, options);
+            case ".pdf":
+                return SavePdf(text, path, mode, options);
+            case ".eps":
+            case ".ps":
+                return SaveEps(text, path, mode, options);
             default:
                 return SavePng(text, path, mode, options);
         }
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -539,6 +695,11 @@ public static class DataMatrixCode {
                 return SaveJpeg(data, path, mode, options);
             case ".bmp":
                 return SaveBmp(data, path, mode, options);
+            case ".pdf":
+                return SavePdf(data, path, mode, options);
+            case ".eps":
+            case ".ps":
+                return SaveEps(data, path, mode, options);
             default:
                 return SavePng(data, path, mode, options);
         }
@@ -754,6 +915,20 @@ public static class DataMatrixCode {
         }
 
         /// <summary>
+        /// Renders PDF bytes.
+        /// </summary>
+        public byte[] Pdf() {
+            return _text is not null ? DataMatrixCode.Pdf(_text, _mode, _options) : DataMatrixCode.Pdf(_bytes!, _mode, _options);
+        }
+
+        /// <summary>
+        /// Renders EPS text.
+        /// </summary>
+        public string Eps() {
+            return _text is not null ? DataMatrixCode.Eps(_text, _mode, _options) : DataMatrixCode.Eps(_bytes!, _mode, _options);
+        }
+
+        /// <summary>
         /// Renders ASCII text.
         /// </summary>
         public string Ascii(MatrixAsciiRenderOptions? options = null) {
@@ -801,6 +976,20 @@ public static class DataMatrixCode {
         /// </summary>
         public string SaveBmp(string path) {
             return _text is not null ? DataMatrixCode.SaveBmp(_text, path, _mode, _options) : DataMatrixCode.SaveBmp(_bytes!, path, _mode, _options);
+        }
+
+        /// <summary>
+        /// Saves PDF to a file.
+        /// </summary>
+        public string SavePdf(string path) {
+            return _text is not null ? DataMatrixCode.SavePdf(_text, path, _mode, _options) : DataMatrixCode.SavePdf(_bytes!, path, _mode, _options);
+        }
+
+        /// <summary>
+        /// Saves EPS to a file.
+        /// </summary>
+        public string SaveEps(string path) {
+            return _text is not null ? DataMatrixCode.SaveEps(_text, path, _mode, _options) : DataMatrixCode.SaveEps(_bytes!, path, _mode, _options);
         }
     }
 }

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using CodeGlyphX.DataMatrix;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
@@ -84,6 +86,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Renders Data Matrix as BMP from bytes.
+    /// </summary>
+    public static byte[] Bmp(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as ASCII from bytes.
+    /// </summary>
+    public static string Ascii(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixAsciiRenderer.Render(modules, options);
+    }
+
+    /// <summary>
     /// Saves Data Matrix PNG to a file for byte payloads.
     /// </summary>
     public static string SavePng(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -146,6 +164,14 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix BMP to a file for byte payloads.
+    /// </summary>
+    public static string SaveBmp(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var bmp = Bmp(data, mode, options);
+        return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
     /// Saves Data Matrix JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -156,7 +182,15 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg).
+    /// Saves Data Matrix BMP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -174,6 +208,8 @@ public static class DataMatrixCode {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(data, path, mode, options);
+            case ".bmp":
+                return SaveBmp(data, path, mode, options);
             default:
                 return SavePng(data, path, mode, options);
         }
@@ -239,6 +275,22 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Renders Data Matrix as BMP.
+    /// </summary>
+    public static byte[] Bmp(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as ASCII.
+    /// </summary>
+    public static string Ascii(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
+        var modules = Encode(text, mode);
+        return MatrixAsciiRenderer.Render(modules, options);
+    }
+
+    /// <summary>
     /// Renders Data Matrix as JPEG from bytes.
     /// </summary>
     public static byte[] Jpeg(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -246,6 +298,22 @@ public static class DataMatrixCode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 85;
         return MatrixJpegRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as BMP from bytes.
+    /// </summary>
+    public static byte[] Bmp(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as ASCII from bytes.
+    /// </summary>
+    public static string Ascii(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        return MatrixAsciiRenderer.Render(modules, options);
     }
 
     /// <summary>
@@ -365,11 +433,27 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix BMP to a file.
+    /// </summary>
+    public static string SaveBmp(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var bmp = Bmp(text, mode, options);
+        return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
     /// Saves Data Matrix JPEG to a file for byte payloads.
     /// </summary>
     public static string SaveJpeg(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var jpeg = Jpeg(data, mode, options);
         return jpeg.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix BMP to a file for byte payloads.
+    /// </summary>
+    public static string SaveBmp(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var bmp = Bmp(data, mode, options);
+        return bmp.WriteBinary(path);
     }
 
     /// <summary>
@@ -383,6 +467,14 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix BMP to a stream.
+    /// </summary>
+    public static void SaveBmp(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
     /// Saves Data Matrix JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -393,7 +485,15 @@ public static class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file based on extension (.png/.svg/.html/.jpg).
+    /// Saves Data Matrix BMP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveBmp(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file based on extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -411,13 +511,15 @@ public static class DataMatrixCode {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(text, path, mode, options);
+            case ".bmp":
+                return SaveBmp(text, path, mode, options);
             default:
                 return SavePng(text, path, mode, options);
         }
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg).
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -435,6 +537,8 @@ public static class DataMatrixCode {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(data, path, mode, options);
+            case ".bmp":
+                return SaveBmp(data, path, mode, options);
             default:
                 return SavePng(data, path, mode, options);
         }
@@ -643,6 +747,20 @@ public static class DataMatrixCode {
         }
 
         /// <summary>
+        /// Renders BMP bytes.
+        /// </summary>
+        public byte[] Bmp() {
+            return _text is not null ? DataMatrixCode.Bmp(_text, _mode, _options) : DataMatrixCode.Bmp(_bytes!, _mode, _options);
+        }
+
+        /// <summary>
+        /// Renders ASCII text.
+        /// </summary>
+        public string Ascii(MatrixAsciiRenderOptions? options = null) {
+            return _text is not null ? DataMatrixCode.Ascii(_text, _mode, options) : DataMatrixCode.Ascii(_bytes!, _mode, options);
+        }
+
+        /// <summary>
         /// Saves output based on file extension.
         /// </summary>
         public string Save(string path, string? title = null) {
@@ -676,6 +794,13 @@ public static class DataMatrixCode {
         /// </summary>
         public string SaveJpeg(string path) {
             return _text is not null ? DataMatrixCode.SaveJpeg(_text, path, _mode, _options) : DataMatrixCode.SaveJpeg(_bytes!, path, _mode, _options);
+        }
+
+        /// <summary>
+        /// Saves BMP to a file.
+        /// </summary>
+        public string SaveBmp(string path) {
+            return _text is not null ? DataMatrixCode.SaveBmp(_text, path, _mode, _options) : DataMatrixCode.SaveBmp(_bytes!, path, _mode, _options);
         }
     }
 }

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -98,17 +98,17 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PDF from bytes.
     /// </summary>
-    public static byte[] Pdf(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static byte[] Pdf(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options));
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
     }
 
     /// <summary>
     /// Renders Data Matrix as EPS from bytes.
     /// </summary>
-    public static string Eps(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static string Eps(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options));
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
     }
 
     /// <summary>
@@ -192,16 +192,16 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a file for byte payloads.
     /// </summary>
-    public static string SavePdf(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
-        var pdf = Pdf(data, mode, options);
+    public static string SavePdf(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
+        var pdf = Pdf(data, mode, options, renderMode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Saves Data Matrix EPS to a file for byte payloads.
     /// </summary>
-    public static string SaveEps(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
-        var eps = Eps(data, mode, options);
+    public static string SaveEps(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
+        var eps = Eps(data, mode, options, renderMode);
         return eps.WriteText(path);
     }
 
@@ -226,17 +226,17 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a stream for byte payloads.
     /// </summary>
-    public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
     }
 
     /// <summary>
     /// Saves Data Matrix EPS to a stream for byte payloads.
     /// </summary>
-    public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
     }
 
     /// <summary>
@@ -340,17 +340,17 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PDF.
     /// </summary>
-    public static byte[] Pdf(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static byte[] Pdf(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
-        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options));
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
     }
 
     /// <summary>
     /// Renders Data Matrix as EPS.
     /// </summary>
-    public static string Eps(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static string Eps(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
-        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options));
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
     }
 
     /// <summary>
@@ -382,17 +382,17 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PDF from bytes.
     /// </summary>
-    public static byte[] Pdf(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static byte[] Pdf(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options));
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
     }
 
     /// <summary>
     /// Renders Data Matrix as EPS from bytes.
     /// </summary>
-    public static string Eps(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static string Eps(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options));
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
     }
 
     /// <summary>
@@ -530,16 +530,16 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a file.
     /// </summary>
-    public static string SavePdf(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
-        var pdf = Pdf(text, mode, options);
+    public static string SavePdf(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
+        var pdf = Pdf(text, mode, options, renderMode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Saves Data Matrix EPS to a file.
     /// </summary>
-    public static string SaveEps(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
-        var eps = Eps(text, mode, options);
+    public static string SaveEps(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
+        var eps = Eps(text, mode, options, renderMode);
         return eps.WriteText(path);
     }
 
@@ -562,16 +562,16 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a file for byte payloads.
     /// </summary>
-    public static string SavePdf(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
-        var pdf = Pdf(data, mode, options);
+    public static string SavePdf(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
+        var pdf = Pdf(data, mode, options, renderMode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Saves Data Matrix EPS to a file for byte payloads.
     /// </summary>
-    public static string SaveEps(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
-        var eps = Eps(data, mode, options);
+    public static string SaveEps(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
+        var eps = Eps(data, mode, options, renderMode);
         return eps.WriteText(path);
     }
 
@@ -596,17 +596,17 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a stream.
     /// </summary>
-    public static void SavePdf(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static void SavePdf(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
-        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
     }
 
     /// <summary>
     /// Saves Data Matrix EPS to a stream.
     /// </summary>
-    public static void SaveEps(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static void SaveEps(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
-        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
     }
 
     /// <summary>
@@ -630,17 +630,17 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a stream for byte payloads.
     /// </summary>
-    public static void SavePdf(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static void SavePdf(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
     }
 
     /// <summary>
     /// Saves Data Matrix EPS to a stream for byte payloads.
     /// </summary>
-    public static void SaveEps(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+    public static void SaveEps(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
-        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
     }
 
     /// <summary>
@@ -917,15 +917,15 @@ public static class DataMatrixCode {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
-        public byte[] Pdf() {
-            return _text is not null ? DataMatrixCode.Pdf(_text, _mode, _options) : DataMatrixCode.Pdf(_bytes!, _mode, _options);
+        public byte[] Pdf(RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? DataMatrixCode.Pdf(_text, _mode, _options, renderMode) : DataMatrixCode.Pdf(_bytes!, _mode, _options, renderMode);
         }
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
-        public string Eps() {
-            return _text is not null ? DataMatrixCode.Eps(_text, _mode, _options) : DataMatrixCode.Eps(_bytes!, _mode, _options);
+        public string Eps(RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? DataMatrixCode.Eps(_text, _mode, _options, renderMode) : DataMatrixCode.Eps(_bytes!, _mode, _options, renderMode);
         }
 
         /// <summary>
@@ -981,15 +981,15 @@ public static class DataMatrixCode {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
-        public string SavePdf(string path) {
-            return _text is not null ? DataMatrixCode.SavePdf(_text, path, _mode, _options) : DataMatrixCode.SavePdf(_bytes!, path, _mode, _options);
+        public string SavePdf(string path, RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? DataMatrixCode.SavePdf(_text, path, _mode, _options, renderMode) : DataMatrixCode.SavePdf(_bytes!, path, _mode, _options, renderMode);
         }
 
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
-        public string SaveEps(string path) {
-            return _text is not null ? DataMatrixCode.SaveEps(_text, path, _mode, _options) : DataMatrixCode.SaveEps(_bytes!, path, _mode, _options);
+        public string SaveEps(string path, RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? DataMatrixCode.SaveEps(_text, path, _mode, _options, renderMode) : DataMatrixCode.SaveEps(_bytes!, path, _mode, _options, renderMode);
         }
     }
 }

--- a/CodeGlyphX/Otp.cs
+++ b/CodeGlyphX/Otp.cs
@@ -223,7 +223,7 @@ public static class Otp {
     }
 
     /// <summary>
-    /// Saves a TOTP QR based on file extension (.png/.svg/.html/.jpg).
+    /// Saves a TOTP QR based on file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveTotp(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30, string? title = null) {
@@ -232,7 +232,7 @@ public static class Otp {
     }
 
     /// <summary>
-    /// Saves a HOTP QR based on file extension (.png/.svg/.html/.jpg).
+    /// Saves a HOTP QR based on file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveHotp(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, string? title = null) {

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Text;
 using CodeGlyphX.Pdf417;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
@@ -85,6 +87,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Renders PDF417 as BMP from bytes.
+    /// </summary>
+    public static byte[] Bmp(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as ASCII from bytes.
+    /// </summary>
+    public static string Ascii(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixAsciiRenderer.Render(modules, options);
+    }
+
+    /// <summary>
     /// Saves PDF417 PNG to a file for byte payloads.
     /// </summary>
     public static string SavePng(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -147,6 +165,14 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 BMP to a file for byte payloads.
+    /// </summary>
+    public static string SaveBmp(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var bmp = Bmp(data, encodeOptions, renderOptions);
+        return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
     /// Saves PDF417 JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -157,7 +183,15 @@ public static class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg).
+    /// Saves PDF417 BMP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -175,6 +209,8 @@ public static class Pdf417Code {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(data, path, encodeOptions, renderOptions);
+            case ".bmp":
+                return SaveBmp(data, path, encodeOptions, renderOptions);
             default:
                 return SavePng(data, path, encodeOptions, renderOptions);
         }
@@ -240,6 +276,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Renders PDF417 as BMP.
+    /// </summary>
+    public static byte[] Bmp(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as ASCII.
+    /// </summary>
+    public static string Ascii(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
+        var modules = Encode(text, encodeOptions);
+        return MatrixAsciiRenderer.Render(modules, options);
+    }
+
+    /// <summary>
     /// Renders PDF417 as JPEG from bytes.
     /// </summary>
     public static byte[] Jpeg(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -247,6 +299,22 @@ public static class Pdf417Code {
         var opts = BuildPngOptions(renderOptions);
         var quality = renderOptions?.JpegQuality ?? 85;
         return MatrixJpegRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders PDF417 as BMP from bytes.
+    /// </summary>
+    public static byte[] Bmp(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as ASCII from bytes.
+    /// </summary>
+    public static string Ascii(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixAsciiRenderer.Render(modules, options);
     }
 
     /// <summary>
@@ -366,11 +434,27 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 BMP to a file.
+    /// </summary>
+    public static string SaveBmp(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var bmp = Bmp(text, encodeOptions, renderOptions);
+        return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
     /// Saves PDF417 JPEG to a file for byte payloads.
     /// </summary>
     public static string SaveJpeg(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var jpeg = Jpeg(data, encodeOptions, renderOptions);
         return jpeg.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 BMP to a file for byte payloads.
+    /// </summary>
+    public static string SaveBmp(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var bmp = Bmp(data, encodeOptions, renderOptions);
+        return bmp.WriteBinary(path);
     }
 
     /// <summary>
@@ -384,6 +468,14 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 BMP to a stream.
+    /// </summary>
+    public static void SaveBmp(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
     /// Saves PDF417 JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -394,7 +486,15 @@ public static class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file based on extension (.png/.svg/.html/.jpg).
+    /// Saves PDF417 BMP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveBmp(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file based on extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -412,13 +512,15 @@ public static class Pdf417Code {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(text, path, encodeOptions, renderOptions);
+            case ".bmp":
+                return SaveBmp(text, path, encodeOptions, renderOptions);
             default:
                 return SavePng(text, path, encodeOptions, renderOptions);
         }
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg).
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -436,6 +538,8 @@ public static class Pdf417Code {
             case ".jpg":
             case ".jpeg":
                 return SaveJpeg(data, path, encodeOptions, renderOptions);
+            case ".bmp":
+                return SaveBmp(data, path, encodeOptions, renderOptions);
             default:
                 return SavePng(data, path, encodeOptions, renderOptions);
         }
@@ -703,6 +807,20 @@ public static class Pdf417Code {
         }
 
         /// <summary>
+        /// Renders BMP bytes.
+        /// </summary>
+        public byte[] Bmp() {
+            return _text is not null ? Pdf417Code.Bmp(_text, _encodeOptions, _renderOptions) : Pdf417Code.Bmp(_bytes!, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
+        /// Renders ASCII text.
+        /// </summary>
+        public string Ascii(MatrixAsciiRenderOptions? options = null) {
+            return _text is not null ? Pdf417Code.Ascii(_text, _encodeOptions, options) : Pdf417Code.Ascii(_bytes!, _encodeOptions, options);
+        }
+
+        /// <summary>
         /// Saves output based on file extension.
         /// </summary>
         public string Save(string path, string? title = null) {
@@ -736,6 +854,13 @@ public static class Pdf417Code {
         /// </summary>
         public string SaveJpeg(string path) {
             return _text is not null ? Pdf417Code.SaveJpeg(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveJpeg(_bytes!, path, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
+        /// Saves BMP to a file.
+        /// </summary>
+        public string SaveBmp(string path) {
+            return _text is not null ? Pdf417Code.SaveBmp(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveBmp(_bytes!, path, _encodeOptions, _renderOptions);
         }
     }
 }

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -99,17 +99,17 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PDF from bytes.
     /// </summary>
-    public static byte[] Pdf(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static byte[] Pdf(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions));
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
     }
 
     /// <summary>
     /// Renders PDF417 as EPS from bytes.
     /// </summary>
-    public static string Eps(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static string Eps(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions));
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
     }
 
     /// <summary>
@@ -193,16 +193,16 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a file for byte payloads.
     /// </summary>
-    public static string SavePdf(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
-        var pdf = Pdf(data, encodeOptions, renderOptions);
+    public static string SavePdf(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
+        var pdf = Pdf(data, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Saves PDF417 EPS to a file for byte payloads.
     /// </summary>
-    public static string SaveEps(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
-        var eps = Eps(data, encodeOptions, renderOptions);
+    public static string SaveEps(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
+        var eps = Eps(data, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
     }
 
@@ -227,17 +227,17 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a stream for byte payloads.
     /// </summary>
-    public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
     }
 
     /// <summary>
     /// Saves PDF417 EPS to a stream for byte payloads.
     /// </summary>
-    public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
     }
 
     /// <summary>
@@ -341,17 +341,17 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PDF.
     /// </summary>
-    public static byte[] Pdf(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static byte[] Pdf(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
-        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions));
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
     }
 
     /// <summary>
     /// Renders PDF417 as EPS.
     /// </summary>
-    public static string Eps(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static string Eps(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
-        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions));
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
     }
 
     /// <summary>
@@ -383,17 +383,17 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PDF from bytes.
     /// </summary>
-    public static byte[] Pdf(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static byte[] Pdf(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions));
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
     }
 
     /// <summary>
     /// Renders PDF417 as EPS from bytes.
     /// </summary>
-    public static string Eps(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static string Eps(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions));
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
     }
 
     /// <summary>
@@ -531,16 +531,16 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a file.
     /// </summary>
-    public static string SavePdf(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
-        var pdf = Pdf(text, encodeOptions, renderOptions);
+    public static string SavePdf(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
+        var pdf = Pdf(text, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Saves PDF417 EPS to a file.
     /// </summary>
-    public static string SaveEps(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
-        var eps = Eps(text, encodeOptions, renderOptions);
+    public static string SaveEps(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
+        var eps = Eps(text, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
     }
 
@@ -563,16 +563,16 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a file for byte payloads.
     /// </summary>
-    public static string SavePdf(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
-        var pdf = Pdf(data, encodeOptions, renderOptions);
+    public static string SavePdf(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
+        var pdf = Pdf(data, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
     }
 
     /// <summary>
     /// Saves PDF417 EPS to a file for byte payloads.
     /// </summary>
-    public static string SaveEps(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
-        var eps = Eps(data, encodeOptions, renderOptions);
+    public static string SaveEps(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
+        var eps = Eps(data, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
     }
 
@@ -597,17 +597,17 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a stream.
     /// </summary>
-    public static void SavePdf(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static void SavePdf(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
-        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
     }
 
     /// <summary>
     /// Saves PDF417 EPS to a stream.
     /// </summary>
-    public static void SaveEps(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static void SaveEps(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
-        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
     }
 
     /// <summary>
@@ -631,17 +631,17 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a stream for byte payloads.
     /// </summary>
-    public static void SavePdf(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static void SavePdf(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
     }
 
     /// <summary>
     /// Saves PDF417 EPS to a stream for byte payloads.
     /// </summary>
-    public static void SaveEps(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+    public static void SaveEps(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
-        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
     }
 
     /// <summary>
@@ -977,15 +977,15 @@ public static class Pdf417Code {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
-        public byte[] Pdf() {
-            return _text is not null ? Pdf417Code.Pdf(_text, _encodeOptions, _renderOptions) : Pdf417Code.Pdf(_bytes!, _encodeOptions, _renderOptions);
+        public byte[] Pdf(RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? Pdf417Code.Pdf(_text, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.Pdf(_bytes!, _encodeOptions, _renderOptions, renderMode);
         }
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
-        public string Eps() {
-            return _text is not null ? Pdf417Code.Eps(_text, _encodeOptions, _renderOptions) : Pdf417Code.Eps(_bytes!, _encodeOptions, _renderOptions);
+        public string Eps(RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? Pdf417Code.Eps(_text, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.Eps(_bytes!, _encodeOptions, _renderOptions, renderMode);
         }
 
         /// <summary>
@@ -1041,15 +1041,15 @@ public static class Pdf417Code {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
-        public string SavePdf(string path) {
-            return _text is not null ? Pdf417Code.SavePdf(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SavePdf(_bytes!, path, _encodeOptions, _renderOptions);
+        public string SavePdf(string path, RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? Pdf417Code.SavePdf(_text, path, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.SavePdf(_bytes!, path, _encodeOptions, _renderOptions, renderMode);
         }
 
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
-        public string SaveEps(string path) {
-            return _text is not null ? Pdf417Code.SaveEps(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveEps(_bytes!, path, _encodeOptions, _renderOptions);
+        public string SaveEps(string path, RenderMode renderMode = RenderMode.Vector) {
+            return _text is not null ? Pdf417Code.SaveEps(_text, path, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.SaveEps(_bytes!, path, _encodeOptions, _renderOptions, renderMode);
         }
     }
 }

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -5,8 +5,10 @@ using CodeGlyphX.Pdf417;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pdf;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 
@@ -95,6 +97,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Renders PDF417 as PDF from bytes.
+    /// </summary>
+    public static byte[] Pdf(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as EPS from bytes.
+    /// </summary>
+    public static string Eps(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
     /// Renders PDF417 as ASCII from bytes.
     /// </summary>
     public static string Ascii(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
@@ -173,6 +191,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 PDF to a file for byte payloads.
+    /// </summary>
+    public static string SavePdf(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var pdf = Pdf(data, encodeOptions, renderOptions);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 EPS to a file for byte payloads.
+    /// </summary>
+    public static string SaveEps(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var eps = Eps(data, encodeOptions, renderOptions);
+        return eps.WriteText(path);
+    }
+
+    /// <summary>
     /// Saves PDF417 JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -191,7 +225,23 @@ public static class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves PDF417 PDF to a stream for byte payloads.
+    /// </summary>
+    public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 EPS to a stream for byte payloads.
+    /// </summary>
+    public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -211,6 +261,11 @@ public static class Pdf417Code {
                 return SaveJpeg(data, path, encodeOptions, renderOptions);
             case ".bmp":
                 return SaveBmp(data, path, encodeOptions, renderOptions);
+            case ".pdf":
+                return SavePdf(data, path, encodeOptions, renderOptions);
+            case ".eps":
+            case ".ps":
+                return SaveEps(data, path, encodeOptions, renderOptions);
             default:
                 return SavePng(data, path, encodeOptions, renderOptions);
         }
@@ -284,6 +339,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Renders PDF417 as PDF.
+    /// </summary>
+    public static byte[] Pdf(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as EPS.
+    /// </summary>
+    public static string Eps(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
     /// Renders PDF417 as ASCII.
     /// </summary>
     public static string Ascii(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
@@ -307,6 +378,22 @@ public static class Pdf417Code {
     public static byte[] Bmp(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as PDF from bytes.
+    /// </summary>
+    public static byte[] Pdf(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions));
+    }
+
+    /// <summary>
+    /// Renders PDF417 as EPS from bytes.
+    /// </summary>
+    public static string Eps(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions));
     }
 
     /// <summary>
@@ -442,6 +529,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 PDF to a file.
+    /// </summary>
+    public static string SavePdf(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var pdf = Pdf(text, encodeOptions, renderOptions);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 EPS to a file.
+    /// </summary>
+    public static string SaveEps(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var eps = Eps(text, encodeOptions, renderOptions);
+        return eps.WriteText(path);
+    }
+
+    /// <summary>
     /// Saves PDF417 JPEG to a file for byte payloads.
     /// </summary>
     public static string SaveJpeg(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -455,6 +558,22 @@ public static class Pdf417Code {
     public static string SaveBmp(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var bmp = Bmp(data, encodeOptions, renderOptions);
         return bmp.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 PDF to a file for byte payloads.
+    /// </summary>
+    public static string SavePdf(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var pdf = Pdf(data, encodeOptions, renderOptions);
+        return pdf.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 EPS to a file for byte payloads.
+    /// </summary>
+    public static string SaveEps(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var eps = Eps(data, encodeOptions, renderOptions);
+        return eps.WriteText(path);
     }
 
     /// <summary>
@@ -476,6 +595,22 @@ public static class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 PDF to a stream.
+    /// </summary>
+    public static void SavePdf(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 EPS to a stream.
+    /// </summary>
+    public static void SaveEps(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
     /// Saves PDF417 JPEG to a stream for byte payloads.
     /// </summary>
     public static void SaveJpeg(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -494,7 +629,23 @@ public static class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file based on extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves PDF417 PDF to a stream for byte payloads.
+    /// </summary>
+    public static void SavePdf(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 EPS to a stream for byte payloads.
+    /// </summary>
+    public static void SaveEps(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file based on extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -514,13 +665,18 @@ public static class Pdf417Code {
                 return SaveJpeg(text, path, encodeOptions, renderOptions);
             case ".bmp":
                 return SaveBmp(text, path, encodeOptions, renderOptions);
+            case ".pdf":
+                return SavePdf(text, path, encodeOptions, renderOptions);
+            case ".eps":
+            case ".ps":
+                return SaveEps(text, path, encodeOptions, renderOptions);
             default:
                 return SavePng(text, path, encodeOptions, renderOptions);
         }
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -540,6 +696,11 @@ public static class Pdf417Code {
                 return SaveJpeg(data, path, encodeOptions, renderOptions);
             case ".bmp":
                 return SaveBmp(data, path, encodeOptions, renderOptions);
+            case ".pdf":
+                return SavePdf(data, path, encodeOptions, renderOptions);
+            case ".eps":
+            case ".ps":
+                return SaveEps(data, path, encodeOptions, renderOptions);
             default:
                 return SavePng(data, path, encodeOptions, renderOptions);
         }
@@ -814,6 +975,20 @@ public static class Pdf417Code {
         }
 
         /// <summary>
+        /// Renders PDF bytes.
+        /// </summary>
+        public byte[] Pdf() {
+            return _text is not null ? Pdf417Code.Pdf(_text, _encodeOptions, _renderOptions) : Pdf417Code.Pdf(_bytes!, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
+        /// Renders EPS text.
+        /// </summary>
+        public string Eps() {
+            return _text is not null ? Pdf417Code.Eps(_text, _encodeOptions, _renderOptions) : Pdf417Code.Eps(_bytes!, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
         /// Renders ASCII text.
         /// </summary>
         public string Ascii(MatrixAsciiRenderOptions? options = null) {
@@ -861,6 +1036,20 @@ public static class Pdf417Code {
         /// </summary>
         public string SaveBmp(string path) {
             return _text is not null ? Pdf417Code.SaveBmp(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveBmp(_bytes!, path, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
+        /// Saves PDF to a file.
+        /// </summary>
+        public string SavePdf(string path) {
+            return _text is not null ? Pdf417Code.SavePdf(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SavePdf(_bytes!, path, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
+        /// Saves EPS to a file.
+        /// </summary>
+        public string SaveEps(string path) {
+            return _text is not null ? Pdf417Code.SaveEps(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveEps(_bytes!, path, _encodeOptions, _renderOptions);
         }
     }
 }

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -129,6 +129,40 @@ public static class QR {
     public static byte[] Bmp(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderBmp(payload, options);
 
     /// <summary>
+    /// Renders a QR code as PDF.
+    /// </summary>
+    public static byte[] Pdf(string payload, QrEasyOptions? options = null) => QrEasy.RenderPdf(payload, options);
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as PDF.
+    /// </summary>
+    public static byte[] PdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderPdfAuto(payload, detectOptions, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as PDF for a payload with embedded defaults.
+    /// </summary>
+    public static byte[] Pdf(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPdf(payload, options);
+
+    /// <summary>
+    /// Renders a QR code as EPS.
+    /// </summary>
+    public static string Eps(string payload, QrEasyOptions? options = null) => QrEasy.RenderEps(payload, options);
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as EPS.
+    /// </summary>
+    public static string EpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderEpsAuto(payload, detectOptions, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS for a payload with embedded defaults.
+    /// </summary>
+    public static string Eps(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderEps(payload, options);
+
+    /// <summary>
     /// Renders a QR code as ASCII text.
     /// </summary>
     public static string Ascii(string payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
@@ -298,7 +332,63 @@ public static class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves a PDF QR to a file.
+    /// </summary>
+    public static string SavePdf(string payload, string path, QrEasyOptions? options = null) {
+        return Pdf(payload, options).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a PDF QR to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string SavePdf(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        return Pdf(payload, options).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a PDF QR to a stream.
+    /// </summary>
+    public static void SavePdf(string payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderPdfToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves a PDF QR to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void SavePdf(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderPdfToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves an EPS QR to a file.
+    /// </summary>
+    public static string SaveEps(string payload, string path, QrEasyOptions? options = null) {
+        return Eps(payload, options).WriteText(path);
+    }
+
+    /// <summary>
+    /// Saves an EPS QR to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string SaveEps(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        return Eps(payload, options).WriteText(path);
+    }
+
+    /// <summary>
+    /// Saves an EPS QR to a stream.
+    /// </summary>
+    public static void SaveEps(string payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderEpsToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves an EPS QR to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void SaveEps(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderEpsToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -306,7 +396,7 @@ public static class QR {
     }
 
     /// <summary>
-    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
+    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveAuto(string payload, string path, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, string? title = null) {
@@ -315,7 +405,7 @@ public static class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
+    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -542,6 +632,16 @@ public static class QR {
         public byte[] Jpeg() => _payloadData is null ? QrEasy.RenderJpeg(_payload, Options) : QrEasy.RenderJpeg(_payloadData, Options);
 
         /// <summary>
+        /// Renders PDF bytes.
+        /// </summary>
+        public byte[] Pdf() => _payloadData is null ? QrEasy.RenderPdf(_payload, Options) : QrEasy.RenderPdf(_payloadData, Options);
+
+        /// <summary>
+        /// Renders EPS text.
+        /// </summary>
+        public string Eps() => _payloadData is null ? QrEasy.RenderEps(_payload, Options) : QrEasy.RenderEps(_payloadData, Options);
+
+        /// <summary>
         /// Saves PNG to a file.
         /// </summary>
         public string SavePng(string path) => _payloadData is null ? QR.SavePng(_payload, path, Options) : QR.SavePng(_payloadData, path, Options);
@@ -622,6 +722,38 @@ public static class QR {
         }
 
         /// <summary>
+        /// Saves PDF to a file.
+        /// </summary>
+        public string SavePdf(string path) => _payloadData is null ? QR.SavePdf(_payload, path, Options) : QR.SavePdf(_payloadData, path, Options);
+
+        /// <summary>
+        /// Saves PDF to a stream.
+        /// </summary>
+        public void SavePdf(Stream stream) {
+            if (_payloadData is null) {
+                QR.SavePdf(_payload, stream, Options);
+            } else {
+                QR.SavePdf(_payloadData, stream, Options);
+            }
+        }
+
+        /// <summary>
+        /// Saves EPS to a file.
+        /// </summary>
+        public string SaveEps(string path) => _payloadData is null ? QR.SaveEps(_payload, path, Options) : QR.SaveEps(_payloadData, path, Options);
+
+        /// <summary>
+        /// Saves EPS to a stream.
+        /// </summary>
+        public void SaveEps(Stream stream) {
+            if (_payloadData is null) {
+                QR.SaveEps(_payload, stream, Options);
+            } else {
+                QR.SaveEps(_payloadData, stream, Options);
+            }
+        }
+
+        /// <summary>
         /// Renders ASCII text.
         /// </summary>
         public string Ascii(MatrixAsciiRenderOptions? asciiOptions = null) => _payloadData is null
@@ -634,7 +766,7 @@ public static class QR {
         public string SaveAscii(string path, MatrixAsciiRenderOptions? asciiOptions = null) => Ascii(asciiOptions).WriteText(path);
 
         /// <summary>
-        /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp). Defaults to PNG when no extension is provided.
+        /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) => _payloadData is null
             ? QR.Save(_payload, path, Options, title)
@@ -660,6 +792,11 @@ public static class QR {
                 return payloadData is null ? SaveJpeg(payload, path, options) : SaveJpeg(payloadData, path, options);
             case ".bmp":
                 return payloadData is null ? SaveBmp(payload, path, options) : SaveBmp(payloadData, path, options);
+            case ".pdf":
+                return payloadData is null ? SavePdf(payload, path, options) : SavePdf(payloadData, path, options);
+            case ".eps":
+            case ".ps":
+                return payloadData is null ? SaveEps(payload, path, options) : SaveEps(payloadData, path, options);
             default:
                 // Fallback to PNG for unknown extensions to keep the API forgiving.
                 return payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options);

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -131,36 +131,36 @@ public static class QR {
     /// <summary>
     /// Renders a QR code as PDF.
     /// </summary>
-    public static byte[] Pdf(string payload, QrEasyOptions? options = null) => QrEasy.RenderPdf(payload, options);
+    public static byte[] Pdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderPdf(payload, options, mode);
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PDF.
     /// </summary>
-    public static byte[] PdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderPdfAuto(payload, detectOptions, options);
+    public static byte[] PdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return QrEasy.RenderPdfAuto(payload, detectOptions, options, mode);
     }
 
     /// <summary>
     /// Renders a QR code as PDF for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Pdf(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPdf(payload, options);
+    public static byte[] Pdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderPdf(payload, options, mode);
 
     /// <summary>
     /// Renders a QR code as EPS.
     /// </summary>
-    public static string Eps(string payload, QrEasyOptions? options = null) => QrEasy.RenderEps(payload, options);
+    public static string Eps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderEps(payload, options, mode);
 
     /// <summary>
     /// Detects a payload type and renders a QR code as EPS.
     /// </summary>
-    public static string EpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderEpsAuto(payload, detectOptions, options);
+    public static string EpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return QrEasy.RenderEpsAuto(payload, detectOptions, options, mode);
     }
 
     /// <summary>
     /// Renders a QR code as EPS for a payload with embedded defaults.
     /// </summary>
-    public static string Eps(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderEps(payload, options);
+    public static string Eps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderEps(payload, options, mode);
 
     /// <summary>
     /// Renders a QR code as ASCII text.
@@ -334,57 +334,57 @@ public static class QR {
     /// <summary>
     /// Saves a PDF QR to a file.
     /// </summary>
-    public static string SavePdf(string payload, string path, QrEasyOptions? options = null) {
-        return Pdf(payload, options).WriteBinary(path);
+    public static string SavePdf(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Pdf(payload, options, mode).WriteBinary(path);
     }
 
     /// <summary>
     /// Saves a PDF QR to a file for a payload with embedded defaults.
     /// </summary>
-    public static string SavePdf(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Pdf(payload, options).WriteBinary(path);
+    public static string SavePdf(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Pdf(payload, options, mode).WriteBinary(path);
     }
 
     /// <summary>
     /// Saves a PDF QR to a stream.
     /// </summary>
-    public static void SavePdf(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPdfToStream(payload, stream, options);
+    public static void SavePdf(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        QrEasy.RenderPdfToStream(payload, stream, options, mode);
     }
 
     /// <summary>
     /// Saves a PDF QR to a stream for a payload with embedded defaults.
     /// </summary>
-    public static void SavePdf(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPdfToStream(payload, stream, options);
+    public static void SavePdf(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        QrEasy.RenderPdfToStream(payload, stream, options, mode);
     }
 
     /// <summary>
     /// Saves an EPS QR to a file.
     /// </summary>
-    public static string SaveEps(string payload, string path, QrEasyOptions? options = null) {
-        return Eps(payload, options).WriteText(path);
+    public static string SaveEps(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Eps(payload, options, mode).WriteText(path);
     }
 
     /// <summary>
     /// Saves an EPS QR to a file for a payload with embedded defaults.
     /// </summary>
-    public static string SaveEps(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Eps(payload, options).WriteText(path);
+    public static string SaveEps(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Eps(payload, options, mode).WriteText(path);
     }
 
     /// <summary>
     /// Saves an EPS QR to a stream.
     /// </summary>
-    public static void SaveEps(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderEpsToStream(payload, stream, options);
+    public static void SaveEps(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        QrEasy.RenderEpsToStream(payload, stream, options, mode);
     }
 
     /// <summary>
     /// Saves an EPS QR to a stream for a payload with embedded defaults.
     /// </summary>
-    public static void SaveEps(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderEpsToStream(payload, stream, options);
+    public static void SaveEps(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        QrEasy.RenderEpsToStream(payload, stream, options, mode);
     }
 
     /// <summary>
@@ -634,12 +634,12 @@ public static class QR {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
-        public byte[] Pdf() => _payloadData is null ? QrEasy.RenderPdf(_payload, Options) : QrEasy.RenderPdf(_payloadData, Options);
+        public byte[] Pdf(RenderMode mode = RenderMode.Vector) => _payloadData is null ? QrEasy.RenderPdf(_payload, Options, mode) : QrEasy.RenderPdf(_payloadData, Options, mode);
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
-        public string Eps() => _payloadData is null ? QrEasy.RenderEps(_payload, Options) : QrEasy.RenderEps(_payloadData, Options);
+        public string Eps(RenderMode mode = RenderMode.Vector) => _payloadData is null ? QrEasy.RenderEps(_payload, Options, mode) : QrEasy.RenderEps(_payloadData, Options, mode);
 
         /// <summary>
         /// Saves PNG to a file.
@@ -724,32 +724,32 @@ public static class QR {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
-        public string SavePdf(string path) => _payloadData is null ? QR.SavePdf(_payload, path, Options) : QR.SavePdf(_payloadData, path, Options);
+        public string SavePdf(string path, RenderMode mode = RenderMode.Vector) => _payloadData is null ? QR.SavePdf(_payload, path, Options, mode) : QR.SavePdf(_payloadData, path, Options, mode);
 
         /// <summary>
         /// Saves PDF to a stream.
         /// </summary>
-        public void SavePdf(Stream stream) {
+        public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) {
             if (_payloadData is null) {
-                QR.SavePdf(_payload, stream, Options);
+                QR.SavePdf(_payload, stream, Options, mode);
             } else {
-                QR.SavePdf(_payloadData, stream, Options);
+                QR.SavePdf(_payloadData, stream, Options, mode);
             }
         }
 
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
-        public string SaveEps(string path) => _payloadData is null ? QR.SaveEps(_payload, path, Options) : QR.SaveEps(_payloadData, path, Options);
+        public string SaveEps(string path, RenderMode mode = RenderMode.Vector) => _payloadData is null ? QR.SaveEps(_payload, path, Options, mode) : QR.SaveEps(_payloadData, path, Options, mode);
 
         /// <summary>
         /// Saves EPS to a stream.
         /// </summary>
-        public void SaveEps(Stream stream) {
+        public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) {
             if (_payloadData is null) {
-                QR.SaveEps(_payload, stream, Options);
+                QR.SaveEps(_payload, stream, Options, mode);
             } else {
-                QR.SaveEps(_payloadData, stream, Options);
+                QR.SaveEps(_payloadData, stream, Options, mode);
             }
         }
 

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX;
@@ -108,6 +110,44 @@ public static class QR {
     /// Renders a QR code as JPEG for a payload with embedded defaults.
     /// </summary>
     public static byte[] Jpeg(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderJpeg(payload, options);
+
+    /// <summary>
+    /// Renders a QR code as BMP.
+    /// </summary>
+    public static byte[] Bmp(string payload, QrEasyOptions? options = null) => QrEasy.RenderBmp(payload, options);
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as BMP.
+    /// </summary>
+    public static byte[] BmpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderBmpAuto(payload, detectOptions, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP for a payload with embedded defaults.
+    /// </summary>
+    public static byte[] Bmp(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderBmp(payload, options);
+
+    /// <summary>
+    /// Renders a QR code as ASCII text.
+    /// </summary>
+    public static string Ascii(string payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderAscii(payload, asciiOptions, options);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as ASCII text.
+    /// </summary>
+    public static string AsciiAuto(string payload, QrPayloadDetectOptions? detectOptions = null, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderAsciiAuto(payload, detectOptions, asciiOptions, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as ASCII text for a payload with embedded defaults.
+    /// </summary>
+    public static string Ascii(QrPayloadData payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderAscii(payload, asciiOptions, options);
+    }
 
     /// <summary>
     /// Saves a PNG QR to a file.
@@ -230,7 +270,35 @@ public static class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg).
+    /// Saves a BMP QR to a file.
+    /// </summary>
+    public static string SaveBmp(string payload, string path, QrEasyOptions? options = null) {
+        return Bmp(payload, options).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a BMP QR to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string SaveBmp(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        return Bmp(payload, options).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a BMP QR to a stream.
+    /// </summary>
+    public static void SaveBmp(string payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderBmpToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves a BMP QR to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void SaveBmp(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderBmpToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -238,7 +306,7 @@ public static class QR {
     }
 
     /// <summary>
-    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg).
+    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveAuto(string payload, string path, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, string? title = null) {
@@ -247,7 +315,7 @@ public static class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg).
+    /// Saves a QR code to a file based on the file extension (.png/.svg/.html/.jpg/.bmp).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -538,7 +606,35 @@ public static class QR {
         }
 
         /// <summary>
-        /// Saves based on file extension (.png/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
+        /// Saves BMP to a file.
+        /// </summary>
+        public string SaveBmp(string path) => _payloadData is null ? QR.SaveBmp(_payload, path, Options) : QR.SaveBmp(_payloadData, path, Options);
+
+        /// <summary>
+        /// Saves BMP to a stream.
+        /// </summary>
+        public void SaveBmp(Stream stream) {
+            if (_payloadData is null) {
+                QR.SaveBmp(_payload, stream, Options);
+            } else {
+                QR.SaveBmp(_payloadData, stream, Options);
+            }
+        }
+
+        /// <summary>
+        /// Renders ASCII text.
+        /// </summary>
+        public string Ascii(MatrixAsciiRenderOptions? asciiOptions = null) => _payloadData is null
+            ? QR.Ascii(_payload, asciiOptions, Options)
+            : QR.Ascii(_payloadData, asciiOptions, Options);
+
+        /// <summary>
+        /// Saves ASCII to a file.
+        /// </summary>
+        public string SaveAscii(string path, MatrixAsciiRenderOptions? asciiOptions = null) => Ascii(asciiOptions).WriteText(path);
+
+        /// <summary>
+        /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) => _payloadData is null
             ? QR.Save(_payload, path, Options, title)
@@ -562,6 +658,8 @@ public static class QR {
             case ".jpg":
             case ".jpeg":
                 return payloadData is null ? SaveJpeg(payload, path, options) : SaveJpeg(payloadData, path, options);
+            case ".bmp":
+                return payloadData is null ? SaveBmp(payload, path, options) : SaveBmp(payloadData, path, options);
             default:
                 // Fallback to PNG for unknown extensions to keep the API forgiving.
                 return payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options);

--- a/CodeGlyphX/QrEasy.cs
+++ b/CodeGlyphX/QrEasy.cs
@@ -5,8 +5,10 @@ using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pdf;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 
@@ -441,12 +443,147 @@ public static class QrEasy {
     }
 
     /// <summary>
+    /// Renders a QR code as PDF.
+    /// </summary>
+    public static byte[] RenderPdf(string payload, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, payload);
+        return QrPdfRenderer.Render(qr.Modules, render);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as PDF.
+    /// </summary>
+    public static byte[] RenderPdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var detected = QrPayloads.Detect(payload, detectOptions);
+        return RenderPdf(detected, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as PDF to a stream.
+    /// </summary>
+    public static void RenderPdfToStream(string payload, Stream stream, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, payload);
+        QrPdfRenderer.RenderToStream(qr.Modules, render, stream);
+    }
+
+    /// <summary>
+    /// Renders a QR code as PDF and writes it to a file.
+    /// </summary>
+    public static string RenderPdfToFile(string payload, string path, QrEasyOptions? options = null) {
+        var pdf = RenderPdf(payload, options);
+        return RenderIO.WriteBinary(path, pdf);
+    }
+
+    /// <summary>
+    /// Renders a QR code as PDF and writes it to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderPdfToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        var pdf = RenderPdf(payload, options);
+        return RenderIO.WriteBinary(path, pdf);
+    }
+
+    /// <summary>
+    /// Renders a QR code as PDF for a payload with embedded defaults.
+    /// </summary>
+    public static byte[] RenderPdf(QrPayloadData payload, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, payload.Text);
+        return QrPdfRenderer.Render(qr.Modules, render);
+    }
+
+    /// <summary>
+    /// Renders a QR code as PDF to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void RenderPdfToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, payload.Text);
+        QrPdfRenderer.RenderToStream(qr.Modules, render, stream);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS.
+    /// </summary>
+    public static string RenderEps(string payload, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, payload);
+        return QrEpsRenderer.Render(qr.Modules, render);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as EPS.
+    /// </summary>
+    public static string RenderEpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var detected = QrPayloads.Detect(payload, detectOptions);
+        return RenderEps(detected, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS to a stream.
+    /// </summary>
+    public static void RenderEpsToStream(string payload, Stream stream, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, payload);
+        QrEpsRenderer.RenderToStream(qr.Modules, render, stream);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS and writes it to a file.
+    /// </summary>
+    public static string RenderEpsToFile(string payload, string path, QrEasyOptions? options = null) {
+        var eps = RenderEps(payload, options);
+        return RenderIO.WriteText(path, eps);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS and writes it to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderEpsToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        var eps = RenderEps(payload, options);
+        return RenderIO.WriteText(path, eps);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderEps(QrPayloadData payload, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, payload.Text);
+        return QrEpsRenderer.Render(qr.Modules, render);
+    }
+
+    /// <summary>
+    /// Renders a QR code as EPS to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void RenderEpsToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, payload.Text);
+        QrEpsRenderer.RenderToStream(qr.Modules, render, stream);
+    }
+
+    /// <summary>
     /// Renders a QR code as ASCII text.
     /// </summary>
     public static string RenderAscii(string payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
-        return MatrixAsciiRenderer.Render(qr.Modules, asciiOptions);
+        var resolved = BuildAsciiOptions(asciiOptions, opts);
+        return MatrixAsciiRenderer.Render(qr.Modules, resolved);
     }
 
     /// <summary>
@@ -465,7 +602,8 @@ public static class QrEasy {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
-        return MatrixAsciiRenderer.Render(qr.Modules, asciiOptions);
+        var resolved = BuildAsciiOptions(asciiOptions, opts);
+        return MatrixAsciiRenderer.Render(qr.Modules, resolved);
     }
 
     /// <summary>
@@ -539,6 +677,14 @@ public static class QrEasy {
         if (logo is not null) render.Logo = logo;
 
         return render;
+    }
+
+    private static MatrixAsciiRenderOptions BuildAsciiOptions(MatrixAsciiRenderOptions? asciiOptions, QrEasyOptions opts) {
+        var resolved = asciiOptions ?? new MatrixAsciiRenderOptions();
+        if (asciiOptions is null || asciiOptions.QuietZone == RenderDefaults.QrQuietZone) {
+            resolved.QuietZone = opts.QuietZone;
+        }
+        return resolved;
     }
 
     private static QrCode EncodePayload(string payload, QrEasyOptions opts) {

--- a/CodeGlyphX/QrEasy.cs
+++ b/CodeGlyphX/QrEasy.cs
@@ -445,135 +445,135 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF.
     /// </summary>
-    public static byte[] RenderPdf(string payload, QrEasyOptions? options = null) {
+    public static byte[] RenderPdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, payload);
-        return QrPdfRenderer.Render(qr.Modules, render);
+        return QrPdfRenderer.Render(qr.Modules, render, mode);
     }
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PDF.
     /// </summary>
-    public static byte[] RenderPdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+    public static byte[] RenderPdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
-        return RenderPdf(detected, options);
+        return RenderPdf(detected, options, mode);
     }
 
     /// <summary>
     /// Renders a QR code as PDF to a stream.
     /// </summary>
-    public static void RenderPdfToStream(string payload, Stream stream, QrEasyOptions? options = null) {
+    public static void RenderPdfToStream(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, payload);
-        QrPdfRenderer.RenderToStream(qr.Modules, render, stream);
+        QrPdfRenderer.RenderToStream(qr.Modules, render, stream, mode);
     }
 
     /// <summary>
     /// Renders a QR code as PDF and writes it to a file.
     /// </summary>
-    public static string RenderPdfToFile(string payload, string path, QrEasyOptions? options = null) {
-        var pdf = RenderPdf(payload, options);
+    public static string RenderPdfToFile(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var pdf = RenderPdf(payload, options, mode);
         return RenderIO.WriteBinary(path, pdf);
     }
 
     /// <summary>
     /// Renders a QR code as PDF and writes it to a file for a payload with embedded defaults.
     /// </summary>
-    public static string RenderPdfToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var pdf = RenderPdf(payload, options);
+    public static string RenderPdfToFile(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var pdf = RenderPdf(payload, options, mode);
         return RenderIO.WriteBinary(path, pdf);
     }
 
     /// <summary>
     /// Renders a QR code as PDF for a payload with embedded defaults.
     /// </summary>
-    public static byte[] RenderPdf(QrPayloadData payload, QrEasyOptions? options = null) {
+    public static byte[] RenderPdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, payload.Text);
-        return QrPdfRenderer.Render(qr.Modules, render);
+        return QrPdfRenderer.Render(qr.Modules, render, mode);
     }
 
     /// <summary>
     /// Renders a QR code as PDF to a stream for a payload with embedded defaults.
     /// </summary>
-    public static void RenderPdfToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+    public static void RenderPdfToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, payload.Text);
-        QrPdfRenderer.RenderToStream(qr.Modules, render, stream);
+        QrPdfRenderer.RenderToStream(qr.Modules, render, stream, mode);
     }
 
     /// <summary>
     /// Renders a QR code as EPS.
     /// </summary>
-    public static string RenderEps(string payload, QrEasyOptions? options = null) {
+    public static string RenderEps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, payload);
-        return QrEpsRenderer.Render(qr.Modules, render);
+        return QrEpsRenderer.Render(qr.Modules, render, mode);
     }
 
     /// <summary>
     /// Detects a payload type and renders a QR code as EPS.
     /// </summary>
-    public static string RenderEpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+    public static string RenderEpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
-        return RenderEps(detected, options);
+        return RenderEps(detected, options, mode);
     }
 
     /// <summary>
     /// Renders a QR code as EPS to a stream.
     /// </summary>
-    public static void RenderEpsToStream(string payload, Stream stream, QrEasyOptions? options = null) {
+    public static void RenderEpsToStream(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, payload);
-        QrEpsRenderer.RenderToStream(qr.Modules, render, stream);
+        QrEpsRenderer.RenderToStream(qr.Modules, render, stream, mode);
     }
 
     /// <summary>
     /// Renders a QR code as EPS and writes it to a file.
     /// </summary>
-    public static string RenderEpsToFile(string payload, string path, QrEasyOptions? options = null) {
-        var eps = RenderEps(payload, options);
+    public static string RenderEpsToFile(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var eps = RenderEps(payload, options, mode);
         return RenderIO.WriteText(path, eps);
     }
 
     /// <summary>
     /// Renders a QR code as EPS and writes it to a file for a payload with embedded defaults.
     /// </summary>
-    public static string RenderEpsToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var eps = RenderEps(payload, options);
+    public static string RenderEpsToFile(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        var eps = RenderEps(payload, options, mode);
         return RenderIO.WriteText(path, eps);
     }
 
     /// <summary>
     /// Renders a QR code as EPS for a payload with embedded defaults.
     /// </summary>
-    public static string RenderEps(QrPayloadData payload, QrEasyOptions? options = null) {
+    public static string RenderEps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, payload.Text);
-        return QrEpsRenderer.Render(qr.Modules, render);
+        return QrEpsRenderer.Render(qr.Modules, render, mode);
     }
 
     /// <summary>
     /// Renders a QR code as EPS to a stream for a payload with embedded defaults.
     /// </summary>
-    public static void RenderEpsToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+    public static void RenderEpsToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, payload.Text);
-        QrEpsRenderer.RenderToStream(qr.Modules, render, stream);
+        QrEpsRenderer.RenderToStream(qr.Modules, render, stream, mode);
     }
 
     /// <summary>

--- a/CodeGlyphX/QrEasy.cs
+++ b/CodeGlyphX/QrEasy.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using System.IO;
 using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
@@ -369,6 +371,101 @@ public static class QrEasy {
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, payload.Text);
         QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP.
+    /// </summary>
+    public static byte[] RenderBmp(string payload, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, payload);
+        return QrBmpRenderer.Render(qr.Modules, render);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as BMP.
+    /// </summary>
+    public static byte[] RenderBmpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var detected = QrPayloads.Detect(payload, detectOptions);
+        return RenderBmp(detected, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP to a stream.
+    /// </summary>
+    public static void RenderBmpToStream(string payload, Stream stream, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, payload);
+        QrBmpRenderer.RenderToStream(qr.Modules, render, stream);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP and writes it to a file.
+    /// </summary>
+    public static string RenderBmpToFile(string payload, string path, QrEasyOptions? options = null) {
+        var bmp = RenderBmp(payload, options);
+        return RenderIO.WriteBinary(path, bmp);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP and writes it to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderBmpToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        var bmp = RenderBmp(payload, options);
+        return RenderIO.WriteBinary(path, bmp);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP for a payload with embedded defaults.
+    /// </summary>
+    public static byte[] RenderBmp(QrPayloadData payload, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, payload.Text);
+        return QrBmpRenderer.Render(qr.Modules, render);
+    }
+
+    /// <summary>
+    /// Renders a QR code as BMP to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void RenderBmpToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, payload.Text);
+        QrBmpRenderer.RenderToStream(qr.Modules, render, stream);
+    }
+
+    /// <summary>
+    /// Renders a QR code as ASCII text.
+    /// </summary>
+    public static string RenderAscii(string payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
+        var opts = options ?? new QrEasyOptions();
+        var qr = Encode(payload, opts);
+        return MatrixAsciiRenderer.Render(qr.Modules, asciiOptions);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as ASCII text.
+    /// </summary>
+    public static string RenderAsciiAuto(string payload, QrPayloadDetectOptions? detectOptions = null, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var detected = QrPayloads.Detect(payload, detectOptions);
+        return RenderAscii(detected, asciiOptions, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as ASCII text for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderAscii(QrPayloadData payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        return MatrixAsciiRenderer.Render(qr.Modules, asciiOptions);
     }
 
     /// <summary>

--- a/CodeGlyphX/Rendering/Ascii/BarcodeAsciiRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/BarcodeAsciiRenderOptions.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Rendering options for ASCII 1D barcodes.
+/// </summary>
+public sealed class BarcodeAsciiRenderOptions {
+    /// <summary>
+    /// Module width in characters.
+    /// </summary>
+    public int ModuleWidth { get; set; } = 1;
+
+    /// <summary>
+    /// Quiet zone size in modules.
+    /// </summary>
+    public int QuietZone { get; set; } = RenderDefaults.BarcodeQuietZone;
+
+    /// <summary>
+    /// Height in text rows.
+    /// </summary>
+    public int Height { get; set; } = RenderDefaults.BarcodeHeightModules;
+
+    /// <summary>
+    /// Character(s) used for bars.
+    /// </summary>
+    public string Dark { get; set; } = "#";
+
+    /// <summary>
+    /// Character(s) used for spaces.
+    /// </summary>
+    public string Light { get; set; } = " ";
+
+    /// <summary>
+    /// Line separator used between rows.
+    /// </summary>
+    public string NewLine { get; set; } = Environment.NewLine;
+}

--- a/CodeGlyphX/Rendering/Ascii/BarcodeAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/BarcodeAsciiRenderer.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Renders 1D barcodes as ASCII text.
+/// </summary>
+public static class BarcodeAsciiRenderer {
+    /// <summary>
+    /// Renders the barcode to an ASCII string.
+    /// </summary>
+    public static string Render(Barcode1D barcode, BarcodeAsciiRenderOptions? options = null) {
+        if (barcode is null) throw new ArgumentNullException(nameof(barcode));
+        var opts = options ?? new BarcodeAsciiRenderOptions();
+
+        var moduleWidth = Math.Max(1, opts.ModuleWidth);
+        var quiet = Math.Max(0, opts.QuietZone);
+        var height = Math.Max(1, opts.Height);
+        var dark = string.IsNullOrEmpty(opts.Dark) ? "#" : opts.Dark;
+        var light = string.IsNullOrEmpty(opts.Light) ? " " : opts.Light;
+        var newline = opts.NewLine ?? Environment.NewLine;
+
+        var darkCell = Repeat(dark, moduleWidth);
+        var lightCell = Repeat(light, moduleWidth);
+
+        var lineCapacity = (barcode.TotalModules + quiet * 2) * darkCell.Length;
+        var row = new StringBuilder(lineCapacity);
+
+        for (var i = 0; i < quiet; i++) row.Append(lightCell);
+        for (var i = 0; i < barcode.Segments.Count; i++) {
+            var segment = barcode.Segments[i];
+            var cell = segment.IsBar ? darkCell : lightCell;
+            for (var j = 0; j < segment.Modules; j++) row.Append(cell);
+        }
+        for (var i = 0; i < quiet; i++) row.Append(lightCell);
+
+        var line = row.ToString();
+        var sb = new StringBuilder((line.Length + newline.Length) * height);
+        for (var i = 0; i < height; i++) {
+            sb.Append(line);
+            if (i < height - 1) sb.Append(newline);
+        }
+        return sb.ToString();
+    }
+
+    private static string Repeat(string text, int count) {
+        if (count <= 1) return text;
+        var sb = new StringBuilder(text.Length * count);
+        for (var i = 0; i < count; i++) sb.Append(text);
+        return sb.ToString();
+    }
+}

--- a/CodeGlyphX/Rendering/Ascii/BarcodeAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/BarcodeAsciiRenderer.cs
@@ -19,7 +19,7 @@ public static class BarcodeAsciiRenderer {
         var height = Math.Max(1, opts.Height);
         var dark = string.IsNullOrEmpty(opts.Dark) ? "#" : opts.Dark;
         var light = string.IsNullOrEmpty(opts.Light) ? " " : opts.Light;
-        var newline = opts.NewLine ?? Environment.NewLine;
+        var newline = NormalizeNewLine(opts.NewLine) ?? Environment.NewLine;
 
         var darkCell = Repeat(dark, moduleWidth);
         var lightCell = Repeat(light, moduleWidth);
@@ -49,5 +49,14 @@ public static class BarcodeAsciiRenderer {
         var sb = new StringBuilder(text.Length * count);
         for (var i = 0; i < count; i++) sb.Append(text);
         return sb.ToString();
+    }
+
+    private static string? NormalizeNewLine(string? value) {
+        if (value is null) return null;
+        if (value.IndexOf('\\') < 0) return value;
+        return value
+            .Replace("\\r\\n", "\r\n")
+            .Replace("\\n", "\n")
+            .Replace("\\r", "\r");
     }
 }

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Rendering options for ASCII matrix output.
+/// </summary>
+public sealed class MatrixAsciiRenderOptions {
+    /// <summary>
+    /// Quiet zone size in modules.
+    /// </summary>
+    public int QuietZone { get; set; } = RenderDefaults.QrQuietZone;
+
+    /// <summary>
+    /// Module width in characters.
+    /// </summary>
+    public int ModuleWidth { get; set; } = 2;
+
+    /// <summary>
+    /// Module height in rows.
+    /// </summary>
+    public int ModuleHeight { get; set; } = 1;
+
+    /// <summary>
+    /// Character(s) used for dark modules.
+    /// </summary>
+    public string Dark { get; set; } = "#";
+
+    /// <summary>
+    /// Character(s) used for light modules.
+    /// </summary>
+    public string Light { get; set; } = " ";
+
+    /// <summary>
+    /// Line separator used between rows.
+    /// </summary>
+    public string NewLine { get; set; } = Environment.NewLine;
+}

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -30,9 +30,10 @@ public static class MatrixAsciiRenderer {
 
         var lineCapacity = widthModules * darkCell.Length;
         var sb = new StringBuilder((lineCapacity + newline.Length) * heightModules * moduleHeight);
+        var row = new StringBuilder(lineCapacity);
 
         for (var y = 0; y < heightModules; y++) {
-            var row = new StringBuilder(lineCapacity);
+            row.Clear();
             var my = y - quiet;
             for (var x = 0; x < widthModules; x++) {
                 var mx = x - quiet;
@@ -43,7 +44,7 @@ public static class MatrixAsciiRenderer {
             var rowText = row.ToString();
             for (var rep = 0; rep < moduleHeight; rep++) {
                 sb.Append(rowText);
-                if (!(y == heightModules - 1 && rep == moduleHeight - 1)) {
+                if (y != heightModules - 1 || rep != moduleHeight - 1) {
                     sb.Append(newline);
                 }
             }

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Renders 2D matrices as ASCII text.
+/// </summary>
+public static class MatrixAsciiRenderer {
+    /// <summary>
+    /// Renders the matrix to an ASCII string.
+    /// </summary>
+    public static string Render(BitMatrix modules, MatrixAsciiRenderOptions? options = null) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        var opts = options ?? new MatrixAsciiRenderOptions();
+
+        var quiet = Math.Max(0, opts.QuietZone);
+        var moduleWidth = Math.Max(1, opts.ModuleWidth);
+        var moduleHeight = Math.Max(1, opts.ModuleHeight);
+        var dark = string.IsNullOrEmpty(opts.Dark) ? "#" : opts.Dark;
+        var light = string.IsNullOrEmpty(opts.Light) ? " " : opts.Light;
+        var newline = opts.NewLine ?? Environment.NewLine;
+
+        var widthModules = modules.Width + quiet * 2;
+        var heightModules = modules.Height + quiet * 2;
+        if (widthModules <= 0 || heightModules <= 0) return string.Empty;
+
+        var darkCell = Repeat(dark, moduleWidth);
+        var lightCell = Repeat(light, moduleWidth);
+
+        var lineCapacity = widthModules * darkCell.Length;
+        var sb = new StringBuilder((lineCapacity + newline.Length) * heightModules * moduleHeight);
+
+        for (var y = 0; y < heightModules; y++) {
+            var row = new StringBuilder(lineCapacity);
+            var my = y - quiet;
+            for (var x = 0; x < widthModules; x++) {
+                var mx = x - quiet;
+                var isDark = (uint)mx < (uint)modules.Width && (uint)my < (uint)modules.Height && modules[mx, my];
+                row.Append(isDark ? darkCell : lightCell);
+            }
+
+            var rowText = row.ToString();
+            for (var rep = 0; rep < moduleHeight; rep++) {
+                sb.Append(rowText);
+                if (!(y == heightModules - 1 && rep == moduleHeight - 1)) {
+                    sb.Append(newline);
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Repeat(string text, int count) {
+        if (count <= 1) return text;
+        var sb = new StringBuilder(text.Length * count);
+        for (var i = 0; i < count; i++) sb.Append(text);
+        return sb.ToString();
+    }
+}

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -19,7 +19,7 @@ public static class MatrixAsciiRenderer {
         var moduleHeight = Math.Max(1, opts.ModuleHeight);
         var dark = string.IsNullOrEmpty(opts.Dark) ? "#" : opts.Dark;
         var light = string.IsNullOrEmpty(opts.Light) ? " " : opts.Light;
-        var newline = opts.NewLine ?? Environment.NewLine;
+        var newline = NormalizeNewLine(opts.NewLine) ?? Environment.NewLine;
 
         var widthModules = modules.Width + quiet * 2;
         var heightModules = modules.Height + quiet * 2;
@@ -58,5 +58,14 @@ public static class MatrixAsciiRenderer {
         var sb = new StringBuilder(text.Length * count);
         for (var i = 0; i < count; i++) sb.Append(text);
         return sb.ToString();
+    }
+
+    private static string? NormalizeNewLine(string? value) {
+        if (value is null) return null;
+        if (value.IndexOf('\\') < 0) return value;
+        return value
+            .Replace("\\r\\n", "\r\n")
+            .Replace("\\n", "\n")
+            .Replace("\\r", "\r");
     }
 }

--- a/CodeGlyphX/Rendering/Bmp/BarcodeBmpRenderer.cs
+++ b/CodeGlyphX/Rendering/Bmp/BarcodeBmpRenderer.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Bmp;
+
+/// <summary>
+/// Renders 1D barcodes to BMP images (BGRA32).
+/// </summary>
+public static class BarcodeBmpRenderer {
+    /// <summary>
+    /// Renders the barcode to a BMP byte array.
+    /// </summary>
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        return BmpWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a BMP stream.
+    /// </summary>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        BmpWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a BMP file.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
+        var bmp = Render(barcode, opts);
+        return RenderIO.WriteBinary(path, bmp);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a BMP file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
+        var bmp = Render(barcode, opts);
+        return RenderIO.WriteBinary(directory, fileName, bmp);
+    }
+}

--- a/CodeGlyphX/Rendering/Bmp/BmpWriter.cs
+++ b/CodeGlyphX/Rendering/Bmp/BmpWriter.cs
@@ -27,7 +27,7 @@ public static class BmpWriter {
         if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
 
         const int fileHeaderSize = 14;
-        const int infoHeaderSize = 40;
+        const int infoHeaderSize = 108;
         var dataOffset = fileHeaderSize + infoHeaderSize;
         var rowSize = width * 4;
         var imageSize = rowSize * height;
@@ -44,12 +44,17 @@ public static class BmpWriter {
         WriteInt32(header, 22, height);
         WriteInt16(header, 26, 1);
         WriteInt16(header, 28, 32);
-        WriteInt32(header, 30, 0);
+        WriteInt32(header, 30, 3);
         WriteInt32(header, 34, imageSize);
         WriteInt32(header, 38, 0);
         WriteInt32(header, 42, 0);
         WriteInt32(header, 46, 0);
         WriteInt32(header, 50, 0);
+        WriteInt32(header, 54, 0x00FF0000);
+        WriteInt32(header, 58, 0x0000FF00);
+        WriteInt32(header, 62, 0x000000FF);
+        WriteInt32(header, 66, unchecked((int)0xFF000000));
+        WriteInt32(header, 70, 0x73524742);
 
         stream.Write(header, 0, header.Length);
 

--- a/CodeGlyphX/Rendering/Bmp/BmpWriter.cs
+++ b/CodeGlyphX/Rendering/Bmp/BmpWriter.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+
+namespace CodeGlyphX.Rendering.Bmp;
+
+/// <summary>
+/// Writes BMP images from RGBA buffers.
+/// </summary>
+public static class BmpWriter {
+    /// <summary>
+    /// Writes a BMP (32-bit BGRA) byte array from an RGBA buffer.
+    /// </summary>
+    public static byte[] WriteRgba32(int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        using var ms = new MemoryStream();
+        WriteRgba32(ms, width, height, rgba, stride);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a BMP (32-bit BGRA) to a stream from an RGBA buffer.
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+
+        const int fileHeaderSize = 14;
+        const int infoHeaderSize = 40;
+        var dataOffset = fileHeaderSize + infoHeaderSize;
+        var rowSize = width * 4;
+        var imageSize = rowSize * height;
+        var fileSize = dataOffset + imageSize;
+
+        var header = new byte[fileHeaderSize + infoHeaderSize];
+        header[0] = (byte)'B';
+        header[1] = (byte)'M';
+        WriteInt32(header, 2, fileSize);
+        WriteInt32(header, 10, dataOffset);
+
+        WriteInt32(header, 14, infoHeaderSize);
+        WriteInt32(header, 18, width);
+        WriteInt32(header, 22, height);
+        WriteInt16(header, 26, 1);
+        WriteInt16(header, 28, 32);
+        WriteInt32(header, 30, 0);
+        WriteInt32(header, 34, imageSize);
+        WriteInt32(header, 38, 0);
+        WriteInt32(header, 42, 0);
+        WriteInt32(header, 46, 0);
+        WriteInt32(header, 50, 0);
+
+        stream.Write(header, 0, header.Length);
+
+        var row = new byte[rowSize];
+        for (var y = 0; y < height; y++) {
+            var srcRow = (height - 1 - y) * stride;
+            var dst = 0;
+            for (var x = 0; x < width; x++) {
+                var p = srcRow + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                var a = rgba[p + 3];
+                row[dst++] = b;
+                row[dst++] = g;
+                row[dst++] = r;
+                row[dst++] = a;
+            }
+            stream.Write(row, 0, rowSize);
+        }
+    }
+
+    /// <summary>
+    /// Writes a BMP (24-bit BGR) byte array from an RGBA buffer (alpha discarded).
+    /// </summary>
+    public static byte[] WriteRgb24(int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        using var ms = new MemoryStream();
+        WriteRgb24(ms, width, height, rgba, stride);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a BMP (24-bit BGR) to a stream from an RGBA buffer (alpha discarded).
+    /// </summary>
+    public static void WriteRgb24(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+
+        const int fileHeaderSize = 14;
+        const int infoHeaderSize = 40;
+        var dataOffset = fileHeaderSize + infoHeaderSize;
+        var rowSize = ((width * 3 + 3) / 4) * 4;
+        var imageSize = rowSize * height;
+        var fileSize = dataOffset + imageSize;
+
+        var header = new byte[fileHeaderSize + infoHeaderSize];
+        header[0] = (byte)'B';
+        header[1] = (byte)'M';
+        WriteInt32(header, 2, fileSize);
+        WriteInt32(header, 10, dataOffset);
+
+        WriteInt32(header, 14, infoHeaderSize);
+        WriteInt32(header, 18, width);
+        WriteInt32(header, 22, height);
+        WriteInt16(header, 26, 1);
+        WriteInt16(header, 28, 24);
+        WriteInt32(header, 30, 0);
+        WriteInt32(header, 34, imageSize);
+        WriteInt32(header, 38, 0);
+        WriteInt32(header, 42, 0);
+        WriteInt32(header, 46, 0);
+        WriteInt32(header, 50, 0);
+
+        stream.Write(header, 0, header.Length);
+
+        var row = new byte[rowSize];
+        for (var y = 0; y < height; y++) {
+            var srcRow = (height - 1 - y) * stride;
+            var dst = 0;
+            for (var x = 0; x < width; x++) {
+                var p = srcRow + x * 4;
+                row[dst++] = rgba[p + 2];
+                row[dst++] = rgba[p + 1];
+                row[dst++] = rgba[p + 0];
+            }
+            while (dst < rowSize) row[dst++] = 0;
+            stream.Write(row, 0, rowSize);
+        }
+    }
+
+    private static void WriteInt16(byte[] buffer, int offset, short value) {
+        buffer[offset + 0] = (byte)value;
+        buffer[offset + 1] = (byte)(value >> 8);
+    }
+
+    private static void WriteInt32(byte[] buffer, int offset, int value) {
+        buffer[offset + 0] = (byte)value;
+        buffer[offset + 1] = (byte)(value >> 8);
+        buffer[offset + 2] = (byte)(value >> 16);
+        buffer[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/CodeGlyphX/Rendering/Bmp/MatrixBmpRenderer.cs
+++ b/CodeGlyphX/Rendering/Bmp/MatrixBmpRenderer.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Bmp;
+
+/// <summary>
+/// Renders generic 2D matrices to BMP images (BGRA32).
+/// </summary>
+public static class MatrixBmpRenderer {
+    /// <summary>
+    /// Renders the matrix to a BMP byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return BmpWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a BMP stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        BmpWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a BMP file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
+        var bmp = Render(modules, opts);
+        return RenderIO.WriteBinary(path, bmp);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a BMP file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
+        var bmp = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, bmp);
+    }
+}

--- a/CodeGlyphX/Rendering/Bmp/QrBmpRenderer.cs
+++ b/CodeGlyphX/Rendering/Bmp/QrBmpRenderer.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Bmp;
+
+/// <summary>
+/// Renders QR modules to a BMP image (BGRA32).
+/// </summary>
+public static class QrBmpRenderer {
+    /// <summary>
+    /// Renders the QR module matrix to a BMP byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return BmpWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a BMP stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        BmpWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a BMP file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
+        var bmp = Render(modules, opts);
+        return RenderIO.WriteBinary(path, bmp);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a BMP file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
+        var bmp = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, bmp);
+    }
+}

--- a/CodeGlyphX/Rendering/Bmp/QrBmpRenderer.cs
+++ b/CodeGlyphX/Rendering/Bmp/QrBmpRenderer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;

--- a/CodeGlyphX/Rendering/Eps/BarcodeEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/BarcodeEpsRenderer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Eps;
+
+/// <summary>
+/// Renders 1D barcodes to an EPS image.
+/// </summary>
+public static class BarcodeEpsRenderer {
+    /// <summary>
+    /// Renders the barcode to an EPS string.
+    /// </summary>
+    public static string Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
+        return BuildEps(barcode, opts);
+    }
+
+    /// <summary>
+    /// Renders the barcode to an EPS stream.
+    /// </summary>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
+        var eps = BuildEps(barcode, opts);
+        RenderIO.WriteText(stream, eps, Encoding.ASCII);
+    }
+
+    /// <summary>
+    /// Renders the barcode to an EPS file.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
+        var eps = Render(barcode, opts);
+        return RenderIO.WriteText(path, eps, Encoding.ASCII);
+    }
+
+    /// <summary>
+    /// Renders the barcode to an EPS file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
+        var eps = Render(barcode, opts);
+        return RenderIO.WriteText(directory, fileName, eps, Encoding.ASCII);
+    }
+
+    private static string BuildEps(Barcode1D barcode, BarcodePngRenderOptions opts) {
+        if (barcode is null) throw new ArgumentNullException(nameof(barcode));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+        if (opts.HeightModules <= 0) throw new ArgumentOutOfRangeException(nameof(opts.HeightModules));
+
+        var outModules = barcode.TotalModules + opts.QuietZone * 2;
+        var widthPx = outModules * opts.ModuleSize;
+        var barHeightPx = opts.HeightModules * opts.ModuleSize;
+
+        var labelText = BarcodeLabelText.Normalize(opts.LabelText);
+        var hasLabel = !string.IsNullOrEmpty(labelText);
+        var labelFontPx = Math.Max(1, opts.LabelFontSize);
+        var labelMarginPx = Math.Max(0, opts.LabelMargin);
+        var labelScale = Math.Max(1, (int)Math.Round(labelFontPx / (double)BarcodeLabelFont.GlyphHeight));
+        var labelHeightPx = hasLabel ? labelMarginPx + BarcodeLabelFont.GlyphHeight * labelScale : 0;
+
+        var heightPx = barHeightPx + labelHeightPx;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+        var labelColor = Flatten(opts.LabelColor, bg);
+
+        var sb = new StringBuilder(widthPx * 2);
+        sb.AppendLine("%!PS-Adobe-3.0 EPSF-3.0");
+        sb.AppendLine($"%%BoundingBox: 0 0 {widthPx} {heightPx}");
+        sb.AppendLine("%%LanguageLevel: 2");
+        sb.AppendLine("%%Pages: 1");
+        sb.AppendLine("%%EndComments");
+        sb.AppendLine("gsave");
+        AppendColor(sb, bg);
+        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
+
+        AppendColor(sb, fg);
+        var xModules = opts.QuietZone;
+        for (var i = 0; i < barcode.Segments.Count; i++) {
+            var seg = barcode.Segments[i];
+            if (seg.IsBar) {
+                var x0 = xModules * opts.ModuleSize;
+                var w = seg.Modules * opts.ModuleSize;
+                AppendRectTopLeft(sb, x0, 0, w, barHeightPx, heightPx);
+            }
+            xModules += seg.Modules;
+        }
+
+        if (hasLabel) {
+            AppendColor(sb, labelColor);
+            var spacing = labelScale;
+            var textWidth = BarcodeLabelFont.MeasureTextWidth(labelText, labelScale, spacing);
+            var xStart = (widthPx - textWidth) / 2;
+            if (xStart < 0) xStart = 0;
+            var yStart = barHeightPx + labelMarginPx;
+            DrawLabel(sb, heightPx, xStart, yStart, labelText, labelScale, spacing);
+        }
+
+        sb.AppendLine("grestore");
+        sb.AppendLine("showpage");
+        sb.AppendLine("%%EOF");
+        return sb.ToString();
+    }
+
+    private static void DrawLabel(StringBuilder sb, int heightPx, int xStart, int yStart, string text, int scale, int spacing) {
+        var x = xStart;
+        for (var i = 0; i < text.Length; i++) {
+            var glyph = BarcodeLabelFont.GetGlyph(text[i]);
+            for (var row = 0; row < BarcodeLabelFont.GlyphHeight; row++) {
+                var bits = glyph[row];
+                for (var col = 0; col < BarcodeLabelFont.GlyphWidth; col++) {
+                    if ((bits & (1 << (BarcodeLabelFont.GlyphWidth - 1 - col))) == 0) continue;
+                    var px = x + col * scale;
+                    var py = yStart + row * scale;
+                    AppendRectTopLeft(sb, px, py, scale, scale, heightPx);
+                }
+            }
+            x += BarcodeLabelFont.GlyphWidth * scale + spacing;
+        }
+    }
+
+    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+        sb.Append(ToComponent(color.R)).Append(' ')
+            .Append(ToComponent(color.G)).Append(' ')
+            .Append(ToComponent(color.B)).AppendLine(" setrgbcolor");
+    }
+
+    private static string ToComponent(byte value) {
+        var scaled = value / 255.0;
+        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
+        var y = totalHeight - yTop - height;
+        sb.Append(x).Append(' ')
+            .Append(y).Append(' ')
+            .Append(width).Append(' ')
+            .Append(height).AppendLine(" rectfill");
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+}

--- a/CodeGlyphX/Rendering/Eps/BarcodeEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/BarcodeEpsRenderer.cs
@@ -14,14 +14,23 @@ public static class BarcodeEpsRenderer {
     /// <summary>
     /// Renders the barcode to an EPS string.
     /// </summary>
-    public static string Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
+    public static string Render(Barcode1D barcode, BarcodePngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+            return Encoding.ASCII.GetString(EpsWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background));
+        }
         return BuildEps(barcode, opts);
     }
 
     /// <summary>
     /// Renders the barcode to an EPS stream.
     /// </summary>
-    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+            EpsWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
+            return;
+        }
         var eps = BuildEps(barcode, opts);
         RenderIO.WriteText(stream, eps, Encoding.ASCII);
     }
@@ -29,16 +38,16 @@ public static class BarcodeEpsRenderer {
     /// <summary>
     /// Renders the barcode to an EPS file.
     /// </summary>
-    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
-        var eps = Render(barcode, opts);
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path, RenderMode mode = RenderMode.Vector) {
+        var eps = Render(barcode, opts, mode);
         return RenderIO.WriteText(path, eps, Encoding.ASCII);
     }
 
     /// <summary>
     /// Renders the barcode to an EPS file under the specified directory.
     /// </summary>
-    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
-        var eps = Render(barcode, opts);
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName, RenderMode mode = RenderMode.Vector) {
+        var eps = Render(barcode, opts, mode);
         return RenderIO.WriteText(directory, fileName, eps, Encoding.ASCII);
     }
 

--- a/CodeGlyphX/Rendering/Eps/EpsWriter.cs
+++ b/CodeGlyphX/Rendering/Eps/EpsWriter.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Eps;
+
+/// <summary>
+/// Minimal EPS writer for embedding RGB images.
+/// </summary>
+public static class EpsWriter {
+    private static readonly char[] Hex = "0123456789ABCDEF".ToCharArray();
+
+    /// <summary>
+    /// Writes a single-page EPS containing the supplied RGBA image.
+    /// </summary>
+    public static byte[] WriteRgba32(int width, int height, ReadOnlySpan<byte> rgba, int stride, Rgba32? background = null) {
+        using var ms = new MemoryStream();
+        WriteRgba32(ms, width, height, rgba, stride, background);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a single-page EPS containing the supplied RGBA image.
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride, Rgba32? background = null) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+
+        var rgb = ToRgb(width, height, rgba, stride, background ?? Rgba32.White);
+        WriteRgb24(stream, width, height, rgb);
+    }
+
+    /// <summary>
+    /// Writes a single-page EPS containing the supplied RGB image.
+    /// </summary>
+    public static byte[] WriteRgb24(int width, int height, byte[] rgb) {
+        using var ms = new MemoryStream();
+        WriteRgb24(ms, width, height, rgb);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a single-page EPS containing the supplied RGB image.
+    /// </summary>
+    public static void WriteRgb24(Stream stream, int width, int height, byte[] rgb) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (rgb is null) throw new ArgumentNullException(nameof(rgb));
+        if (rgb.Length < width * height * 3) throw new ArgumentException("RGB buffer is too small.", nameof(rgb));
+
+        using var writer = new StreamWriter(stream, Encoding.ASCII, 1024, leaveOpen: true);
+        writer.WriteLine("%!PS-Adobe-3.0 EPSF-3.0");
+        writer.WriteLine($"%%BoundingBox: 0 0 {width} {height}");
+        writer.WriteLine("%%LanguageLevel: 2");
+        writer.WriteLine("%%Pages: 1");
+        writer.WriteLine("%%EndComments");
+        writer.WriteLine("gsave");
+        writer.WriteLine("/DeviceRGB setcolorspace");
+        writer.WriteLine($"{width} {height} 8");
+        writer.WriteLine($"[{width} 0 0 -{height} 0 {height}]");
+        writer.WriteLine("{currentfile /ASCIIHexDecode filter} false 3 colorimage");
+        writer.Flush();
+
+        WriteHex(writer, rgb);
+
+        writer.WriteLine("grestore");
+        writer.WriteLine("showpage");
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+    }
+
+    private static void WriteHex(StreamWriter writer, byte[] data) {
+        const int lineLength = 96;
+        var sb = new StringBuilder(lineLength + 2);
+        for (var i = 0; i < data.Length; i++) {
+            var b = data[i];
+            sb.Append(Hex[b >> 4]);
+            sb.Append(Hex[b & 0xF]);
+            if (sb.Length >= lineLength) {
+                writer.WriteLine(sb.ToString());
+                sb.Clear();
+            }
+        }
+
+        if (sb.Length > 0) {
+            writer.WriteLine(sb.ToString());
+        }
+        writer.WriteLine(">");
+    }
+
+    private static byte[] ToRgb(int width, int height, ReadOnlySpan<byte> rgba, int stride, Rgba32 background) {
+        var rgb = new byte[width * height * 3];
+        var bgR = background.R;
+        var bgG = background.G;
+        var bgB = background.B;
+
+        var dst = 0;
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var p = row + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                var a = rgba[p + 3];
+
+                if (a == 255) {
+                    rgb[dst++] = r;
+                    rgb[dst++] = g;
+                    rgb[dst++] = b;
+                } else if (a == 0) {
+                    rgb[dst++] = bgR;
+                    rgb[dst++] = bgG;
+                    rgb[dst++] = bgB;
+                } else {
+                    var inv = 255 - a;
+                    rgb[dst++] = (byte)((r * a + bgR * inv + 127) / 255);
+                    rgb[dst++] = (byte)((g * a + bgG * inv + 127) / 255);
+                    rgb[dst++] = (byte)((b * a + bgB * inv + 127) / 255);
+                }
+            }
+        }
+
+        return rgb;
+    }
+}

--- a/CodeGlyphX/Rendering/Eps/MatrixEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/MatrixEpsRenderer.cs
@@ -14,14 +14,23 @@ public static class MatrixEpsRenderer {
     /// <summary>
     /// Renders the matrix to an EPS string.
     /// </summary>
-    public static string Render(BitMatrix modules, MatrixPngRenderOptions opts) {
+    public static string Render(BitMatrix modules, MatrixPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            return Encoding.ASCII.GetString(EpsWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background));
+        }
         return BuildEps(modules, opts);
     }
 
     /// <summary>
     /// Renders the matrix to an EPS stream.
     /// </summary>
-    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            EpsWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
+            return;
+        }
         var eps = BuildEps(modules, opts);
         RenderIO.WriteText(stream, eps, Encoding.ASCII);
     }
@@ -29,16 +38,16 @@ public static class MatrixEpsRenderer {
     /// <summary>
     /// Renders the matrix to an EPS file.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
-        var eps = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path, RenderMode mode = RenderMode.Vector) {
+        var eps = Render(modules, opts, mode);
         return RenderIO.WriteText(path, eps, Encoding.ASCII);
     }
 
     /// <summary>
     /// Renders the matrix to an EPS file under the specified directory.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
-        var eps = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName, RenderMode mode = RenderMode.Vector) {
+        var eps = Render(modules, opts, mode);
         return RenderIO.WriteText(directory, fileName, eps, Encoding.ASCII);
     }
 

--- a/CodeGlyphX/Rendering/Eps/MatrixEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/MatrixEpsRenderer.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Eps;
+
+/// <summary>
+/// Renders generic 2D matrices to an EPS image.
+/// </summary>
+public static class MatrixEpsRenderer {
+    /// <summary>
+    /// Renders the matrix to an EPS string.
+    /// </summary>
+    public static string Render(BitMatrix modules, MatrixPngRenderOptions opts) {
+        return BuildEps(modules, opts);
+    }
+
+    /// <summary>
+    /// Renders the matrix to an EPS stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
+        var eps = BuildEps(modules, opts);
+        RenderIO.WriteText(stream, eps, Encoding.ASCII);
+    }
+
+    /// <summary>
+    /// Renders the matrix to an EPS file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
+        var eps = Render(modules, opts);
+        return RenderIO.WriteText(path, eps, Encoding.ASCII);
+    }
+
+    /// <summary>
+    /// Renders the matrix to an EPS file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
+        var eps = Render(modules, opts);
+        return RenderIO.WriteText(directory, fileName, eps, Encoding.ASCII);
+    }
+
+    private static string BuildEps(BitMatrix modules, MatrixPngRenderOptions opts) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+
+        var outWidthModules = modules.Width + opts.QuietZone * 2;
+        var outHeightModules = modules.Height + opts.QuietZone * 2;
+        var widthPx = outWidthModules * opts.ModuleSize;
+        var heightPx = outHeightModules * opts.ModuleSize;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+
+        var sb = new StringBuilder(outWidthModules * outHeightModules * 3);
+        sb.AppendLine("%!PS-Adobe-3.0 EPSF-3.0");
+        sb.AppendLine($"%%BoundingBox: 0 0 {widthPx} {heightPx}");
+        sb.AppendLine("%%LanguageLevel: 2");
+        sb.AppendLine("%%Pages: 1");
+        sb.AppendLine("%%EndComments");
+        sb.AppendLine("gsave");
+        AppendColor(sb, bg);
+        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
+        AppendColor(sb, fg);
+
+        for (var my = 0; my < modules.Height; my++) {
+            for (var mx = 0; mx < modules.Width; mx++) {
+                if (!modules[mx, my]) continue;
+                var x = (mx + opts.QuietZone) * opts.ModuleSize;
+                var y = (my + opts.QuietZone) * opts.ModuleSize;
+                AppendRectTopLeft(sb, x, y, opts.ModuleSize, opts.ModuleSize, heightPx);
+            }
+        }
+
+        sb.AppendLine("grestore");
+        sb.AppendLine("showpage");
+        sb.AppendLine("%%EOF");
+        return sb.ToString();
+    }
+
+    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+        sb.Append(ToComponent(color.R)).Append(' ')
+            .Append(ToComponent(color.G)).Append(' ')
+            .Append(ToComponent(color.B)).AppendLine(" setrgbcolor");
+    }
+
+    private static string ToComponent(byte value) {
+        var scaled = value / 255.0;
+        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
+        var y = totalHeight - yTop - height;
+        sb.Append(x).Append(' ')
+            .Append(y).Append(' ')
+            .Append(width).Append(' ')
+            .Append(height).AppendLine(" rectfill");
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+}

--- a/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
@@ -14,14 +14,23 @@ public static class QrEpsRenderer {
     /// <summary>
     /// Renders the QR module matrix to an EPS string.
     /// </summary>
-    public static string Render(BitMatrix modules, QrPngRenderOptions opts) {
+    public static string Render(BitMatrix modules, QrPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            return Encoding.ASCII.GetString(EpsWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background));
+        }
         return BuildEps(modules, opts);
     }
 
     /// <summary>
     /// Renders the QR module matrix to an EPS stream.
     /// </summary>
-    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            EpsWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
+            return;
+        }
         var eps = BuildEps(modules, opts);
         RenderIO.WriteText(stream, eps, Encoding.ASCII);
     }
@@ -29,16 +38,16 @@ public static class QrEpsRenderer {
     /// <summary>
     /// Renders the QR module matrix to an EPS file.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
-        var eps = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path, RenderMode mode = RenderMode.Vector) {
+        var eps = Render(modules, opts, mode);
         return RenderIO.WriteText(path, eps, Encoding.ASCII);
     }
 
     /// <summary>
     /// Renders the QR module matrix to an EPS file under the specified directory.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
-        var eps = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName, RenderMode mode = RenderMode.Vector) {
+        var eps = Render(modules, opts, mode);
         return RenderIO.WriteText(directory, fileName, eps, Encoding.ASCII);
     }
 

--- a/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Eps;
+
+/// <summary>
+/// Renders QR modules to an EPS image.
+/// </summary>
+public static class QrEpsRenderer {
+    /// <summary>
+    /// Renders the QR module matrix to an EPS string.
+    /// </summary>
+    public static string Render(BitMatrix modules, QrPngRenderOptions opts) {
+        return BuildEps(modules, opts);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to an EPS stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
+        var eps = BuildEps(modules, opts);
+        RenderIO.WriteText(stream, eps, Encoding.ASCII);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to an EPS file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
+        var eps = Render(modules, opts);
+        return RenderIO.WriteText(path, eps, Encoding.ASCII);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to an EPS file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
+        var eps = Render(modules, opts);
+        return RenderIO.WriteText(directory, fileName, eps, Encoding.ASCII);
+    }
+
+    private static string BuildEps(BitMatrix modules, QrPngRenderOptions opts) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+
+        var size = modules.Width;
+        var outModules = size + opts.QuietZone * 2;
+        var widthPx = outModules * opts.ModuleSize;
+        var heightPx = widthPx;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+
+        var sb = new StringBuilder(outModules * outModules * 3);
+        sb.AppendLine("%!PS-Adobe-3.0 EPSF-3.0");
+        sb.AppendLine($"%%BoundingBox: 0 0 {widthPx} {heightPx}");
+        sb.AppendLine("%%LanguageLevel: 2");
+        sb.AppendLine("%%Pages: 1");
+        sb.AppendLine("%%EndComments");
+        sb.AppendLine("gsave");
+        AppendColor(sb, bg);
+        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
+        AppendColor(sb, fg);
+
+        for (var my = 0; my < size; my++) {
+            for (var mx = 0; mx < size; mx++) {
+                if (!modules[mx, my]) continue;
+                var x = (mx + opts.QuietZone) * opts.ModuleSize;
+                var y = (my + opts.QuietZone) * opts.ModuleSize;
+                AppendRectTopLeft(sb, x, y, opts.ModuleSize, opts.ModuleSize, heightPx);
+            }
+        }
+
+        sb.AppendLine("grestore");
+        sb.AppendLine("showpage");
+        sb.AppendLine("%%EOF");
+        return sb.ToString();
+    }
+
+    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+        sb.Append(ToComponent(color.R)).Append(' ')
+            .Append(ToComponent(color.G)).Append(' ')
+            .Append(ToComponent(color.B)).AppendLine(" setrgbcolor");
+    }
+
+    private static string ToComponent(byte value) {
+        var scaled = value / 255.0;
+        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
+        var y = totalHeight - yTop - height;
+        sb.Append(x).Append(' ')
+            .Append(y).Append(' ')
+            .Append(width).Append(' ')
+            .Append(height).AppendLine(" rectfill");
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+}

--- a/CodeGlyphX/Rendering/Pdf/BarcodePdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/BarcodePdfRenderer.cs
@@ -14,32 +14,41 @@ public static class BarcodePdfRenderer {
     /// <summary>
     /// Renders the barcode to a PDF byte array.
     /// </summary>
-    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
-        var content = BuildContent(barcode, opts, out var widthPx, out var heightPx);
-        return PdfVectorWriter.Write(widthPx, heightPx, content);
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+            return PdfWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background);
+        }
+        var content = BuildContent(barcode, opts, out var widthPx2, out var heightPx2);
+        return PdfVectorWriter.Write(widthPx2, heightPx2, content);
     }
 
     /// <summary>
     /// Renders the barcode to a PDF stream.
     /// </summary>
-    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
-        var content = BuildContent(barcode, opts, out var widthPx, out var heightPx);
-        PdfVectorWriter.Write(stream, widthPx, heightPx, content);
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+            PdfWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
+            return;
+        }
+        var content = BuildContent(barcode, opts, out var widthPx2, out var heightPx2);
+        PdfVectorWriter.Write(stream, widthPx2, heightPx2, content);
     }
 
     /// <summary>
     /// Renders the barcode to a PDF file.
     /// </summary>
-    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
-        var pdf = Render(barcode, opts);
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path, RenderMode mode = RenderMode.Vector) {
+        var pdf = Render(barcode, opts, mode);
         return RenderIO.WriteBinary(path, pdf);
     }
 
     /// <summary>
     /// Renders the barcode to a PDF file under the specified directory.
     /// </summary>
-    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
-        var pdf = Render(barcode, opts);
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName, RenderMode mode = RenderMode.Vector) {
+        var pdf = Render(barcode, opts, mode);
         return RenderIO.WriteBinary(directory, fileName, pdf);
     }
 

--- a/CodeGlyphX/Rendering/Pdf/BarcodePdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/BarcodePdfRenderer.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Pdf;
+
+/// <summary>
+/// Renders 1D barcodes to a PDF image.
+/// </summary>
+public static class BarcodePdfRenderer {
+    /// <summary>
+    /// Renders the barcode to a PDF byte array.
+    /// </summary>
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
+        var content = BuildContent(barcode, opts, out var widthPx, out var heightPx);
+        return PdfVectorWriter.Write(widthPx, heightPx, content);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a PDF stream.
+    /// </summary>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
+        var content = BuildContent(barcode, opts, out var widthPx, out var heightPx);
+        PdfVectorWriter.Write(stream, widthPx, heightPx, content);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a PDF file.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
+        var pdf = Render(barcode, opts);
+        return RenderIO.WriteBinary(path, pdf);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a PDF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
+        var pdf = Render(barcode, opts);
+        return RenderIO.WriteBinary(directory, fileName, pdf);
+    }
+
+    private static string BuildContent(Barcode1D barcode, BarcodePngRenderOptions opts, out int widthPx, out int heightPx) {
+        if (barcode is null) throw new ArgumentNullException(nameof(barcode));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+        if (opts.HeightModules <= 0) throw new ArgumentOutOfRangeException(nameof(opts.HeightModules));
+
+        var outModules = barcode.TotalModules + opts.QuietZone * 2;
+        widthPx = outModules * opts.ModuleSize;
+        var barHeightPx = opts.HeightModules * opts.ModuleSize;
+
+        var labelText = BarcodeLabelText.Normalize(opts.LabelText);
+        var hasLabel = !string.IsNullOrEmpty(labelText);
+        var labelFontPx = Math.Max(1, opts.LabelFontSize);
+        var labelMarginPx = Math.Max(0, opts.LabelMargin);
+        var labelScale = Math.Max(1, (int)Math.Round(labelFontPx / (double)BarcodeLabelFont.GlyphHeight));
+        var labelHeightPx = hasLabel ? labelMarginPx + BarcodeLabelFont.GlyphHeight * labelScale : 0;
+
+        heightPx = barHeightPx + labelHeightPx;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+        var labelColor = Flatten(opts.LabelColor, bg);
+
+        var sb = new StringBuilder(widthPx * 2);
+        AppendColor(sb, bg);
+        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
+
+        AppendColor(sb, fg);
+        var xModules = opts.QuietZone;
+        for (var i = 0; i < barcode.Segments.Count; i++) {
+            var seg = barcode.Segments[i];
+            if (seg.IsBar) {
+                var x0 = xModules * opts.ModuleSize;
+                var w = seg.Modules * opts.ModuleSize;
+                AppendRectTopLeft(sb, x0, 0, w, barHeightPx, heightPx);
+            }
+            xModules += seg.Modules;
+        }
+
+        if (hasLabel) {
+            AppendColor(sb, labelColor);
+            var spacing = labelScale;
+            var textWidth = BarcodeLabelFont.MeasureTextWidth(labelText, labelScale, spacing);
+            var xStart = (widthPx - textWidth) / 2;
+            if (xStart < 0) xStart = 0;
+            var yStart = barHeightPx + labelMarginPx;
+            DrawLabel(sb, heightPx, xStart, yStart, labelText, labelScale, spacing);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void DrawLabel(StringBuilder sb, int heightPx, int xStart, int yStart, string text, int scale, int spacing) {
+        var x = xStart;
+        for (var i = 0; i < text.Length; i++) {
+            var glyph = BarcodeLabelFont.GetGlyph(text[i]);
+            for (var row = 0; row < BarcodeLabelFont.GlyphHeight; row++) {
+                var bits = glyph[row];
+                for (var col = 0; col < BarcodeLabelFont.GlyphWidth; col++) {
+                    if ((bits & (1 << (BarcodeLabelFont.GlyphWidth - 1 - col))) == 0) continue;
+                    var px = x + col * scale;
+                    var py = yStart + row * scale;
+                    AppendRectTopLeft(sb, px, py, scale, scale, heightPx);
+                }
+            }
+            x += BarcodeLabelFont.GlyphWidth * scale + spacing;
+        }
+    }
+
+    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+        sb.Append(ToComponent(color.R)).Append(' ')
+            .Append(ToComponent(color.G)).Append(' ')
+            .Append(ToComponent(color.B)).Append(" rg\n");
+    }
+
+    private static string ToComponent(byte value) {
+        var scaled = value / 255.0;
+        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
+        var y = totalHeight - yTop - height;
+        sb.Append(x).Append(' ')
+            .Append(y).Append(' ')
+            .Append(width).Append(' ')
+            .Append(height).Append(" re f\n");
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+}

--- a/CodeGlyphX/Rendering/Pdf/MatrixPdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/MatrixPdfRenderer.cs
@@ -14,32 +14,41 @@ public static class MatrixPdfRenderer {
     /// <summary>
     /// Renders the matrix to a PDF byte array.
     /// </summary>
-    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts) {
-        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
-        return PdfVectorWriter.Write(widthPx, heightPx, content);
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            return PdfWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background);
+        }
+        var content = BuildContent(modules, opts, out var widthPx2, out var heightPx2);
+        return PdfVectorWriter.Write(widthPx2, heightPx2, content);
     }
 
     /// <summary>
     /// Renders the matrix to a PDF stream.
     /// </summary>
-    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
-        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
-        PdfVectorWriter.Write(stream, widthPx, heightPx, content);
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            PdfWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
+            return;
+        }
+        var content = BuildContent(modules, opts, out var widthPx2, out var heightPx2);
+        PdfVectorWriter.Write(stream, widthPx2, heightPx2, content);
     }
 
     /// <summary>
     /// Renders the matrix to a PDF file.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
-        var pdf = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path, RenderMode mode = RenderMode.Vector) {
+        var pdf = Render(modules, opts, mode);
         return RenderIO.WriteBinary(path, pdf);
     }
 
     /// <summary>
     /// Renders the matrix to a PDF file under the specified directory.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
-        var pdf = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName, RenderMode mode = RenderMode.Vector) {
+        var pdf = Render(modules, opts, mode);
         return RenderIO.WriteBinary(directory, fileName, pdf);
     }
 

--- a/CodeGlyphX/Rendering/Pdf/MatrixPdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/MatrixPdfRenderer.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Pdf;
+
+/// <summary>
+/// Renders generic 2D matrices to a PDF image.
+/// </summary>
+public static class MatrixPdfRenderer {
+    /// <summary>
+    /// Renders the matrix to a PDF byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts) {
+        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
+        return PdfVectorWriter.Write(widthPx, heightPx, content);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a PDF stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
+        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
+        PdfVectorWriter.Write(stream, widthPx, heightPx, content);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a PDF file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
+        var pdf = Render(modules, opts);
+        return RenderIO.WriteBinary(path, pdf);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a PDF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
+        var pdf = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, pdf);
+    }
+
+    private static string BuildContent(BitMatrix modules, MatrixPngRenderOptions opts, out int widthPx, out int heightPx) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+
+        var outWidthModules = modules.Width + opts.QuietZone * 2;
+        var outHeightModules = modules.Height + opts.QuietZone * 2;
+        widthPx = outWidthModules * opts.ModuleSize;
+        heightPx = outHeightModules * opts.ModuleSize;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+
+        var sb = new StringBuilder(outWidthModules * outHeightModules * 4);
+        AppendColor(sb, bg);
+        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
+        AppendColor(sb, fg);
+
+        for (var my = 0; my < modules.Height; my++) {
+            for (var mx = 0; mx < modules.Width; mx++) {
+                if (!modules[mx, my]) continue;
+                var x = (mx + opts.QuietZone) * opts.ModuleSize;
+                var y = (my + opts.QuietZone) * opts.ModuleSize;
+                AppendRectTopLeft(sb, x, y, opts.ModuleSize, opts.ModuleSize, heightPx);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+        sb.Append(ToComponent(color.R)).Append(' ')
+            .Append(ToComponent(color.G)).Append(' ')
+            .Append(ToComponent(color.B)).Append(" rg\n");
+    }
+
+    private static string ToComponent(byte value) {
+        var scaled = value / 255.0;
+        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
+        var y = totalHeight - yTop - height;
+        sb.Append(x).Append(' ')
+            .Append(y).Append(' ')
+            .Append(width).Append(' ')
+            .Append(height).Append(" re f\n");
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+}

--- a/CodeGlyphX/Rendering/Pdf/PdfVectorWriter.cs
+++ b/CodeGlyphX/Rendering/Pdf/PdfVectorWriter.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace CodeGlyphX.Rendering.Pdf;
+
+/// <summary>
+/// Minimal PDF writer for vector content streams.
+/// </summary>
+internal static class PdfVectorWriter {
+    internal static byte[] Write(int width, int height, string content) {
+        using var ms = new MemoryStream();
+        Write(ms, width, height, content);
+        return ms.ToArray();
+    }
+
+    internal static void Write(Stream stream, int width, int height, string content) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (content is null) throw new ArgumentNullException(nameof(content));
+
+        var offsets = new long[5];
+        using var writer = new StreamWriter(stream, Encoding.ASCII, 1024, leaveOpen: true);
+
+        writer.WriteLine("%PDF-1.4");
+        writer.Flush();
+
+        offsets[1] = stream.Position;
+        writer.WriteLine("1 0 obj");
+        writer.WriteLine("<< /Type /Catalog /Pages 2 0 R >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[2] = stream.Position;
+        writer.WriteLine("2 0 obj");
+        writer.WriteLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[3] = stream.Position;
+        writer.WriteLine("3 0 obj");
+        writer.WriteLine($"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {width} {height}]");
+        writer.WriteLine("   /Resources << >>");
+        writer.WriteLine("   /Contents 4 0 R >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        var contentBytes = Encoding.ASCII.GetBytes(content);
+        offsets[4] = stream.Position;
+        writer.WriteLine("4 0 obj");
+        writer.WriteLine($"<< /Length {contentBytes.Length} >>");
+        writer.WriteLine("stream");
+        writer.Flush();
+        stream.Write(contentBytes, 0, contentBytes.Length);
+        writer.WriteLine();
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        var xrefStart = stream.Position;
+        writer.WriteLine("xref");
+        writer.WriteLine("0 5");
+        writer.WriteLine("0000000000 65535 f ");
+        for (var i = 1; i <= 4; i++) {
+            writer.WriteLine($"{offsets[i]:0000000000} 00000 n ");
+        }
+        writer.WriteLine("trailer");
+        writer.WriteLine("<< /Size 5 /Root 1 0 R >>");
+        writer.WriteLine("startxref");
+        writer.WriteLine(xrefStart);
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+    }
+}

--- a/CodeGlyphX/Rendering/Pdf/PdfWriter.cs
+++ b/CodeGlyphX/Rendering/Pdf/PdfWriter.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Pdf;
+
+/// <summary>
+/// Minimal PDF writer for embedding RGB images.
+/// </summary>
+public static class PdfWriter {
+    /// <summary>
+    /// Writes a single-page PDF containing the supplied RGBA image.
+    /// </summary>
+    public static byte[] WriteRgba32(int width, int height, ReadOnlySpan<byte> rgba, int stride, Rgba32? background = null) {
+        using var ms = new MemoryStream();
+        WriteRgba32(ms, width, height, rgba, stride, background);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a single-page PDF containing the supplied RGBA image.
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride, Rgba32? background = null) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+
+        var rgb = ToRgb(width, height, rgba, stride, background ?? Rgba32.White);
+        WriteRgb24(stream, width, height, rgb);
+    }
+
+    /// <summary>
+    /// Writes a single-page PDF containing the supplied RGB image.
+    /// </summary>
+    public static byte[] WriteRgb24(int width, int height, byte[] rgb) {
+        using var ms = new MemoryStream();
+        WriteRgb24(ms, width, height, rgb);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a single-page PDF containing the supplied RGB image.
+    /// </summary>
+    public static void WriteRgb24(Stream stream, int width, int height, byte[] rgb) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (rgb is null) throw new ArgumentNullException(nameof(rgb));
+        if (rgb.Length < width * height * 3) throw new ArgumentException("RGB buffer is too small.", nameof(rgb));
+
+        var offsets = new long[6];
+        var writer = new StreamWriter(stream, Encoding.ASCII, 1024, leaveOpen: true);
+
+        writer.WriteLine("%PDF-1.4");
+        writer.Flush();
+
+        offsets[1] = stream.Position;
+        writer.WriteLine("1 0 obj");
+        writer.WriteLine("<< /Type /Catalog /Pages 2 0 R >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[2] = stream.Position;
+        writer.WriteLine("2 0 obj");
+        writer.WriteLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[3] = stream.Position;
+        writer.WriteLine("3 0 obj");
+        writer.WriteLine($"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {width} {height}]");
+        writer.WriteLine("   /Resources << /XObject << /Im0 5 0 R >> >>");
+        writer.WriteLine("   /Contents 4 0 R >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        var content = $"q\n{width} 0 0 {height} 0 0 cm\n/Im0 Do\nQ\n";
+        var contentBytes = Encoding.ASCII.GetBytes(content);
+
+        offsets[4] = stream.Position;
+        writer.WriteLine("4 0 obj");
+        writer.WriteLine($"<< /Length {contentBytes.Length} >>");
+        writer.WriteLine("stream");
+        writer.Flush();
+        stream.Write(contentBytes, 0, contentBytes.Length);
+        writer.WriteLine();
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[5] = stream.Position;
+        writer.WriteLine("5 0 obj");
+        writer.WriteLine($"<< /Type /XObject /Subtype /Image /Width {width} /Height {height}");
+        writer.WriteLine("   /ColorSpace /DeviceRGB /BitsPerComponent 8");
+        writer.WriteLine($"   /Length {width * height * 3} >>");
+        writer.WriteLine("stream");
+        writer.Flush();
+        stream.Write(rgb, 0, width * height * 3);
+        writer.WriteLine();
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        var xrefStart = stream.Position;
+        writer.WriteLine("xref");
+        writer.WriteLine("0 6");
+        writer.WriteLine("0000000000 65535 f ");
+        for (var i = 1; i <= 5; i++) {
+            writer.WriteLine($"{offsets[i]:0000000000} 00000 n ");
+        }
+        writer.WriteLine("trailer");
+        writer.WriteLine("<< /Size 6 /Root 1 0 R >>");
+        writer.WriteLine("startxref");
+        writer.WriteLine(xrefStart);
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+    }
+
+    private static byte[] ToRgb(int width, int height, ReadOnlySpan<byte> rgba, int stride, Rgba32 background) {
+        var rgb = new byte[width * height * 3];
+        var bgR = background.R;
+        var bgG = background.G;
+        var bgB = background.B;
+
+        var dst = 0;
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var p = row + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                var a = rgba[p + 3];
+
+                if (a == 255) {
+                    rgb[dst++] = r;
+                    rgb[dst++] = g;
+                    rgb[dst++] = b;
+                } else if (a == 0) {
+                    rgb[dst++] = bgR;
+                    rgb[dst++] = bgG;
+                    rgb[dst++] = bgB;
+                } else {
+                    var inv = 255 - a;
+                    rgb[dst++] = (byte)((r * a + bgR * inv + 127) / 255);
+                    rgb[dst++] = (byte)((g * a + bgG * inv + 127) / 255);
+                    rgb[dst++] = (byte)((b * a + bgB * inv + 127) / 255);
+                }
+            }
+        }
+
+        return rgb;
+    }
+}

--- a/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Pdf;
+
+/// <summary>
+/// Renders QR modules to a PDF image.
+/// </summary>
+public static class QrPdfRenderer {
+    /// <summary>
+    /// Renders the QR module matrix to a PDF byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts) {
+        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
+        return PdfVectorWriter.Write(widthPx, heightPx, content);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a PDF stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
+        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
+        PdfVectorWriter.Write(stream, widthPx, heightPx, content);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a PDF file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
+        var pdf = Render(modules, opts);
+        return RenderIO.WriteBinary(path, pdf);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a PDF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
+        var pdf = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, pdf);
+    }
+
+    private static string BuildContent(BitMatrix modules, QrPngRenderOptions opts, out int widthPx, out int heightPx) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+
+        var size = modules.Width;
+        var outModules = size + opts.QuietZone * 2;
+        widthPx = outModules * opts.ModuleSize;
+        heightPx = widthPx;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+
+        var sb = new StringBuilder(outModules * outModules * 4);
+        AppendColor(sb, bg);
+        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
+        AppendColor(sb, fg);
+
+        for (var my = 0; my < size; my++) {
+            for (var mx = 0; mx < size; mx++) {
+                if (!modules[mx, my]) continue;
+                var x = (mx + opts.QuietZone) * opts.ModuleSize;
+                var y = (my + opts.QuietZone) * opts.ModuleSize;
+                AppendRectTopLeft(sb, x, y, opts.ModuleSize, opts.ModuleSize, heightPx);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+        sb.Append(ToComponent(color.R)).Append(' ')
+            .Append(ToComponent(color.G)).Append(' ')
+            .Append(ToComponent(color.B)).Append(" rg\n");
+    }
+
+    private static string ToComponent(byte value) {
+        var scaled = value / 255.0;
+        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
+        var y = totalHeight - yTop - height;
+        sb.Append(x).Append(' ')
+            .Append(y).Append(' ')
+            .Append(width).Append(' ')
+            .Append(height).Append(" re f\n");
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+}

--- a/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
@@ -14,32 +14,41 @@ public static class QrPdfRenderer {
     /// <summary>
     /// Renders the QR module matrix to a PDF byte array.
     /// </summary>
-    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts) {
-        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
-        return PdfVectorWriter.Write(widthPx, heightPx, content);
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            return PdfWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background);
+        }
+        var content = BuildContent(modules, opts, out var widthPx2, out var heightPx2);
+        return PdfVectorWriter.Write(widthPx2, heightPx2, content);
     }
 
     /// <summary>
     /// Renders the QR module matrix to a PDF stream.
     /// </summary>
-    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
-        var content = BuildContent(modules, opts, out var widthPx, out var heightPx);
-        PdfVectorWriter.Write(stream, widthPx, heightPx, content);
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
+        if (mode == RenderMode.Raster) {
+            var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+            PdfWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
+            return;
+        }
+        var content = BuildContent(modules, opts, out var widthPx2, out var heightPx2);
+        PdfVectorWriter.Write(stream, widthPx2, heightPx2, content);
     }
 
     /// <summary>
     /// Renders the QR module matrix to a PDF file.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
-        var pdf = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path, RenderMode mode = RenderMode.Vector) {
+        var pdf = Render(modules, opts, mode);
         return RenderIO.WriteBinary(path, pdf);
     }
 
     /// <summary>
     /// Renders the QR module matrix to a PDF file under the specified directory.
     /// </summary>
-    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
-        var pdf = Render(modules, opts);
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName, RenderMode mode = RenderMode.Vector) {
+        var pdf = Render(modules, opts, mode);
         return RenderIO.WriteBinary(directory, fileName, pdf);
     }
 

--- a/CodeGlyphX/Rendering/RenderExtensions.cs
+++ b/CodeGlyphX/Rendering/RenderExtensions.cs
@@ -131,7 +131,7 @@ public static class RenderExtensions {
     /// </summary>
     public static string ToDataUri(this byte[] data, string mimeType) {
         if (data is null) throw new ArgumentNullException(nameof(data));
-        if (string.IsNullOrWhiteSpace(mimeType)) throw new ArgumentNullException(nameof(mimeType));
+        if (string.IsNullOrWhiteSpace(mimeType)) throw new ArgumentException("Mime type cannot be null, empty, or whitespace.", nameof(mimeType));
         return "data:" + mimeType + ";base64," + Convert.ToBase64String(data);
     }
 }

--- a/CodeGlyphX/Rendering/RenderExtensions.cs
+++ b/CodeGlyphX/Rendering/RenderExtensions.cs
@@ -108,4 +108,30 @@ public static class RenderExtensions {
                "<body style=\"background:#f5f7fb;font-family:Segoe UI,Arial,sans-serif;\">" +
                "<div style=\"padding:24px;\">" + innerHtml + "</div></body></html>";
     }
+
+    /// <summary>
+    /// Encodes binary data as Base64.
+    /// </summary>
+    public static string ToBase64(this byte[] data) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return Convert.ToBase64String(data);
+    }
+
+    /// <summary>
+    /// Encodes text as Base64 (UTF-8 by default).
+    /// </summary>
+    public static string ToBase64(this string text, Encoding? encoding = null) {
+        if (text is null) throw new ArgumentNullException(nameof(text));
+        var enc = encoding ?? Encoding.UTF8;
+        return Convert.ToBase64String(enc.GetBytes(text));
+    }
+
+    /// <summary>
+    /// Encodes binary data as a Base64 data URI.
+    /// </summary>
+    public static string ToDataUri(this byte[] data, string mimeType) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        if (string.IsNullOrWhiteSpace(mimeType)) throw new ArgumentNullException(nameof(mimeType));
+        return "data:" + mimeType + ";base64," + Convert.ToBase64String(data);
+    }
 }

--- a/CodeGlyphX/Rendering/RenderMode.cs
+++ b/CodeGlyphX/Rendering/RenderMode.cs
@@ -1,0 +1,15 @@
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Output mode for vector-capable formats.
+/// </summary>
+public enum RenderMode {
+    /// <summary>
+    /// Vector output (default).
+    /// </summary>
+    Vector = 0,
+    /// <summary>
+    /// Raster output.
+    /// </summary>
+    Raster = 1
+}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ QR.Save("https://example.com", "qr.pdf");
 
 ```csharp
 using CodeGlyphX;
+using CodeGlyphX.Rendering;
+
+// PDF/EPS are vector by default. Use Raster when you need pixels.
+QR.SavePdf("https://example.com", "qr-raster.pdf", renderMode: RenderMode.Raster);
+```
+
+```csharp
+using CodeGlyphX;
 
 Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.png");
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CodeGlyphX is a fast, dependency-free toolkit for QR codes and barcodes, with ro
 - Reliable QR decoding (ECI, FNC1/GS1, Kanji, structured append, Micro QR)
 - 1D barcode encoding/decoding (Code128/GS1-128, Code39, Code93, EAN/UPC, ITF-14)
 - 2D encoding/decoding (Data Matrix, PDF417)
-- Renderers (SVG / HTML / PNG / JPEG / BMP / ASCII) and image decoding (PNG/JPEG/GIF/BMP/PPM/TGA)
+- Renderers (SVG / HTML / PNG / JPEG / BMP / PDF / EPS / ASCII) and image decoding (PNG/JPEG/GIF/BMP/PPM/TGA)
 - OTP helpers (otpauth://totp + Base32)
 - WPF controls + demo apps
 
@@ -74,7 +74,7 @@ CodeGlyphX is a fast, dependency-free toolkit for QR codes and barcodes, with ro
 - [x] Micro QR support
 - [x] 1D barcode encode + decode
 - [x] Data Matrix + PDF417 encode + decode
-- [x] SVG / HTML / PNG / JPEG / BMP / ASCII renderers
+- [x] SVG / HTML / PNG / JPEG / BMP / PDF / EPS / ASCII renderers
 - [x] Image decode: PNG / JPEG / GIF / BMP / PPM / TGA
 - [x] Base64 helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone, SMS, Contact, Calendar, OTP, Social)
@@ -88,6 +88,7 @@ using CodeGlyphX;
 QR.Save("https://example.com", "qr.png");
 QR.Save("https://example.com", "qr.svg");
 QR.Save("https://example.com", "qr.jpg");
+QR.Save("https://example.com", "qr.pdf");
 ```
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CodeGlyphX is a fast, dependency-free toolkit for QR codes and barcodes, with ro
 - Reliable QR decoding (ECI, FNC1/GS1, Kanji, structured append, Micro QR)
 - 1D barcode encoding/decoding (Code128/GS1-128, Code39, Code93, EAN/UPC, ITF-14)
 - 2D encoding/decoding (Data Matrix, PDF417)
-- Renderers (SVG / HTML / PNG / JPEG) and image decoding (PNG/JPEG/GIF/BMP/PPM/TGA)
+- Renderers (SVG / HTML / PNG / JPEG / BMP / ASCII) and image decoding (PNG/JPEG/GIF/BMP/PPM/TGA)
 - OTP helpers (otpauth://totp + Base32)
 - WPF controls + demo apps
 
@@ -74,8 +74,9 @@ CodeGlyphX is a fast, dependency-free toolkit for QR codes and barcodes, with ro
 - [x] Micro QR support
 - [x] 1D barcode encode + decode
 - [x] Data Matrix + PDF417 encode + decode
-- [x] SVG / HTML / PNG / JPEG renderers
+- [x] SVG / HTML / PNG / JPEG / BMP / ASCII renderers
 - [x] Image decode: PNG / JPEG / GIF / BMP / PPM / TGA
+- [x] Base64 helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone, SMS, Contact, Calendar, OTP, Social)
 - [x] WPF controls and demo apps
 


### PR DESCRIPTION
## Summary
- Add BMP writer + BMP renderers for QR/Barcode/Matrix outputs
- Add ASCII renderers for QR/Barcode/Matrix with escaped-newline normalization
- Add Base64/data URI helpers
- Add PDF/EPS renderers with vector default and optional raster mode (RenderMode)
- Vector QR styling for PDF/EPS (square/rounded/circle modules + eye shapes); gradients/logos auto-raster
- Preserve BMP alpha via BITMAPV4 masks
- Honor QrEasyOptions quiet zone for ASCII
- Wire formats into QR/Barcode/DataMatrix/Pdf417 APIs and builders
- Add renderer format tests for PDF/EPS/BMP/ASCII

## Testing
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0
