### PR TITLE
Add RenderMode and vector QR styling for PDF/EPS

### DIFF
--- a/CodeGlyphX.Examples/BarcodeExample.cs
+++ b/CodeGlyphX.Examples/BarcodeExample.cs
@@ -18,5 +18,7 @@ internal static class BarcodeExample {
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.svg"), options);
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.html"), options, title: "Code128");
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.jpg"), options);
+        Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.pdf"), options);
+        Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.eps"), options);
     }
 }

--- a/CodeGlyphX.Examples/DataMatrixExample.cs
+++ b/CodeGlyphX.Examples/DataMatrixExample.cs
@@ -7,8 +7,12 @@ internal static class DataMatrixExample {
     public static void Run(string outputDir) {
         var pngPath = Path.Combine(outputDir, "datamatrix.png");
         var svgPath = Path.Combine(outputDir, "datamatrix.svg");
+        var pdfPath = Path.Combine(outputDir, "datamatrix.pdf");
+        var epsPath = Path.Combine(outputDir, "datamatrix.eps");
 
         DataMatrixCode.Save("DataMatrix-HELLO", pngPath);
         DataMatrixCode.Save("DataMatrix-HELLO", svgPath);
+        DataMatrixCode.Save("DataMatrix-HELLO", pdfPath);
+        DataMatrixCode.Save("DataMatrix-HELLO", epsPath);
     }
 }

--- a/CodeGlyphX.Examples/Pdf417Example.cs
+++ b/CodeGlyphX.Examples/Pdf417Example.cs
@@ -7,8 +7,12 @@ internal static class Pdf417Example {
     public static void Run(string outputDir) {
         var pngPath = Path.Combine(outputDir, "pdf417.png");
         var svgPath = Path.Combine(outputDir, "pdf417.svg");
+        var pdfPath = Path.Combine(outputDir, "pdf417.pdf");
+        var epsPath = Path.Combine(outputDir, "pdf417.eps");
 
         Pdf417Code.Save("PDF417-HELLO", pngPath);
         Pdf417Code.Save("PDF417-HELLO", svgPath);
+        Pdf417Code.Save("PDF417-HELLO", pdfPath);
+        Pdf417Code.Save("PDF417-HELLO", epsPath);
     }
 }

--- a/CodeGlyphX.Examples/QrFancyExample.cs
+++ b/CodeGlyphX.Examples/QrFancyExample.cs
@@ -24,5 +24,7 @@ internal static class QrFancyExample {
         };
 
         QR.Save(payload, Path.Combine(outputDir, "qr-fancy.png"), options);
+        QR.SavePdf(payload, Path.Combine(outputDir, "qr-fancy.pdf"), options, RenderMode.Raster);
+        QR.SaveEps(payload, Path.Combine(outputDir, "qr-fancy.eps"), options, RenderMode.Raster);
     }
 }

--- a/CodeGlyphX.Examples/QrGenerationExample.cs
+++ b/CodeGlyphX.Examples/QrGenerationExample.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using CodeGlyphX;
+using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX.Examples;
 
@@ -10,5 +11,8 @@ internal static class QrGenerationExample {
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.svg"));
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.html"), title: "CodeGlyphX QR");
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.jpg"));
+        QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic.pdf"));
+        QR.SaveEps(payload, Path.Combine(outputDir, "qr-basic.eps"));
+        QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic-raster.pdf"), renderMode: RenderMode.Raster);
     }
 }

--- a/CodeGlyphX.Examples/QrGenerationExample.cs
+++ b/CodeGlyphX.Examples/QrGenerationExample.cs
@@ -13,6 +13,6 @@ internal static class QrGenerationExample {
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.jpg"));
         QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic.pdf"));
         QR.SaveEps(payload, Path.Combine(outputDir, "qr-basic.eps"));
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic-raster.pdf"), renderMode: RenderMode.Raster);
+        QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic-raster.pdf"), mode: RenderMode.Raster);
     }
 }

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -79,6 +79,10 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as PDF.
     /// </summary>
+    /// <param name="type">The barcode type.</param>
+    /// <param name="content">The barcode content.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] Pdf(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -88,6 +92,10 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as EPS.
     /// </summary>
+    /// <param name="type">The barcode type.</param>
+    /// <param name="content">The barcode content.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string Eps(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -195,6 +203,11 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as PDF and writes it to a file.
     /// </summary>
+    /// <param name="type">The barcode type.</param>
+    /// <param name="content">The barcode content.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string SavePdf(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var pdf = Pdf(type, content, options, mode);
         return pdf.WriteBinary(path);
@@ -203,6 +216,11 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as PDF and writes it to a stream.
     /// </summary>
+    /// <param name="type">The barcode type.</param>
+    /// <param name="content">The barcode content.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void SavePdf(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -212,6 +230,11 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as EPS and writes it to a file.
     /// </summary>
+    /// <param name="type">The barcode type.</param>
+    /// <param name="content">The barcode content.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string SaveEps(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = Eps(type, content, options, mode);
         return eps.WriteText(path);
@@ -220,6 +243,11 @@ public static class Barcode {
     /// <summary>
     /// Renders a barcode as EPS and writes it to a stream.
     /// </summary>
+    /// <param name="type">The barcode type.</param>
+    /// <param name="content">The barcode content.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void SaveEps(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = Eps(type, content, options, mode);
         eps.WriteText(stream);
@@ -552,11 +580,13 @@ public static class Barcode {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
+        /// <param name="mode">Vector or raster output.</param>
         public byte[] Pdf(RenderMode mode = RenderMode.Vector) => Barcode.Pdf(_type, _content, Options, mode);
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
+        /// <param name="mode">Vector or raster output.</param>
         public string Eps(RenderMode mode = RenderMode.Vector) => Barcode.Eps(_type, _content, Options, mode);
 
         /// <summary>
@@ -617,21 +647,29 @@ public static class Barcode {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public string SavePdf(string path, RenderMode mode = RenderMode.Vector) => Barcode.SavePdf(_type, _content, path, Options, mode);
 
         /// <summary>
         /// Saves PDF to a stream.
         /// </summary>
+    /// <param name="stream">Destination stream.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) => Barcode.SavePdf(_type, _content, stream, Options, mode);
 
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public string SaveEps(string path, RenderMode mode = RenderMode.Vector) => Barcode.SaveEps(_type, _content, path, Options, mode);
 
         /// <summary>
         /// Saves EPS to a stream.
         /// </summary>
+    /// <param name="stream">Destination stream.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) => Barcode.SaveEps(_type, _content, stream, Options, mode);
 
         /// <summary>

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -98,6 +98,10 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PDF from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static byte[] Pdf(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -106,6 +110,10 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as EPS from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string Eps(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -192,6 +200,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SavePdf(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, mode, options, renderMode);
         return pdf.WriteBinary(path);
@@ -200,6 +213,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix EPS to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SaveEps(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, mode, options, renderMode);
         return eps.WriteText(path);
@@ -226,6 +244,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -234,6 +257,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix EPS to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -340,6 +368,10 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PDF.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static byte[] Pdf(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -348,6 +380,10 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as EPS.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string Eps(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -382,6 +418,10 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PDF from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static byte[] Pdf(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -390,6 +430,10 @@ public static class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as EPS from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string Eps(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -530,6 +574,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a file.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SavePdf(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(text, mode, options, renderMode);
         return pdf.WriteBinary(path);
@@ -538,6 +587,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix EPS to a file.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SaveEps(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(text, mode, options, renderMode);
         return eps.WriteText(path);
@@ -562,6 +616,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SavePdf(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, mode, options, renderMode);
         return pdf.WriteBinary(path);
@@ -570,6 +629,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix EPS to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SaveEps(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, mode, options, renderMode);
         return eps.WriteText(path);
@@ -596,6 +660,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a stream.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SavePdf(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -604,6 +673,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix EPS to a stream.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SaveEps(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -630,6 +704,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PDF to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SavePdf(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -638,6 +717,11 @@ public static class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix EPS to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="mode">Vector or raster output.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SaveEps(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -917,6 +1001,7 @@ public static class DataMatrixCode {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
+        /// <param name="renderMode">Vector or raster output.</param>
         public byte[] Pdf(RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? DataMatrixCode.Pdf(_text, _mode, _options, renderMode) : DataMatrixCode.Pdf(_bytes!, _mode, _options, renderMode);
         }
@@ -924,6 +1009,7 @@ public static class DataMatrixCode {
         /// <summary>
         /// Renders EPS text.
         /// </summary>
+        /// <param name="renderMode">Vector or raster output.</param>
         public string Eps(RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? DataMatrixCode.Eps(_text, _mode, _options, renderMode) : DataMatrixCode.Eps(_bytes!, _mode, _options, renderMode);
         }
@@ -981,6 +1067,8 @@ public static class DataMatrixCode {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="renderMode">Vector or raster output.</param>
         public string SavePdf(string path, RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? DataMatrixCode.SavePdf(_text, path, _mode, _options, renderMode) : DataMatrixCode.SavePdf(_bytes!, path, _mode, _options, renderMode);
         }
@@ -988,6 +1076,8 @@ public static class DataMatrixCode {
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="renderMode">Vector or raster output.</param>
         public string SaveEps(string path, RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? DataMatrixCode.SaveEps(_text, path, _mode, _options, renderMode) : DataMatrixCode.SaveEps(_bytes!, path, _mode, _options, renderMode);
         }

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -99,6 +99,10 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PDF from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static byte[] Pdf(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -107,6 +111,10 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as EPS from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string Eps(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -193,6 +201,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SavePdf(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
@@ -201,6 +214,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 EPS to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SaveEps(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
@@ -227,6 +245,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -235,6 +258,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 EPS to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -341,6 +369,10 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PDF.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static byte[] Pdf(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -349,6 +381,10 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as EPS.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string Eps(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -383,6 +419,10 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PDF from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static byte[] Pdf(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -391,6 +431,10 @@ public static class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as EPS from bytes.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string Eps(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -531,6 +575,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a file.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SavePdf(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(text, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
@@ -539,6 +588,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 EPS to a file.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SaveEps(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(text, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
@@ -563,6 +617,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SavePdf(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
@@ -571,6 +630,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 EPS to a file for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static string SaveEps(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
@@ -597,6 +661,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a stream.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SavePdf(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -605,6 +674,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 EPS to a stream.
     /// </summary>
+    /// <param name="text">Input text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SaveEps(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -631,6 +705,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PDF to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SavePdf(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -639,6 +718,11 @@ public static class Pdf417Code {
     /// <summary>
     /// Saves PDF417 EPS to a stream for byte payloads.
     /// </summary>
+    /// <param name="data">Payload bytes.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="encodeOptions">Encoding options.</param>
+    /// <param name="renderOptions">Rendering options.</param>
+    /// <param name="renderMode">Vector or raster output.</param>
     public static void SaveEps(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -977,6 +1061,7 @@ public static class Pdf417Code {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
+        /// <param name="renderMode">Vector or raster output.</param>
         public byte[] Pdf(RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? Pdf417Code.Pdf(_text, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.Pdf(_bytes!, _encodeOptions, _renderOptions, renderMode);
         }
@@ -984,6 +1069,7 @@ public static class Pdf417Code {
         /// <summary>
         /// Renders EPS text.
         /// </summary>
+        /// <param name="renderMode">Vector or raster output.</param>
         public string Eps(RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? Pdf417Code.Eps(_text, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.Eps(_bytes!, _encodeOptions, _renderOptions, renderMode);
         }
@@ -1041,6 +1127,8 @@ public static class Pdf417Code {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="renderMode">Vector or raster output.</param>
         public string SavePdf(string path, RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? Pdf417Code.SavePdf(_text, path, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.SavePdf(_bytes!, path, _encodeOptions, _renderOptions, renderMode);
         }
@@ -1048,6 +1136,8 @@ public static class Pdf417Code {
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="renderMode">Vector or raster output.</param>
         public string SaveEps(string path, RenderMode renderMode = RenderMode.Vector) {
             return _text is not null ? Pdf417Code.SaveEps(_text, path, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.SaveEps(_bytes!, path, _encodeOptions, _renderOptions, renderMode);
         }

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -131,11 +131,18 @@ public static class QR {
     /// <summary>
     /// Renders a QR code as PDF.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] Pdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderPdf(payload, options, mode);
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PDF.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="detectOptions">Payload detection options.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] PdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         return QrEasy.RenderPdfAuto(payload, detectOptions, options, mode);
     }
@@ -143,16 +150,26 @@ public static class QR {
     /// <summary>
     /// Renders a QR code as PDF for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] Pdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderPdf(payload, options, mode);
 
     /// <summary>
     /// Renders a QR code as EPS.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string Eps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderEps(payload, options, mode);
 
     /// <summary>
     /// Detects a payload type and renders a QR code as EPS.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="detectOptions">Payload detection options.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string EpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         return QrEasy.RenderEpsAuto(payload, detectOptions, options, mode);
     }
@@ -160,6 +177,9 @@ public static class QR {
     /// <summary>
     /// Renders a QR code as EPS for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string Eps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderEps(payload, options, mode);
 
     /// <summary>
@@ -334,6 +354,10 @@ public static class QR {
     /// <summary>
     /// Saves a PDF QR to a file.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string SavePdf(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         return Pdf(payload, options, mode).WriteBinary(path);
     }
@@ -341,6 +365,10 @@ public static class QR {
     /// <summary>
     /// Saves a PDF QR to a file for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string SavePdf(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         return Pdf(payload, options, mode).WriteBinary(path);
     }
@@ -348,6 +376,10 @@ public static class QR {
     /// <summary>
     /// Saves a PDF QR to a stream.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void SavePdf(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         QrEasy.RenderPdfToStream(payload, stream, options, mode);
     }
@@ -355,6 +387,10 @@ public static class QR {
     /// <summary>
     /// Saves a PDF QR to a stream for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void SavePdf(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         QrEasy.RenderPdfToStream(payload, stream, options, mode);
     }
@@ -362,6 +398,10 @@ public static class QR {
     /// <summary>
     /// Saves an EPS QR to a file.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string SaveEps(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         return Eps(payload, options, mode).WriteText(path);
     }
@@ -369,6 +409,10 @@ public static class QR {
     /// <summary>
     /// Saves an EPS QR to a file for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string SaveEps(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         return Eps(payload, options, mode).WriteText(path);
     }
@@ -376,6 +420,10 @@ public static class QR {
     /// <summary>
     /// Saves an EPS QR to a stream.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void SaveEps(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         QrEasy.RenderEpsToStream(payload, stream, options, mode);
     }
@@ -383,6 +431,10 @@ public static class QR {
     /// <summary>
     /// Saves an EPS QR to a stream for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void SaveEps(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         QrEasy.RenderEpsToStream(payload, stream, options, mode);
     }
@@ -634,11 +686,13 @@ public static class QR {
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
+        /// <param name="mode">Vector or raster output.</param>
         public byte[] Pdf(RenderMode mode = RenderMode.Vector) => _payloadData is null ? QrEasy.RenderPdf(_payload, Options, mode) : QrEasy.RenderPdf(_payloadData, Options, mode);
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
+        /// <param name="mode">Vector or raster output.</param>
         public string Eps(RenderMode mode = RenderMode.Vector) => _payloadData is null ? QrEasy.RenderEps(_payload, Options, mode) : QrEasy.RenderEps(_payloadData, Options, mode);
 
         /// <summary>
@@ -724,11 +778,15 @@ public static class QR {
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public string SavePdf(string path, RenderMode mode = RenderMode.Vector) => _payloadData is null ? QR.SavePdf(_payload, path, Options, mode) : QR.SavePdf(_payloadData, path, Options, mode);
 
         /// <summary>
         /// Saves PDF to a stream.
         /// </summary>
+    /// <param name="stream">Destination stream.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) {
             if (_payloadData is null) {
                 QR.SavePdf(_payload, stream, Options, mode);
@@ -740,11 +798,15 @@ public static class QR {
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
+    /// <param name="path">Output file path.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public string SaveEps(string path, RenderMode mode = RenderMode.Vector) => _payloadData is null ? QR.SaveEps(_payload, path, Options, mode) : QR.SaveEps(_payloadData, path, Options, mode);
 
         /// <summary>
         /// Saves EPS to a stream.
         /// </summary>
+    /// <param name="stream">Destination stream.</param>
+        /// <param name="mode">Vector or raster output.</param>
         public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) {
             if (_payloadData is null) {
                 QR.SaveEps(_payload, stream, Options, mode);

--- a/CodeGlyphX/QrEasy.cs
+++ b/CodeGlyphX/QrEasy.cs
@@ -445,6 +445,9 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] RenderPdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
@@ -455,6 +458,10 @@ public static class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as PDF.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="detectOptions">Payload detection options.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] RenderPdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -464,6 +471,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF to a stream.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void RenderPdfToStream(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
@@ -474,6 +485,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF and writes it to a file.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderPdfToFile(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var pdf = RenderPdf(payload, options, mode);
         return RenderIO.WriteBinary(path, pdf);
@@ -482,6 +497,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderPdfToFile(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var pdf = RenderPdf(payload, options, mode);
         return RenderIO.WriteBinary(path, pdf);
@@ -490,6 +509,9 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static byte[] RenderPdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -501,6 +523,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as PDF to a stream for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void RenderPdfToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -512,6 +538,9 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as EPS.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderEps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
@@ -522,6 +551,10 @@ public static class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as EPS.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="detectOptions">Payload detection options.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderEpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -531,6 +564,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as EPS to a stream.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void RenderEpsToStream(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options ?? new QrEasyOptions();
         var qr = Encode(payload, opts);
@@ -541,6 +578,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as EPS and writes it to a file.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderEpsToFile(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = RenderEps(payload, options, mode);
         return RenderIO.WriteText(path, eps);
@@ -549,6 +590,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as EPS and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderEpsToFile(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = RenderEps(payload, options, mode);
         return RenderIO.WriteText(path, eps);
@@ -557,6 +602,9 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as EPS for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static string RenderEps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -568,6 +616,10 @@ public static class QrEasy {
     /// <summary>
     /// Renders a QR code as EPS to a stream for a payload with embedded defaults.
     /// </summary>
+    /// <param name="payload">The payload text.</param>
+    /// <param name="stream">Destination stream.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <param name="mode">Vector or raster output.</param>
     public static void RenderEpsToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);

--- a/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
@@ -15,7 +15,7 @@ public static class QrEpsRenderer {
     /// Renders the QR module matrix to an EPS string.
     /// </summary>
     public static string Render(BitMatrix modules, QrPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster) {
+        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             return Encoding.ASCII.GetString(EpsWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background));
         }
@@ -26,7 +26,7 @@ public static class QrEpsRenderer {
     /// Renders the QR module matrix to an EPS stream.
     /// </summary>
     public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster) {
+        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             EpsWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
             return;
@@ -57,6 +57,8 @@ public static class QrEpsRenderer {
         if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
         if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
         if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+        if (opts.ModuleScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleScale));
+        opts.Eyes?.Validate();
 
         var size = modules.Width;
         var outModules = size + opts.QuietZone * 2;
@@ -65,6 +67,8 @@ public static class QrEpsRenderer {
 
         var bg = Flatten(opts.Background, Rgba32.White);
         var fg = Flatten(opts.Foreground, bg);
+        var current = default(Rgba32);
+        var hasCurrent = false;
 
         var sb = new StringBuilder(outModules * outModules * 3);
         sb.AppendLine("%!PS-Adobe-3.0 EPSF-3.0");
@@ -73,17 +77,49 @@ public static class QrEpsRenderer {
         sb.AppendLine("%%Pages: 1");
         sb.AppendLine("%%EndComments");
         sb.AppendLine("gsave");
-        AppendColor(sb, bg);
+        AppendColor(sb, bg, ref current, ref hasCurrent);
         AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
-        AppendColor(sb, fg);
+        AppendColor(sb, fg, ref current, ref hasCurrent);
+
+        var moduleShape = opts.ModuleShape;
+        var moduleScale = opts.ModuleScale;
+        var moduleRadius = opts.ModuleCornerRadiusPx;
+        var eye = opts.Eyes;
+        var useFrame = eye is not null && eye.UseFrame;
 
         for (var my = 0; my < size; my++) {
             for (var mx = 0; mx < size; mx++) {
                 if (!modules[mx, my]) continue;
-                var x = (mx + opts.QuietZone) * opts.ModuleSize;
-                var y = (my + opts.QuietZone) * opts.ModuleSize;
-                AppendRectTopLeft(sb, x, y, opts.ModuleSize, opts.ModuleSize, heightPx);
+                if (useFrame && IsInEye(mx, my, size)) continue;
+
+                var shape = moduleShape;
+                var scale = moduleScale;
+                var radius = moduleRadius;
+                var color = fg;
+
+                if (eye is not null && TryGetEyeKind(mx, my, size, out var kind)) {
+                    if (kind == EyeKind.Outer) {
+                        shape = eye.OuterShape;
+                        scale = eye.OuterScale;
+                        radius = eye.OuterCornerRadiusPx;
+                        color = Flatten(eye.OuterColor ?? opts.Foreground, bg);
+                    } else if (kind == EyeKind.Inner) {
+                        shape = eye.InnerShape;
+                        scale = eye.InnerScale;
+                        radius = eye.InnerCornerRadiusPx;
+                        color = Flatten(eye.InnerColor ?? opts.Foreground, bg);
+                    }
+                }
+
+                AppendColor(sb, color, ref current, ref hasCurrent);
+                DrawModule(sb, mx, my, opts.ModuleSize, opts.QuietZone, heightPx, shape, scale, radius);
             }
+        }
+
+        if (useFrame) {
+            DrawEyeFrame(sb, opts, 0, 0, size, heightPx, bg, ref current, ref hasCurrent);
+            DrawEyeFrame(sb, opts, size - 7, 0, size, heightPx, bg, ref current, ref hasCurrent);
+            DrawEyeFrame(sb, opts, 0, size - 7, size, heightPx, bg, ref current, ref hasCurrent);
         }
 
         sb.AppendLine("grestore");
@@ -92,7 +128,10 @@ public static class QrEpsRenderer {
         return sb.ToString();
     }
 
-    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+    private static void AppendColor(StringBuilder sb, Rgba32 color, ref Rgba32 current, ref bool hasCurrent) {
+        if (hasCurrent && current.R == color.R && current.G == color.G && current.B == color.B) return;
+        current = color;
+        hasCurrent = true;
         sb.Append(ToComponent(color.R)).Append(' ')
             .Append(ToComponent(color.G)).Append(' ')
             .Append(ToComponent(color.B)).AppendLine(" setrgbcolor");
@@ -109,6 +148,171 @@ public static class QrEpsRenderer {
             .Append(y).Append(' ')
             .Append(width).Append(' ')
             .Append(height).AppendLine(" rectfill");
+    }
+
+    private static void AppendRoundedRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int radius, int totalHeight) {
+        if (radius <= 0) {
+            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
+            return;
+        }
+        var r = Math.Min(radius, Math.Min(width, height) / 2);
+        if (r <= 0) {
+            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
+            return;
+        }
+
+        var y = totalHeight - yTop - height;
+        var x0 = x;
+        var y0 = y;
+        var x1 = x + width;
+        var y1 = y + height;
+        var c = r * 0.5522847498307936;
+
+        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" moveto");
+        sb.Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" lineto");
+        sb.Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r)).AppendLine(" curveto");
+        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r)).AppendLine(" lineto");
+        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+            .Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+            .Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y1)).AppendLine(" curveto");
+        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y1)).AppendLine(" lineto");
+        sb.Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r)).AppendLine(" curveto");
+        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r)).AppendLine(" lineto");
+        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+            .Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+            .Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" curveto");
+        sb.AppendLine("closepath fill");
+    }
+
+    private static void DrawModule(StringBuilder sb, int mx, int my, int moduleSize, int quietZone, int totalHeight, QrPngModuleShape shape, double scale, int radius) {
+        var scaled = Math.Max(1, (int)Math.Round(moduleSize * scale));
+        var offset = (moduleSize - scaled) / 2;
+        var x = (mx + quietZone) * moduleSize + offset;
+        var y = (my + quietZone) * moduleSize + offset;
+        switch (shape) {
+            case QrPngModuleShape.Circle:
+                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, scaled / 2, totalHeight);
+                break;
+            case QrPngModuleShape.Rounded:
+                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, radius, totalHeight);
+                break;
+            default:
+                AppendRectTopLeft(sb, x, y, scaled, scaled, totalHeight);
+                break;
+        }
+    }
+
+    private static void DrawEyeFrame(
+        StringBuilder sb,
+        QrPngRenderOptions opts,
+        int ex,
+        int ey,
+        int size,
+        int totalHeight,
+        Rgba32 background,
+        ref Rgba32 current,
+        ref bool hasCurrent) {
+        var moduleSize = opts.ModuleSize;
+        var x0 = (ex + opts.QuietZone) * moduleSize;
+        var y0 = (ey + opts.QuietZone) * moduleSize;
+
+        var outerSize = 7 * moduleSize;
+        var innerSize = 5 * moduleSize;
+        var dotSize = 3 * moduleSize;
+
+        var eye = opts.Eyes!;
+        var outerScaled = ScaleSize(outerSize, eye.OuterScale);
+        var innerScaled = ScaleSize(innerSize, eye.OuterScale);
+        var dotScaled = ScaleSize(dotSize, eye.InnerScale);
+
+        var outerX = x0 + (outerSize - outerScaled) / 2;
+        var outerY = y0 + (outerSize - outerScaled) / 2;
+        var innerX = x0 + (outerSize - innerScaled) / 2;
+        var innerY = y0 + (outerSize - innerScaled) / 2;
+        var dotX = x0 + (outerSize - dotScaled) / 2;
+        var dotY = y0 + (outerSize - dotScaled) / 2;
+
+        var outerColor = Flatten(eye.OuterColor ?? opts.Foreground, background);
+        var innerColor = Flatten(eye.InnerColor ?? opts.Foreground, background);
+
+        AppendColor(sb, outerColor, ref current, ref hasCurrent);
+        DrawShape(sb, outerX, outerY, outerScaled, outerScaled, eye.OuterShape, eye.OuterCornerRadiusPx, totalHeight);
+        AppendColor(sb, background, ref current, ref hasCurrent);
+        DrawShape(sb, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Square, eye.InnerCornerRadiusPx, totalHeight);
+
+        if (dotScaled > 0) {
+            AppendColor(sb, innerColor, ref current, ref hasCurrent);
+            DrawShape(sb, dotX, dotY, dotScaled, dotScaled, eye.InnerShape, eye.InnerCornerRadiusPx, totalHeight);
+        }
+    }
+
+    private static void DrawShape(StringBuilder sb, int x, int y, int width, int height, QrPngModuleShape shape, int radius, int totalHeight) {
+        switch (shape) {
+            case QrPngModuleShape.Circle:
+                AppendRoundedRectTopLeft(sb, x, y, width, height, Math.Min(width, height) / 2, totalHeight);
+                break;
+            case QrPngModuleShape.Rounded:
+                AppendRoundedRectTopLeft(sb, x, y, width, height, radius, totalHeight);
+                break;
+            default:
+                AppendRectTopLeft(sb, x, y, width, height, totalHeight);
+                break;
+        }
+    }
+
+    private static int ScaleSize(int size, double scale) {
+        if (scale < 0.1) scale = 0.1;
+        if (scale > 1.0) scale = 1.0;
+        return Math.Max(1, (int)Math.Round(size * scale));
+    }
+
+    private static bool IsInEye(int x, int y, int size) {
+        return (x < 7 && y < 7) || (x >= size - 7 && y < 7) || (x < 7 && y >= size - 7);
+    }
+
+    private static bool TryGetEyeKind(int x, int y, int size, out EyeKind kind) {
+        if (x < 7 && y < 7) {
+            kind = GetEyeModuleKind(x, y, 0, 0);
+            return true;
+        }
+        if (x >= size - 7 && y < 7) {
+            kind = GetEyeModuleKind(x, y, size - 7, 0);
+            return true;
+        }
+        if (x < 7 && y >= size - 7) {
+            kind = GetEyeModuleKind(x, y, 0, size - 7);
+            return true;
+        }
+        kind = EyeKind.None;
+        return false;
+    }
+
+    private static EyeKind GetEyeModuleKind(int x, int y, int ex, int ey) {
+        var lx = x - ex;
+        var ly = y - ey;
+        if (lx >= 2 && lx <= 4 && ly >= 2 && ly <= 4) return EyeKind.Inner;
+        return EyeKind.Outer;
+    }
+
+    private static bool ShouldRaster(QrPngRenderOptions opts) {
+        if (opts.ForegroundGradient is not null) return true;
+        if (opts.Logo is not null) return true;
+        if (opts.Eyes is not null && (opts.Eyes.OuterGradient is not null || opts.Eyes.InnerGradient is not null)) return true;
+        return false;
+    }
+
+    private static string FormatNumber(double value) {
+        return value.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private enum EyeKind {
+        None,
+        Outer,
+        Inner
     }
 
     private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {

--- a/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
+++ b/CodeGlyphX/Rendering/Eps/QrEpsRenderer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Vector;
 
 namespace CodeGlyphX.Rendering.Eps;
 
@@ -15,7 +16,7 @@ public static class QrEpsRenderer {
     /// Renders the QR module matrix to an EPS string.
     /// </summary>
     public static string Render(BitMatrix modules, QrPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
+        if (mode == RenderMode.Raster || QrVectorLayout.ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             return Encoding.ASCII.GetString(EpsWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background));
         }
@@ -26,7 +27,7 @@ public static class QrEpsRenderer {
     /// Renders the QR module matrix to an EPS stream.
     /// </summary>
     public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
+        if (mode == RenderMode.Raster || QrVectorLayout.ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             EpsWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
             return;
@@ -52,24 +53,8 @@ public static class QrEpsRenderer {
     }
 
     private static string BuildEps(BitMatrix modules, QrPngRenderOptions opts) {
-        if (modules is null) throw new ArgumentNullException(nameof(modules));
-        if (opts is null) throw new ArgumentNullException(nameof(opts));
-        if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
-        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
-        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
-        if (opts.ModuleScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleScale));
-        opts.Eyes?.Validate();
-
-        var size = modules.Width;
-        var outModules = size + opts.QuietZone * 2;
-        var widthPx = outModules * opts.ModuleSize;
-        var heightPx = widthPx;
-
-        var bg = Flatten(opts.Background, Rgba32.White);
-        var fg = Flatten(opts.Foreground, bg);
-        var current = default(Rgba32);
-        var hasCurrent = false;
-
+        QrVectorLayout.GetSize(modules, opts, out var widthPx, out var heightPx);
+        var outModules = modules.Width + opts.QuietZone * 2;
         var sb = new StringBuilder(outModules * outModules * 3);
         sb.AppendLine("%!PS-Adobe-3.0 EPSF-3.0");
         sb.AppendLine($"%%BoundingBox: 0 0 {widthPx} {heightPx}");
@@ -77,50 +62,8 @@ public static class QrEpsRenderer {
         sb.AppendLine("%%Pages: 1");
         sb.AppendLine("%%EndComments");
         sb.AppendLine("gsave");
-        AppendColor(sb, bg, ref current, ref hasCurrent);
-        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
-        AppendColor(sb, fg, ref current, ref hasCurrent);
-
-        var moduleShape = opts.ModuleShape;
-        var moduleScale = opts.ModuleScale;
-        var moduleRadius = opts.ModuleCornerRadiusPx;
-        var eye = opts.Eyes;
-        var useFrame = eye is not null && eye.UseFrame;
-
-        for (var my = 0; my < size; my++) {
-            for (var mx = 0; mx < size; mx++) {
-                if (!modules[mx, my]) continue;
-                if (useFrame && IsInEye(mx, my, size)) continue;
-
-                var shape = moduleShape;
-                var scale = moduleScale;
-                var radius = moduleRadius;
-                var color = fg;
-
-                if (eye is not null && TryGetEyeKind(mx, my, size, out var kind)) {
-                    if (kind == EyeKind.Outer) {
-                        shape = eye.OuterShape;
-                        scale = eye.OuterScale;
-                        radius = eye.OuterCornerRadiusPx;
-                        color = Flatten(eye.OuterColor ?? opts.Foreground, bg);
-                    } else if (kind == EyeKind.Inner) {
-                        shape = eye.InnerShape;
-                        scale = eye.InnerScale;
-                        radius = eye.InnerCornerRadiusPx;
-                        color = Flatten(eye.InnerColor ?? opts.Foreground, bg);
-                    }
-                }
-
-                AppendColor(sb, color, ref current, ref hasCurrent);
-                DrawModule(sb, mx, my, opts.ModuleSize, opts.QuietZone, heightPx, shape, scale, radius);
-            }
-        }
-
-        if (useFrame) {
-            DrawEyeFrame(sb, opts, 0, 0, size, heightPx, bg, ref current, ref hasCurrent);
-            DrawEyeFrame(sb, opts, size - 7, 0, size, heightPx, bg, ref current, ref hasCurrent);
-            DrawEyeFrame(sb, opts, 0, size - 7, size, heightPx, bg, ref current, ref hasCurrent);
-        }
+        var sink = new EpsSink(sb, heightPx);
+        QrVectorLayout.Render(modules, opts, sink, out _, out _);
 
         sb.AppendLine("grestore");
         sb.AppendLine("showpage");
@@ -128,200 +71,79 @@ public static class QrEpsRenderer {
         return sb.ToString();
     }
 
-    private static void AppendColor(StringBuilder sb, Rgba32 color, ref Rgba32 current, ref bool hasCurrent) {
-        if (hasCurrent && current.R == color.R && current.G == color.G && current.B == color.B) return;
-        current = color;
-        hasCurrent = true;
-        sb.Append(ToComponent(color.R)).Append(' ')
-            .Append(ToComponent(color.G)).Append(' ')
-            .Append(ToComponent(color.B)).AppendLine(" setrgbcolor");
-    }
+    private sealed class EpsSink : IQrVectorSink {
+        private readonly StringBuilder _sb;
+        private readonly int _height;
+        private Rgba32 _current;
+        private bool _hasCurrent;
 
-    private static string ToComponent(byte value) {
-        var scaled = value / 255.0;
-        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
-    }
-
-    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
-        var y = totalHeight - yTop - height;
-        sb.Append(x).Append(' ')
-            .Append(y).Append(' ')
-            .Append(width).Append(' ')
-            .Append(height).AppendLine(" rectfill");
-    }
-
-    private static void AppendRoundedRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int radius, int totalHeight) {
-        if (radius <= 0) {
-            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
-            return;
-        }
-        var r = Math.Min(radius, Math.Min(width, height) / 2);
-        if (r <= 0) {
-            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
-            return;
+        public EpsSink(StringBuilder sb, int height) {
+            _sb = sb ?? throw new ArgumentNullException(nameof(sb));
+            _height = height;
         }
 
-        var y = totalHeight - yTop - height;
-        var x0 = x;
-        var y0 = y;
-        var x1 = x + width;
-        var y1 = y + height;
-        var c = r * 0.5522847498307936;
-
-        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" moveto");
-        sb.Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" lineto");
-        sb.Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
-            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
-            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r)).AppendLine(" curveto");
-        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r)).AppendLine(" lineto");
-        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
-            .Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
-            .Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y1)).AppendLine(" curveto");
-        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y1)).AppendLine(" lineto");
-        sb.Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
-            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
-            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r)).AppendLine(" curveto");
-        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r)).AppendLine(" lineto");
-        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
-            .Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
-            .Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" curveto");
-        sb.AppendLine("closepath fill");
-    }
-
-    private static void DrawModule(StringBuilder sb, int mx, int my, int moduleSize, int quietZone, int totalHeight, QrPngModuleShape shape, double scale, int radius) {
-        var scaled = Math.Max(1, (int)Math.Round(moduleSize * scale));
-        var offset = (moduleSize - scaled) / 2;
-        var x = (mx + quietZone) * moduleSize + offset;
-        var y = (my + quietZone) * moduleSize + offset;
-        switch (shape) {
-            case QrPngModuleShape.Circle:
-                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, scaled / 2, totalHeight);
-                break;
-            case QrPngModuleShape.Rounded:
-                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, radius, totalHeight);
-                break;
-            default:
-                AppendRectTopLeft(sb, x, y, scaled, scaled, totalHeight);
-                break;
+        public void SetFillColor(Rgba32 color) {
+            if (_hasCurrent && _current.R == color.R && _current.G == color.G && _current.B == color.B) return;
+            _current = color;
+            _hasCurrent = true;
+            _sb.Append(ToComponent(color.R)).Append(' ')
+                .Append(ToComponent(color.G)).Append(' ')
+                .Append(ToComponent(color.B)).AppendLine(" setrgbcolor");
         }
-    }
 
-    private static void DrawEyeFrame(
-        StringBuilder sb,
-        QrPngRenderOptions opts,
-        int ex,
-        int ey,
-        int size,
-        int totalHeight,
-        Rgba32 background,
-        ref Rgba32 current,
-        ref bool hasCurrent) {
-        var moduleSize = opts.ModuleSize;
-        var x0 = (ex + opts.QuietZone) * moduleSize;
-        var y0 = (ey + opts.QuietZone) * moduleSize;
-
-        var outerSize = 7 * moduleSize;
-        var innerSize = 5 * moduleSize;
-        var dotSize = 3 * moduleSize;
-
-        var eye = opts.Eyes!;
-        var outerScaled = ScaleSize(outerSize, eye.OuterScale);
-        var innerScaled = ScaleSize(innerSize, eye.OuterScale);
-        var dotScaled = ScaleSize(dotSize, eye.InnerScale);
-
-        var outerX = x0 + (outerSize - outerScaled) / 2;
-        var outerY = y0 + (outerSize - outerScaled) / 2;
-        var innerX = x0 + (outerSize - innerScaled) / 2;
-        var innerY = y0 + (outerSize - innerScaled) / 2;
-        var dotX = x0 + (outerSize - dotScaled) / 2;
-        var dotY = y0 + (outerSize - dotScaled) / 2;
-
-        var outerColor = Flatten(eye.OuterColor ?? opts.Foreground, background);
-        var innerColor = Flatten(eye.InnerColor ?? opts.Foreground, background);
-
-        AppendColor(sb, outerColor, ref current, ref hasCurrent);
-        DrawShape(sb, outerX, outerY, outerScaled, outerScaled, eye.OuterShape, eye.OuterCornerRadiusPx, totalHeight);
-        AppendColor(sb, background, ref current, ref hasCurrent);
-        DrawShape(sb, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Square, eye.InnerCornerRadiusPx, totalHeight);
-
-        if (dotScaled > 0) {
-            AppendColor(sb, innerColor, ref current, ref hasCurrent);
-            DrawShape(sb, dotX, dotY, dotScaled, dotScaled, eye.InnerShape, eye.InnerCornerRadiusPx, totalHeight);
+        public void FillRect(int x, int yTop, int width, int height) {
+            var y = _height - yTop - height;
+            _sb.Append(x).Append(' ')
+                .Append(y).Append(' ')
+                .Append(width).Append(' ')
+                .Append(height).AppendLine(" rectfill");
         }
-    }
 
-    private static void DrawShape(StringBuilder sb, int x, int y, int width, int height, QrPngModuleShape shape, int radius, int totalHeight) {
-        switch (shape) {
-            case QrPngModuleShape.Circle:
-                AppendRoundedRectTopLeft(sb, x, y, width, height, Math.Min(width, height) / 2, totalHeight);
-                break;
-            case QrPngModuleShape.Rounded:
-                AppendRoundedRectTopLeft(sb, x, y, width, height, radius, totalHeight);
-                break;
-            default:
-                AppendRectTopLeft(sb, x, y, width, height, totalHeight);
-                break;
+        public void FillRoundedRect(int x, int yTop, int width, int height, int radius) {
+            if (radius <= 0) {
+                FillRect(x, yTop, width, height);
+                return;
+            }
+            var r = Math.Min(radius, Math.Min(width, height) / 2);
+            if (r <= 0) {
+                FillRect(x, yTop, width, height);
+                return;
+            }
+
+            var y = _height - yTop - height;
+            var x0 = x;
+            var y0 = y;
+            var x1 = x + width;
+            var y1 = y + height;
+            var c = r * 0.5522847498307936;
+
+            _sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" moveto");
+            _sb.Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" lineto");
+            _sb.Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+                .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+                .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r)).AppendLine(" curveto");
+            _sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r)).AppendLine(" lineto");
+            _sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+                .Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+                .Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y1)).AppendLine(" curveto");
+            _sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y1)).AppendLine(" lineto");
+            _sb.Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+                .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+                .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r)).AppendLine(" curveto");
+            _sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r)).AppendLine(" lineto");
+            _sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+                .Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+                .Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).AppendLine(" curveto");
+            _sb.AppendLine("closepath fill");
         }
-    }
 
-    private static int ScaleSize(int size, double scale) {
-        if (scale < 0.1) scale = 0.1;
-        if (scale > 1.0) scale = 1.0;
-        return Math.Max(1, (int)Math.Round(size * scale));
-    }
-
-    private static bool IsInEye(int x, int y, int size) {
-        return (x < 7 && y < 7) || (x >= size - 7 && y < 7) || (x < 7 && y >= size - 7);
-    }
-
-    private static bool TryGetEyeKind(int x, int y, int size, out EyeKind kind) {
-        if (x < 7 && y < 7) {
-            kind = GetEyeModuleKind(x, y, 0, 0);
-            return true;
+        private static string ToComponent(byte value) {
+            var scaled = value / 255.0;
+            return scaled.ToString("0.###", CultureInfo.InvariantCulture);
         }
-        if (x >= size - 7 && y < 7) {
-            kind = GetEyeModuleKind(x, y, size - 7, 0);
-            return true;
+
+        private static string FormatNumber(double value) {
+            return value.ToString("0.###", CultureInfo.InvariantCulture);
         }
-        if (x < 7 && y >= size - 7) {
-            kind = GetEyeModuleKind(x, y, 0, size - 7);
-            return true;
-        }
-        kind = EyeKind.None;
-        return false;
-    }
-
-    private static EyeKind GetEyeModuleKind(int x, int y, int ex, int ey) {
-        var lx = x - ex;
-        var ly = y - ey;
-        if (lx >= 2 && lx <= 4 && ly >= 2 && ly <= 4) return EyeKind.Inner;
-        return EyeKind.Outer;
-    }
-
-    private static bool ShouldRaster(QrPngRenderOptions opts) {
-        if (opts.ForegroundGradient is not null) return true;
-        if (opts.Logo is not null) return true;
-        if (opts.Eyes is not null && (opts.Eyes.OuterGradient is not null || opts.Eyes.InnerGradient is not null)) return true;
-        return false;
-    }
-
-    private static string FormatNumber(double value) {
-        return value.ToString("0.###", CultureInfo.InvariantCulture);
-    }
-
-    private enum EyeKind {
-        None,
-        Outer,
-        Inner
-    }
-
-    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
-        if (color.A == 255) return color;
-        var inv = 255 - color.A;
-        return new Rgba32(
-            (byte)((color.R * color.A + background.R * inv + 127) / 255),
-            (byte)((color.G * color.A + background.G * inv + 127) / 255),
-            (byte)((color.B * color.A + background.B * inv + 127) / 255),
-            255);
     }
 }

--- a/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
@@ -15,7 +15,7 @@ public static class QrPdfRenderer {
     /// Renders the QR module matrix to a PDF byte array.
     /// </summary>
     public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster) {
+        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             return PdfWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background);
         }
@@ -27,7 +27,7 @@ public static class QrPdfRenderer {
     /// Renders the QR module matrix to a PDF stream.
     /// </summary>
     public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster) {
+        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             PdfWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
             return;
@@ -58,6 +58,8 @@ public static class QrPdfRenderer {
         if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
         if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
         if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+        if (opts.ModuleScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleScale));
+        opts.Eyes?.Validate();
 
         var size = modules.Width;
         var outModules = size + opts.QuietZone * 2;
@@ -66,25 +68,62 @@ public static class QrPdfRenderer {
 
         var bg = Flatten(opts.Background, Rgba32.White);
         var fg = Flatten(opts.Foreground, bg);
+        var current = default(Rgba32);
+        var hasCurrent = false;
 
         var sb = new StringBuilder(outModules * outModules * 4);
-        AppendColor(sb, bg);
+        AppendColor(sb, bg, ref current, ref hasCurrent);
         AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
-        AppendColor(sb, fg);
+        AppendColor(sb, fg, ref current, ref hasCurrent);
+
+        var moduleShape = opts.ModuleShape;
+        var moduleScale = opts.ModuleScale;
+        var moduleRadius = opts.ModuleCornerRadiusPx;
+        var eye = opts.Eyes;
+        var useFrame = eye is not null && eye.UseFrame;
 
         for (var my = 0; my < size; my++) {
             for (var mx = 0; mx < size; mx++) {
                 if (!modules[mx, my]) continue;
-                var x = (mx + opts.QuietZone) * opts.ModuleSize;
-                var y = (my + opts.QuietZone) * opts.ModuleSize;
-                AppendRectTopLeft(sb, x, y, opts.ModuleSize, opts.ModuleSize, heightPx);
+                if (useFrame && IsInEye(mx, my, size)) continue;
+
+                var shape = moduleShape;
+                var scale = moduleScale;
+                var radius = moduleRadius;
+                var color = fg;
+
+                if (eye is not null && TryGetEyeKind(mx, my, size, out var kind)) {
+                    if (kind == EyeKind.Outer) {
+                        shape = eye.OuterShape;
+                        scale = eye.OuterScale;
+                        radius = eye.OuterCornerRadiusPx;
+                        color = Flatten(eye.OuterColor ?? opts.Foreground, bg);
+                    } else if (kind == EyeKind.Inner) {
+                        shape = eye.InnerShape;
+                        scale = eye.InnerScale;
+                        radius = eye.InnerCornerRadiusPx;
+                        color = Flatten(eye.InnerColor ?? opts.Foreground, bg);
+                    }
+                }
+
+                AppendColor(sb, color, ref current, ref hasCurrent);
+                DrawModule(sb, mx, my, opts.ModuleSize, opts.QuietZone, heightPx, shape, scale, radius);
             }
+        }
+
+        if (useFrame) {
+            DrawEyeFrame(sb, opts, 0, 0, size, heightPx, bg, ref current, ref hasCurrent);
+            DrawEyeFrame(sb, opts, size - 7, 0, size, heightPx, bg, ref current, ref hasCurrent);
+            DrawEyeFrame(sb, opts, 0, size - 7, size, heightPx, bg, ref current, ref hasCurrent);
         }
 
         return sb.ToString();
     }
 
-    private static void AppendColor(StringBuilder sb, Rgba32 color) {
+    private static void AppendColor(StringBuilder sb, Rgba32 color, ref Rgba32 current, ref bool hasCurrent) {
+        if (hasCurrent && current.R == color.R && current.G == color.G && current.B == color.B) return;
+        current = color;
+        hasCurrent = true;
         sb.Append(ToComponent(color.R)).Append(' ')
             .Append(ToComponent(color.G)).Append(' ')
             .Append(ToComponent(color.B)).Append(" rg\n");
@@ -101,6 +140,171 @@ public static class QrPdfRenderer {
             .Append(y).Append(' ')
             .Append(width).Append(' ')
             .Append(height).Append(" re f\n");
+    }
+
+    private static void AppendRoundedRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int radius, int totalHeight) {
+        if (radius <= 0) {
+            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
+            return;
+        }
+        var r = Math.Min(radius, Math.Min(width, height) / 2);
+        if (r <= 0) {
+            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
+            return;
+        }
+
+        var y = totalHeight - yTop - height;
+        var x0 = x;
+        var y0 = y;
+        var x1 = x + width;
+        var y1 = y + height;
+        var c = r * 0.5522847498307936;
+
+        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).Append(" m\n");
+        sb.Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y0)).Append(" l\n");
+        sb.Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r)).Append(" c\n");
+        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r)).Append(" l\n");
+        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+            .Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+            .Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y1)).Append(" c\n");
+        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y1)).Append(" l\n");
+        sb.Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r)).Append(" c\n");
+        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r)).Append(" l\n");
+        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+            .Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+            .Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).Append(" c\n");
+        sb.Append("h f\n");
+    }
+
+    private static void DrawModule(StringBuilder sb, int mx, int my, int moduleSize, int quietZone, int totalHeight, QrPngModuleShape shape, double scale, int radius) {
+        var scaled = Math.Max(1, (int)Math.Round(moduleSize * scale));
+        var offset = (moduleSize - scaled) / 2;
+        var x = (mx + quietZone) * moduleSize + offset;
+        var y = (my + quietZone) * moduleSize + offset;
+        switch (shape) {
+            case QrPngModuleShape.Circle:
+                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, scaled / 2, totalHeight);
+                break;
+            case QrPngModuleShape.Rounded:
+                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, radius, totalHeight);
+                break;
+            default:
+                AppendRectTopLeft(sb, x, y, scaled, scaled, totalHeight);
+                break;
+        }
+    }
+
+    private static void DrawEyeFrame(
+        StringBuilder sb,
+        QrPngRenderOptions opts,
+        int ex,
+        int ey,
+        int size,
+        int totalHeight,
+        Rgba32 background,
+        ref Rgba32 current,
+        ref bool hasCurrent) {
+        var moduleSize = opts.ModuleSize;
+        var x0 = (ex + opts.QuietZone) * moduleSize;
+        var y0 = (ey + opts.QuietZone) * moduleSize;
+
+        var outerSize = 7 * moduleSize;
+        var innerSize = 5 * moduleSize;
+        var dotSize = 3 * moduleSize;
+
+        var eye = opts.Eyes!;
+        var outerScaled = ScaleSize(outerSize, eye.OuterScale);
+        var innerScaled = ScaleSize(innerSize, eye.OuterScale);
+        var dotScaled = ScaleSize(dotSize, eye.InnerScale);
+
+        var outerX = x0 + (outerSize - outerScaled) / 2;
+        var outerY = y0 + (outerSize - outerScaled) / 2;
+        var innerX = x0 + (outerSize - innerScaled) / 2;
+        var innerY = y0 + (outerSize - innerScaled) / 2;
+        var dotX = x0 + (outerSize - dotScaled) / 2;
+        var dotY = y0 + (outerSize - dotScaled) / 2;
+
+        var outerColor = Flatten(eye.OuterColor ?? opts.Foreground, background);
+        var innerColor = Flatten(eye.InnerColor ?? opts.Foreground, background);
+
+        AppendColor(sb, outerColor, ref current, ref hasCurrent);
+        DrawShape(sb, outerX, outerY, outerScaled, outerScaled, eye.OuterShape, eye.OuterCornerRadiusPx, totalHeight);
+        AppendColor(sb, background, ref current, ref hasCurrent);
+        DrawShape(sb, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Square, eye.InnerCornerRadiusPx, totalHeight);
+
+        if (dotScaled > 0) {
+            AppendColor(sb, innerColor, ref current, ref hasCurrent);
+            DrawShape(sb, dotX, dotY, dotScaled, dotScaled, eye.InnerShape, eye.InnerCornerRadiusPx, totalHeight);
+        }
+    }
+
+    private static void DrawShape(StringBuilder sb, int x, int y, int width, int height, QrPngModuleShape shape, int radius, int totalHeight) {
+        switch (shape) {
+            case QrPngModuleShape.Circle:
+                AppendRoundedRectTopLeft(sb, x, y, width, height, Math.Min(width, height) / 2, totalHeight);
+                break;
+            case QrPngModuleShape.Rounded:
+                AppendRoundedRectTopLeft(sb, x, y, width, height, radius, totalHeight);
+                break;
+            default:
+                AppendRectTopLeft(sb, x, y, width, height, totalHeight);
+                break;
+        }
+    }
+
+    private static int ScaleSize(int size, double scale) {
+        if (scale < 0.1) scale = 0.1;
+        if (scale > 1.0) scale = 1.0;
+        return Math.Max(1, (int)Math.Round(size * scale));
+    }
+
+    private static bool IsInEye(int x, int y, int size) {
+        return (x < 7 && y < 7) || (x >= size - 7 && y < 7) || (x < 7 && y >= size - 7);
+    }
+
+    private static bool TryGetEyeKind(int x, int y, int size, out EyeKind kind) {
+        if (x < 7 && y < 7) {
+            kind = GetEyeModuleKind(x, y, 0, 0);
+            return true;
+        }
+        if (x >= size - 7 && y < 7) {
+            kind = GetEyeModuleKind(x, y, size - 7, 0);
+            return true;
+        }
+        if (x < 7 && y >= size - 7) {
+            kind = GetEyeModuleKind(x, y, 0, size - 7);
+            return true;
+        }
+        kind = EyeKind.None;
+        return false;
+    }
+
+    private static EyeKind GetEyeModuleKind(int x, int y, int ex, int ey) {
+        var lx = x - ex;
+        var ly = y - ey;
+        if (lx >= 2 && lx <= 4 && ly >= 2 && ly <= 4) return EyeKind.Inner;
+        return EyeKind.Outer;
+    }
+
+    private static bool ShouldRaster(QrPngRenderOptions opts) {
+        if (opts.ForegroundGradient is not null) return true;
+        if (opts.Logo is not null) return true;
+        if (opts.Eyes is not null && (opts.Eyes.OuterGradient is not null || opts.Eyes.InnerGradient is not null)) return true;
+        return false;
+    }
+
+    private static string FormatNumber(double value) {
+        return value.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private enum EyeKind {
+        None,
+        Outer,
+        Inner
     }
 
     private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {

--- a/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
+++ b/CodeGlyphX/Rendering/Pdf/QrPdfRenderer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Vector;
 
 namespace CodeGlyphX.Rendering.Pdf;
 
@@ -15,11 +16,11 @@ public static class QrPdfRenderer {
     /// Renders the QR module matrix to a PDF byte array.
     /// </summary>
     public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
+        if (mode == RenderMode.Raster || QrVectorLayout.ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             return PdfWriter.WriteRgba32(widthPx, heightPx, pixels, stride, opts.Background);
         }
-        var content = BuildContent(modules, opts, out var widthPx2, out var heightPx2);
+        var content = BuildVectorContent(modules, opts, out var widthPx2, out var heightPx2);
         return PdfVectorWriter.Write(widthPx2, heightPx2, content);
     }
 
@@ -27,12 +28,12 @@ public static class QrPdfRenderer {
     /// Renders the QR module matrix to a PDF stream.
     /// </summary>
     public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, RenderMode mode = RenderMode.Vector) {
-        if (mode == RenderMode.Raster || ShouldRaster(opts)) {
+        if (mode == RenderMode.Raster || QrVectorLayout.ShouldRaster(opts)) {
             var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
             PdfWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride, opts.Background);
             return;
         }
-        var content = BuildContent(modules, opts, out var widthPx2, out var heightPx2);
+        var content = BuildVectorContent(modules, opts, out var widthPx2, out var heightPx2);
         PdfVectorWriter.Write(stream, widthPx2, heightPx2, content);
     }
 
@@ -52,268 +53,87 @@ public static class QrPdfRenderer {
         return RenderIO.WriteBinary(directory, fileName, pdf);
     }
 
-    private static string BuildContent(BitMatrix modules, QrPngRenderOptions opts, out int widthPx, out int heightPx) {
-        if (modules is null) throw new ArgumentNullException(nameof(modules));
-        if (opts is null) throw new ArgumentNullException(nameof(opts));
-        if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
-        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
-        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
-        if (opts.ModuleScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleScale));
-        opts.Eyes?.Validate();
-
-        var size = modules.Width;
-        var outModules = size + opts.QuietZone * 2;
-        widthPx = outModules * opts.ModuleSize;
-        heightPx = widthPx;
-
-        var bg = Flatten(opts.Background, Rgba32.White);
-        var fg = Flatten(opts.Foreground, bg);
-        var current = default(Rgba32);
-        var hasCurrent = false;
-
-        var sb = new StringBuilder(outModules * outModules * 4);
-        AppendColor(sb, bg, ref current, ref hasCurrent);
-        AppendRectTopLeft(sb, 0, 0, widthPx, heightPx, heightPx);
-        AppendColor(sb, fg, ref current, ref hasCurrent);
-
-        var moduleShape = opts.ModuleShape;
-        var moduleScale = opts.ModuleScale;
-        var moduleRadius = opts.ModuleCornerRadiusPx;
-        var eye = opts.Eyes;
-        var useFrame = eye is not null && eye.UseFrame;
-
-        for (var my = 0; my < size; my++) {
-            for (var mx = 0; mx < size; mx++) {
-                if (!modules[mx, my]) continue;
-                if (useFrame && IsInEye(mx, my, size)) continue;
-
-                var shape = moduleShape;
-                var scale = moduleScale;
-                var radius = moduleRadius;
-                var color = fg;
-
-                if (eye is not null && TryGetEyeKind(mx, my, size, out var kind)) {
-                    if (kind == EyeKind.Outer) {
-                        shape = eye.OuterShape;
-                        scale = eye.OuterScale;
-                        radius = eye.OuterCornerRadiusPx;
-                        color = Flatten(eye.OuterColor ?? opts.Foreground, bg);
-                    } else if (kind == EyeKind.Inner) {
-                        shape = eye.InnerShape;
-                        scale = eye.InnerScale;
-                        radius = eye.InnerCornerRadiusPx;
-                        color = Flatten(eye.InnerColor ?? opts.Foreground, bg);
-                    }
-                }
-
-                AppendColor(sb, color, ref current, ref hasCurrent);
-                DrawModule(sb, mx, my, opts.ModuleSize, opts.QuietZone, heightPx, shape, scale, radius);
-            }
-        }
-
-        if (useFrame) {
-            DrawEyeFrame(sb, opts, 0, 0, size, heightPx, bg, ref current, ref hasCurrent);
-            DrawEyeFrame(sb, opts, size - 7, 0, size, heightPx, bg, ref current, ref hasCurrent);
-            DrawEyeFrame(sb, opts, 0, size - 7, size, heightPx, bg, ref current, ref hasCurrent);
-        }
-
+    private static string BuildVectorContent(BitMatrix modules, QrPngRenderOptions opts, out int widthPx, out int heightPx) {
+        QrVectorLayout.GetSize(modules, opts, out widthPx, out heightPx);
+        var sb = new StringBuilder();
+        var sink = new PdfSink(sb, heightPx);
+        QrVectorLayout.Render(modules, opts, sink, out _, out _);
         return sb.ToString();
     }
 
-    private static void AppendColor(StringBuilder sb, Rgba32 color, ref Rgba32 current, ref bool hasCurrent) {
-        if (hasCurrent && current.R == color.R && current.G == color.G && current.B == color.B) return;
-        current = color;
-        hasCurrent = true;
-        sb.Append(ToComponent(color.R)).Append(' ')
-            .Append(ToComponent(color.G)).Append(' ')
-            .Append(ToComponent(color.B)).Append(" rg\n");
-    }
+    private sealed class PdfSink : IQrVectorSink {
+        private readonly StringBuilder _sb;
+        private readonly int _height;
+        private Rgba32 _current;
+        private bool _hasCurrent;
 
-    private static string ToComponent(byte value) {
-        var scaled = value / 255.0;
-        return scaled.ToString("0.###", CultureInfo.InvariantCulture);
-    }
-
-    private static void AppendRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int totalHeight) {
-        var y = totalHeight - yTop - height;
-        sb.Append(x).Append(' ')
-            .Append(y).Append(' ')
-            .Append(width).Append(' ')
-            .Append(height).Append(" re f\n");
-    }
-
-    private static void AppendRoundedRectTopLeft(StringBuilder sb, int x, int yTop, int width, int height, int radius, int totalHeight) {
-        if (radius <= 0) {
-            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
-            return;
-        }
-        var r = Math.Min(radius, Math.Min(width, height) / 2);
-        if (r <= 0) {
-            AppendRectTopLeft(sb, x, yTop, width, height, totalHeight);
-            return;
+        public PdfSink(StringBuilder sb, int height) {
+            _sb = sb ?? throw new ArgumentNullException(nameof(sb));
+            _height = height;
         }
 
-        var y = totalHeight - yTop - height;
-        var x0 = x;
-        var y0 = y;
-        var x1 = x + width;
-        var y1 = y + height;
-        var c = r * 0.5522847498307936;
-
-        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).Append(" m\n");
-        sb.Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y0)).Append(" l\n");
-        sb.Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
-            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
-            .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r)).Append(" c\n");
-        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r)).Append(" l\n");
-        sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
-            .Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
-            .Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y1)).Append(" c\n");
-        sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y1)).Append(" l\n");
-        sb.Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
-            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
-            .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r)).Append(" c\n");
-        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r)).Append(" l\n");
-        sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
-            .Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
-            .Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).Append(" c\n");
-        sb.Append("h f\n");
-    }
-
-    private static void DrawModule(StringBuilder sb, int mx, int my, int moduleSize, int quietZone, int totalHeight, QrPngModuleShape shape, double scale, int radius) {
-        var scaled = Math.Max(1, (int)Math.Round(moduleSize * scale));
-        var offset = (moduleSize - scaled) / 2;
-        var x = (mx + quietZone) * moduleSize + offset;
-        var y = (my + quietZone) * moduleSize + offset;
-        switch (shape) {
-            case QrPngModuleShape.Circle:
-                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, scaled / 2, totalHeight);
-                break;
-            case QrPngModuleShape.Rounded:
-                AppendRoundedRectTopLeft(sb, x, y, scaled, scaled, radius, totalHeight);
-                break;
-            default:
-                AppendRectTopLeft(sb, x, y, scaled, scaled, totalHeight);
-                break;
+        public void SetFillColor(Rgba32 color) {
+            if (_hasCurrent && _current.R == color.R && _current.G == color.G && _current.B == color.B) return;
+            _current = color;
+            _hasCurrent = true;
+            _sb.Append(ToComponent(color.R)).Append(' ')
+                .Append(ToComponent(color.G)).Append(' ')
+                .Append(ToComponent(color.B)).Append(" rg\n");
         }
-    }
 
-    private static void DrawEyeFrame(
-        StringBuilder sb,
-        QrPngRenderOptions opts,
-        int ex,
-        int ey,
-        int size,
-        int totalHeight,
-        Rgba32 background,
-        ref Rgba32 current,
-        ref bool hasCurrent) {
-        var moduleSize = opts.ModuleSize;
-        var x0 = (ex + opts.QuietZone) * moduleSize;
-        var y0 = (ey + opts.QuietZone) * moduleSize;
-
-        var outerSize = 7 * moduleSize;
-        var innerSize = 5 * moduleSize;
-        var dotSize = 3 * moduleSize;
-
-        var eye = opts.Eyes!;
-        var outerScaled = ScaleSize(outerSize, eye.OuterScale);
-        var innerScaled = ScaleSize(innerSize, eye.OuterScale);
-        var dotScaled = ScaleSize(dotSize, eye.InnerScale);
-
-        var outerX = x0 + (outerSize - outerScaled) / 2;
-        var outerY = y0 + (outerSize - outerScaled) / 2;
-        var innerX = x0 + (outerSize - innerScaled) / 2;
-        var innerY = y0 + (outerSize - innerScaled) / 2;
-        var dotX = x0 + (outerSize - dotScaled) / 2;
-        var dotY = y0 + (outerSize - dotScaled) / 2;
-
-        var outerColor = Flatten(eye.OuterColor ?? opts.Foreground, background);
-        var innerColor = Flatten(eye.InnerColor ?? opts.Foreground, background);
-
-        AppendColor(sb, outerColor, ref current, ref hasCurrent);
-        DrawShape(sb, outerX, outerY, outerScaled, outerScaled, eye.OuterShape, eye.OuterCornerRadiusPx, totalHeight);
-        AppendColor(sb, background, ref current, ref hasCurrent);
-        DrawShape(sb, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Square, eye.InnerCornerRadiusPx, totalHeight);
-
-        if (dotScaled > 0) {
-            AppendColor(sb, innerColor, ref current, ref hasCurrent);
-            DrawShape(sb, dotX, dotY, dotScaled, dotScaled, eye.InnerShape, eye.InnerCornerRadiusPx, totalHeight);
+        public void FillRect(int x, int yTop, int width, int height) {
+            var y = _height - yTop - height;
+            _sb.Append(x).Append(' ')
+                .Append(y).Append(' ')
+                .Append(width).Append(' ')
+                .Append(height).Append(" re f\n");
         }
-    }
 
-    private static void DrawShape(StringBuilder sb, int x, int y, int width, int height, QrPngModuleShape shape, int radius, int totalHeight) {
-        switch (shape) {
-            case QrPngModuleShape.Circle:
-                AppendRoundedRectTopLeft(sb, x, y, width, height, Math.Min(width, height) / 2, totalHeight);
-                break;
-            case QrPngModuleShape.Rounded:
-                AppendRoundedRectTopLeft(sb, x, y, width, height, radius, totalHeight);
-                break;
-            default:
-                AppendRectTopLeft(sb, x, y, width, height, totalHeight);
-                break;
+        public void FillRoundedRect(int x, int yTop, int width, int height, int radius) {
+            if (radius <= 0) {
+                FillRect(x, yTop, width, height);
+                return;
+            }
+            var r = Math.Min(radius, Math.Min(width, height) / 2);
+            if (r <= 0) {
+                FillRect(x, yTop, width, height);
+                return;
+            }
+
+            var y = _height - yTop - height;
+            var x0 = x;
+            var y0 = y;
+            var x1 = x + width;
+            var y1 = y + height;
+            var c = r * 0.5522847498307936;
+
+            _sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).Append(" m\n");
+            _sb.Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y0)).Append(" l\n");
+            _sb.Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+                .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+                .Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y0 + r)).Append(" c\n");
+            _sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r)).Append(" l\n");
+            _sb.Append(FormatNumber(x1)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+                .Append(FormatNumber(x1 - r + c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+                .Append(FormatNumber(x1 - r)).Append(' ').Append(FormatNumber(y1)).Append(" c\n");
+            _sb.Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y1)).Append(" l\n");
+            _sb.Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y1)).Append(' ')
+                .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r + c)).Append(' ')
+                .Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y1 - r)).Append(" c\n");
+            _sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r)).Append(" l\n");
+            _sb.Append(FormatNumber(x0)).Append(' ').Append(FormatNumber(y0 + r - c)).Append(' ')
+                .Append(FormatNumber(x0 + r - c)).Append(' ').Append(FormatNumber(y0)).Append(' ')
+                .Append(FormatNumber(x0 + r)).Append(' ').Append(FormatNumber(y0)).Append(" c\n");
+            _sb.Append("h f\n");
         }
-    }
 
-    private static int ScaleSize(int size, double scale) {
-        if (scale < 0.1) scale = 0.1;
-        if (scale > 1.0) scale = 1.0;
-        return Math.Max(1, (int)Math.Round(size * scale));
-    }
-
-    private static bool IsInEye(int x, int y, int size) {
-        return (x < 7 && y < 7) || (x >= size - 7 && y < 7) || (x < 7 && y >= size - 7);
-    }
-
-    private static bool TryGetEyeKind(int x, int y, int size, out EyeKind kind) {
-        if (x < 7 && y < 7) {
-            kind = GetEyeModuleKind(x, y, 0, 0);
-            return true;
+        private static string ToComponent(byte value) {
+            var scaled = value / 255.0;
+            return scaled.ToString("0.###", CultureInfo.InvariantCulture);
         }
-        if (x >= size - 7 && y < 7) {
-            kind = GetEyeModuleKind(x, y, size - 7, 0);
-            return true;
+
+        private static string FormatNumber(double value) {
+            return value.ToString("0.###", CultureInfo.InvariantCulture);
         }
-        if (x < 7 && y >= size - 7) {
-            kind = GetEyeModuleKind(x, y, 0, size - 7);
-            return true;
-        }
-        kind = EyeKind.None;
-        return false;
-    }
-
-    private static EyeKind GetEyeModuleKind(int x, int y, int ex, int ey) {
-        var lx = x - ex;
-        var ly = y - ey;
-        if (lx >= 2 && lx <= 4 && ly >= 2 && ly <= 4) return EyeKind.Inner;
-        return EyeKind.Outer;
-    }
-
-    private static bool ShouldRaster(QrPngRenderOptions opts) {
-        if (opts.ForegroundGradient is not null) return true;
-        if (opts.Logo is not null) return true;
-        if (opts.Eyes is not null && (opts.Eyes.OuterGradient is not null || opts.Eyes.InnerGradient is not null)) return true;
-        return false;
-    }
-
-    private static string FormatNumber(double value) {
-        return value.ToString("0.###", CultureInfo.InvariantCulture);
-    }
-
-    private enum EyeKind {
-        None,
-        Outer,
-        Inner
-    }
-
-    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
-        if (color.A == 255) return color;
-        var inv = 255 - color.A;
-        return new Rgba32(
-            (byte)((color.R * color.A + background.R * inv + 127) / 255),
-            (byte)((color.G * color.A + background.G * inv + 127) / 255),
-            (byte)((color.B * color.A + background.B * inv + 127) / 255),
-            255);
     }
 }

--- a/CodeGlyphX/Rendering/RenderMode.cs
+++ b/CodeGlyphX/Rendering/RenderMode.cs
@@ -3,6 +3,10 @@ namespace CodeGlyphX.Rendering;
 /// <summary>
 /// Output mode for vector-capable formats.
 /// </summary>
+/// <remarks>
+/// Vector output is the default for PDF/EPS. Raster mode uses pixel rendering and is recommended
+/// when gradients, logos, or bitmap-only effects are needed.
+/// </remarks>
 public enum RenderMode {
     /// <summary>
     /// Vector output (default).

--- a/CodeGlyphX/Rendering/Vector/QrVectorLayout.cs
+++ b/CodeGlyphX/Rendering/Vector/QrVectorLayout.cs
@@ -131,7 +131,7 @@ internal static class QrVectorLayout {
         sink.SetFillColor(outerColor);
         DrawShape(sink, outerX, outerY, outerScaled, outerScaled, eye.OuterShape, eye.OuterCornerRadiusPx);
         sink.SetFillColor(background);
-        DrawShape(sink, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Square, eye.InnerCornerRadiusPx);
+        DrawShape(sink, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Rounded, eye.InnerCornerRadiusPx);
 
         if (dotScaled > 0) {
             sink.SetFillColor(innerColor);

--- a/CodeGlyphX/Rendering/Vector/QrVectorLayout.cs
+++ b/CodeGlyphX/Rendering/Vector/QrVectorLayout.cs
@@ -1,0 +1,201 @@
+using System;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Vector;
+
+internal interface IQrVectorSink {
+    void SetFillColor(Rgba32 color);
+    void FillRect(int x, int yTop, int width, int height);
+    void FillRoundedRect(int x, int yTop, int width, int height, int radius);
+}
+
+internal static class QrVectorLayout {
+    internal static void GetSize(BitMatrix modules, QrPngRenderOptions opts, out int widthPx, out int heightPx) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (modules.Width != modules.Height) throw new ArgumentException("Matrix must be square.", nameof(modules));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+        if (opts.ModuleScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleScale));
+
+        var size = modules.Width;
+        var outModules = size + opts.QuietZone * 2;
+        widthPx = outModules * opts.ModuleSize;
+        heightPx = widthPx;
+    }
+
+    internal static void Render(BitMatrix modules, QrPngRenderOptions opts, IQrVectorSink sink, out int widthPx, out int heightPx) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (sink is null) throw new ArgumentNullException(nameof(sink));
+        opts.Eyes?.Validate();
+
+        GetSize(modules, opts, out widthPx, out heightPx);
+        var size = modules.Width;
+
+        var bg = Flatten(opts.Background, Rgba32.White);
+        var fg = Flatten(opts.Foreground, bg);
+
+        sink.SetFillColor(bg);
+        sink.FillRect(0, 0, widthPx, heightPx);
+        sink.SetFillColor(fg);
+
+        var moduleShape = opts.ModuleShape;
+        var moduleScale = opts.ModuleScale;
+        var moduleRadius = opts.ModuleCornerRadiusPx;
+        var eye = opts.Eyes;
+        var useFrame = eye is not null && eye.UseFrame;
+
+        for (var my = 0; my < size; my++) {
+            for (var mx = 0; mx < size; mx++) {
+                if (!modules[mx, my]) continue;
+                if (useFrame && IsInEye(mx, my, size)) continue;
+
+                var shape = moduleShape;
+                var scale = moduleScale;
+                var radius = moduleRadius;
+                var color = fg;
+
+                if (eye is not null && TryGetEyeKind(mx, my, size, out var kind)) {
+                    if (kind == EyeKind.Outer) {
+                        shape = eye.OuterShape;
+                        scale = eye.OuterScale;
+                        radius = eye.OuterCornerRadiusPx;
+                        color = Flatten(eye.OuterColor ?? opts.Foreground, bg);
+                    } else if (kind == EyeKind.Inner) {
+                        shape = eye.InnerShape;
+                        scale = eye.InnerScale;
+                        radius = eye.InnerCornerRadiusPx;
+                        color = Flatten(eye.InnerColor ?? opts.Foreground, bg);
+                    }
+                }
+
+                sink.SetFillColor(color);
+                DrawModule(sink, mx, my, opts.ModuleSize, opts.QuietZone, shape, scale, radius);
+            }
+        }
+
+        if (useFrame) {
+            DrawEyeFrame(sink, opts, 0, 0, size, bg);
+            DrawEyeFrame(sink, opts, size - 7, 0, size, bg);
+            DrawEyeFrame(sink, opts, 0, size - 7, size, bg);
+        }
+    }
+
+    internal static bool ShouldRaster(QrPngRenderOptions opts) {
+        if (opts.ForegroundGradient is not null) return true;
+        if (opts.Logo is not null) return true;
+        if (opts.Eyes is not null && (opts.Eyes.OuterGradient is not null || opts.Eyes.InnerGradient is not null)) return true;
+        return false;
+    }
+
+    private static void DrawModule(IQrVectorSink sink, int mx, int my, int moduleSize, int quietZone, QrPngModuleShape shape, double scale, int radius) {
+        var scaled = Math.Max(1, (int)Math.Round(moduleSize * scale));
+        var offset = (moduleSize - scaled) / 2;
+        var x = (mx + quietZone) * moduleSize + offset;
+        var y = (my + quietZone) * moduleSize + offset;
+
+        if (shape == QrPngModuleShape.Circle) {
+            sink.FillRoundedRect(x, y, scaled, scaled, scaled / 2);
+        } else if (shape == QrPngModuleShape.Rounded) {
+            sink.FillRoundedRect(x, y, scaled, scaled, radius);
+        } else {
+            sink.FillRect(x, y, scaled, scaled);
+        }
+    }
+
+    private static void DrawEyeFrame(IQrVectorSink sink, QrPngRenderOptions opts, int ex, int ey, int size, Rgba32 background) {
+        var moduleSize = opts.ModuleSize;
+        var x0 = (ex + opts.QuietZone) * moduleSize;
+        var y0 = (ey + opts.QuietZone) * moduleSize;
+
+        var outerSize = 7 * moduleSize;
+        var innerSize = 5 * moduleSize;
+        var dotSize = 3 * moduleSize;
+
+        var eye = opts.Eyes!;
+        var outerScaled = ScaleSize(outerSize, eye.OuterScale);
+        var innerScaled = ScaleSize(innerSize, eye.OuterScale);
+        var dotScaled = ScaleSize(dotSize, eye.InnerScale);
+
+        var outerX = x0 + (outerSize - outerScaled) / 2;
+        var outerY = y0 + (outerSize - outerScaled) / 2;
+        var innerX = x0 + (outerSize - innerScaled) / 2;
+        var innerY = y0 + (outerSize - innerScaled) / 2;
+        var dotX = x0 + (outerSize - dotScaled) / 2;
+        var dotY = y0 + (outerSize - dotScaled) / 2;
+
+        var outerColor = Flatten(eye.OuterColor ?? opts.Foreground, background);
+        var innerColor = Flatten(eye.InnerColor ?? opts.Foreground, background);
+
+        sink.SetFillColor(outerColor);
+        DrawShape(sink, outerX, outerY, outerScaled, outerScaled, eye.OuterShape, eye.OuterCornerRadiusPx);
+        sink.SetFillColor(background);
+        DrawShape(sink, innerX, innerY, innerScaled, innerScaled, QrPngModuleShape.Square, eye.InnerCornerRadiusPx);
+
+        if (dotScaled > 0) {
+            sink.SetFillColor(innerColor);
+            DrawShape(sink, dotX, dotY, dotScaled, dotScaled, eye.InnerShape, eye.InnerCornerRadiusPx);
+        }
+    }
+
+    private static void DrawShape(IQrVectorSink sink, int x, int y, int width, int height, QrPngModuleShape shape, int radius) {
+        if (shape == QrPngModuleShape.Circle) {
+            sink.FillRoundedRect(x, y, width, height, Math.Min(width, height) / 2);
+        } else if (shape == QrPngModuleShape.Rounded) {
+            sink.FillRoundedRect(x, y, width, height, radius);
+        } else {
+            sink.FillRect(x, y, width, height);
+        }
+    }
+
+    private static int ScaleSize(int size, double scale) {
+        if (scale < 0.1) scale = 0.1;
+        if (scale > 1.0) scale = 1.0;
+        return Math.Max(1, (int)Math.Round(size * scale));
+    }
+
+    private static bool IsInEye(int x, int y, int size) {
+        return (x < 7 && y < 7) || (x >= size - 7 && y < 7) || (x < 7 && y >= size - 7);
+    }
+
+    private static bool TryGetEyeKind(int x, int y, int size, out EyeKind kind) {
+        if (x < 7 && y < 7) {
+            kind = GetEyeModuleKind(x, y, 0, 0);
+            return true;
+        }
+        if (x >= size - 7 && y < 7) {
+            kind = GetEyeModuleKind(x, y, size - 7, 0);
+            return true;
+        }
+        if (x < 7 && y >= size - 7) {
+            kind = GetEyeModuleKind(x, y, 0, size - 7);
+            return true;
+        }
+        kind = EyeKind.None;
+        return false;
+    }
+
+    private static EyeKind GetEyeModuleKind(int x, int y, int ex, int ey) {
+        var lx = x - ex;
+        var ly = y - ey;
+        if (lx >= 2 && lx <= 4 && ly >= 2 && ly <= 4) return EyeKind.Inner;
+        return EyeKind.Outer;
+    }
+
+    private static Rgba32 Flatten(Rgba32 color, Rgba32 background) {
+        if (color.A == 255) return color;
+        var inv = 255 - color.A;
+        return new Rgba32(
+            (byte)((color.R * color.A + background.R * inv + 127) / 255),
+            (byte)((color.G * color.A + background.G * inv + 127) / 255),
+            (byte)((color.B * color.A + background.B * inv + 127) / 255),
+            255);
+    }
+
+    private enum EyeKind {
+        None,
+        Outer,
+        Inner
+    }
+}

--- a/README.md
+++ b/README.md
@@ -77,19 +77,19 @@ dotnet add package CodeGlyphX
 
 ## Supported Symbologies
 
-| Symbology | Encode | Decode | Notes |
-| --- | --- | --- | --- |
-| QR | ✅ | ✅ | ECI, FNC1/GS1, Kanji, structured append |
-| Micro QR | ✅ | ✅ | Versions M1–M4 |
-| Code128 | ✅ | ✅ | Set B/C |
-| GS1-128 | ✅ | ✅ | FNC1 + AI helpers |
-| Code39 | ✅ | ✅ | Optional checksum |
-| Code93 | ✅ | ✅ | Optional checksum |
-| EAN-8 / EAN-13 | ✅ | ✅ | Checksum validation |
-| UPC-A / UPC-E | ✅ | ✅ | Checksum validation |
-| ITF-14 | ✅ | ✅ | Checksum validation |
-| Data Matrix | ✅ | ✅ | ASCII/C40/Text/X12/EDIFACT/Base256 |
-| PDF417 | ✅ | ✅ | Full encode/decode |
+| Symbology | Encode | Decode | Outputs | Notes |
+| --- | --- | --- | --- | --- |
+| QR | ✅ | ✅ | All (see Output formats) | ECI, FNC1/GS1, Kanji, structured append |
+| Micro QR | ✅ | ✅ | All (see Output formats) | Versions M1–M4 |
+| Code128 | ✅ | ✅ | All (see Output formats) | Set B/C |
+| GS1-128 | ✅ | ✅ | All (see Output formats) | FNC1 + AI helpers |
+| Code39 | ✅ | ✅ | All (see Output formats) | Optional checksum |
+| Code93 | ✅ | ✅ | All (see Output formats) | Optional checksum |
+| EAN-8 / EAN-13 | ✅ | ✅ | All (see Output formats) | Checksum validation |
+| UPC-A / UPC-E | ✅ | ✅ | All (see Output formats) | Checksum validation |
+| ITF-14 | ✅ | ✅ | All (see Output formats) | Checksum validation |
+| Data Matrix | ✅ | ✅ | All (see Output formats) | ASCII/C40/Text/X12/EDIFACT/Base256 |
+| PDF417 | ✅ | ✅ | All (see Output formats) | Full encode/decode |
 
 ## Features
 
@@ -102,6 +102,22 @@ dotnet add package CodeGlyphX
 - [x] Base64 helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone, SMS, Contact, Calendar, OTP, Social)
 - [x] WPF controls and demo apps
+
+## Output formats (Save by extension)
+
+Save(...) chooses the output based on file extension for QR/Barcode/DataMatrix/PDF417.
+
+| Format | Extensions | Notes |
+| --- | --- | --- |
+| PNG | `.png` | Raster |
+| JPEG | `.jpg`, `.jpeg` | Raster, quality via options |
+| BMP | `.bmp` | Raster |
+| SVG | `.svg` | Vector |
+| HTML | `.html`, `.htm` | Table-based output |
+| PDF | `.pdf` | Vector by default, raster via RenderMode |
+| EPS | `.eps`, `.ps` | Vector by default, raster via RenderMode |
+| ASCII | API only | Use `RenderAscii` methods |
+| Raw RGBA | API only | Use `RenderPixels` methods |
 
 ## Payload helpers
 
@@ -117,13 +133,6 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 | Social & Stores | App Store (Apple/Google), Facebook, X/Twitter, TikTok, LinkedIn, WhatsApp |
 | Payments | UPI, SEPA Girocode (EPC), BezahlCode, Swiss QR Bill, Slovenian UPN |
 | Crypto & Network | Bitcoin / Bitcoin Cash / Litecoin, Monero, ShadowSocks |
-
-## Renderers and output formats
-
-- PNG / JPEG byte arrays and stream writers
-- SVG and HTML strings
-- Raw RGBA pixels
-- WPF controls
 
 ## Image decoding (for readers)
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ using CodeGlyphX;
 using CodeGlyphX.Rendering;
 
 // PDF/EPS are vector by default. Use Raster when you need pixels.
-QR.SavePdf("https://example.com", "qr-raster.pdf", renderMode: RenderMode.Raster);
+QR.SavePdf("https://example.com", "qr-raster.pdf", mode: RenderMode.Raster);
 ```
 
 Notes:
 - Vector PDF/EPS support square/rounded/circle modules and eye shapes.
 - Gradients and logos automatically fall back to raster to preserve appearance.
+- PDF/EPS are output-only. For decoding, rasterize to PNG/BMP/PPM/TGA and use the image decoders.
 
 ```csharp
 using CodeGlyphX;

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ using CodeGlyphX.Rendering;
 QR.SavePdf("https://example.com", "qr-raster.pdf", renderMode: RenderMode.Raster);
 ```
 
+Notes:
+- Vector PDF/EPS support square/rounded/circle modules and eye shapes.
+- Gradients and logos automatically fall back to raster to preserve appearance.
+
 ```csharp
 using CodeGlyphX;
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,19 @@ Notes:
 using CodeGlyphX;
 
 Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.png");
+Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.pdf");
+Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.eps");
 ```
 
 ```csharp
 using CodeGlyphX;
 
 DataMatrixCode.Save("DataMatrix-12345", "datamatrix.png");
+DataMatrixCode.Save("DataMatrix-12345", "datamatrix.pdf");
+DataMatrixCode.Save("DataMatrix-12345", "datamatrix.eps");
 Pdf417Code.Save("PDF417-12345", "pdf417.png");
+Pdf417Code.Save("PDF417-12345", "pdf417.pdf");
+Pdf417Code.Save("PDF417-12345", "pdf417.eps");
 ```
 
 ## Payload helpers (3 lines each)


### PR DESCRIPTION
## Summary
- Add RenderMode (vector/raster) for PDF/EPS across QR/Barcode/DataMatrix/PDF417 APIs and builders
- Refactor QR PDF/EPS vector drawing into shared layout helper to reduce duplication
- Vector QR styling in PDF/EPS (square/rounded/circle modules + eye shapes)
- Auto-raster for gradients/logos in PDF/EPS to preserve appearance
- Normalize escaped newlines in ASCII renderers
- Update README with vector vs raster notes and PDF/EPS decode guidance
- Add PDF/EPS examples (basic + fancy + barcode/datamatrix/pdf417)
- Add tests for vector curves and raster fallback when gradients/logos are enabled

## Testing
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0
