### PR TITLE
Add QR image decode options

### DIFF
--- a/CodeGlyphX.Examples/QrDecodeExample.cs
+++ b/CodeGlyphX.Examples/QrDecodeExample.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 using CodeGlyphX;
 using CodeGlyphX.Rendering;
@@ -10,6 +11,12 @@ internal static class QrDecodeExample {
         var png = QR.Png(payload);
         if (QR.TryDecodePng(png, out var decoded)) {
             decoded.Text.WriteText(outputDir, "qr-decode.txt");
+        }
+
+        var screenPath = Path.Combine(outputDir, "qr-screen.png");
+        png.WriteBinary(screenPath);
+        if (QrImageDecoder.TryDecodeImage(File.ReadAllBytes(screenPath), new QrPixelDecodeOptions { Profile = QrDecodeProfile.Robust }, out var screenDecoded)) {
+            screenDecoded.Text.WriteText(outputDir, "qr-decode-screen.txt");
         }
 
         var fast = new QrPixelDecodeOptions { Profile = QrDecodeProfile.Fast };

--- a/CodeGlyphX.Examples/QrDecodeExample.cs
+++ b/CodeGlyphX.Examples/QrDecodeExample.cs
@@ -11,5 +11,10 @@ internal static class QrDecodeExample {
         if (QR.TryDecodePng(png, out var decoded)) {
             decoded.Text.WriteText(outputDir, "qr-decode.txt");
         }
+
+        var fast = new QrPixelDecodeOptions { Profile = QrDecodeProfile.Fast };
+        if (QrImageDecoder.TryDecodeImage(png, fast, out var decodedFast)) {
+            decodedFast.Text.WriteText(outputDir, "qr-decode-fast.txt");
+        }
     }
 }

--- a/CodeGlyphX.Examples/QrDecodeExample.cs
+++ b/CodeGlyphX.Examples/QrDecodeExample.cs
@@ -15,8 +15,10 @@ internal static class QrDecodeExample {
 
         var screenPath = Path.Combine(outputDir, "qr-screen.png");
         png.WriteBinary(screenPath);
-        if (QrImageDecoder.TryDecodeImage(File.ReadAllBytes(screenPath), new QrPixelDecodeOptions { Profile = QrDecodeProfile.Robust }, out var screenDecoded)) {
+        if (QrImageDecoder.TryDecodeImage(File.ReadAllBytes(screenPath), out var screenDecoded, out var screenInfo, new QrPixelDecodeOptions { Profile = QrDecodeProfile.Robust })) {
             screenDecoded.Text.WriteText(outputDir, "qr-decode-screen.txt");
+        } else {
+            QrDiagnosticsDump.WriteText(outputDir, "qr-decode-screen.txt", screenInfo, label: "Decode failed", source: screenPath);
         }
 
         var fast = new QrPixelDecodeOptions { Profile = QrDecodeProfile.Fast };

--- a/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml
+++ b/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml
@@ -45,6 +45,13 @@
 
             <Button x:Name="PickRegionButton" Content="Pick region…" Click="PickRegion_Click" Margin="0,0,0,12" />
 
+            <TextBlock Text="Decode profile" FontWeight="Bold" />
+            <ComboBox x:Name="ProfileBox" Margin="0,0,0,12" SelectionChanged="ProfileBox_SelectionChanged">
+                <ComboBoxItem Content="Fast" />
+                <ComboBoxItem Content="Balanced" />
+                <ComboBoxItem Content="Robust" />
+            </ComboBox>
+
             <Button x:Name="StartStopButton" Content="Start scanning" Click="StartStop_Click" Margin="0,0,0,12" />
 
             <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
@@ -71,7 +78,7 @@
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0"
-                           Text="Note: this prototype expects a clean, high-contrast QR in the selected region (no rotation/perspective yet)."
+                           Text="Note: rotation/mirroring are supported. Perspective/skew works best with clean finder patterns and good contrast."
                            TextWrapping="Wrap" />
 
                 <TextBlock Grid.Row="1" Text="Live capture preview (verify region selection):" FontWeight="Bold" Margin="0,12,0,6" />

--- a/CodeGlyphX/QrDiagnosticsDump.cs
+++ b/CodeGlyphX/QrDiagnosticsDump.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Text;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// Builds and writes diagnostic dumps for QR pixel decoding attempts.
+/// </summary>
+public static class QrDiagnosticsDump {
+    /// <summary>
+    /// Builds a diagnostic summary string for a decode attempt.
+    /// </summary>
+    public static string Build(QrPixelDecodeInfo info, string? label = null, string? source = null) {
+        var sb = new StringBuilder(256);
+        if (!string.IsNullOrWhiteSpace(label)) {
+            sb.AppendLine(label);
+        }
+        if (!string.IsNullOrWhiteSpace(source)) {
+            sb.AppendLine($"Source: {source}");
+        }
+        sb.AppendLine($"Status: {(info.IsSuccess ? "Success" : "Failure")}");
+        sb.AppendLine($"Scale: {info.Scale}");
+        sb.AppendLine($"Threshold: {info.Threshold}");
+        sb.AppendLine($"Invert: {info.Invert}");
+        sb.AppendLine($"Candidates: {info.CandidateCount}");
+        sb.AppendLine($"TriplesTried: {info.CandidateTriplesTried}");
+        if (info.Dimension > 0) sb.AppendLine($"Dimension: {info.Dimension}");
+        sb.AppendLine($"Module: {info.Module.Message}");
+        sb.AppendLine($"Confidence: {info.Confidence:0.###}");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Writes diagnostics to a text file.
+    /// </summary>
+    public static string WriteText(string path, QrPixelDecodeInfo info, string? label = null, string? source = null) {
+        var text = Build(info, label, source);
+        return RenderIO.WriteText(path, text);
+    }
+
+    /// <summary>
+    /// Writes diagnostics to a text file in the provided directory.
+    /// </summary>
+    public static string WriteText(string directory, string fileName, QrPixelDecodeInfo info, string? label = null, string? source = null) {
+        var text = Build(info, label, source);
+        return RenderIO.WriteText(directory, fileName, text);
+    }
+
+    /// <summary>
+    /// Writes diagnostics to a text stream.
+    /// </summary>
+    public static void WriteText(Stream stream, QrPixelDecodeInfo info, string? label = null, string? source = null) {
+        var text = Build(info, label, source);
+        RenderIO.WriteText(stream, text);
+    }
+}

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -21,11 +21,35 @@ public static class QrImageDecoder {
     }
 
     /// <summary>
+    /// Attempts to decode a QR code from a raw pixel buffer.
+    /// </summary>
+    public static bool TryDecode(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded decoded) {
+#if NET8_0_OR_GREATER
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, out decoded);
+#else
+        decoded = null!;
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// Attempts to decode all QR codes from a raw pixel buffer.
     /// </summary>
     public static bool TryDecodeAll(byte[] pixels, int width, int height, int stride, PixelFormat format, out QrDecoded[] decoded) {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, out decoded);
+#else
+        decoded = Array.Empty<QrDecoded>();
+        return false;
+#endif
+    }
+
+    /// <summary>
+    /// Attempts to decode all QR codes from a raw pixel buffer.
+    /// </summary>
+    public static bool TryDecodeAll(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded[] decoded) {
+#if NET8_0_OR_GREATER
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, out decoded);
 #else
         decoded = Array.Empty<QrDecoded>();
         return false;
@@ -50,6 +74,23 @@ public static class QrImageDecoder {
     }
 
     /// <summary>
+    /// Attempts to decode a QR code from common image formats (PNG/BMP/PPM/TGA).
+    /// </summary>
+    public static bool TryDecodeImage(byte[] image, QrPixelDecodeOptions? options, out QrDecoded decoded) {
+#if NET8_0_OR_GREATER
+        if (image is null) throw new ArgumentNullException(nameof(image));
+        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            decoded = null!;
+            return false;
+        }
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
+#else
+        decoded = null!;
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// Attempts to decode all QR codes from common image formats (PNG/BMP/PPM/TGA).
     /// </summary>
     public static bool TryDecodeAllImage(byte[] image, out QrDecoded[] decoded) {
@@ -60,6 +101,23 @@ public static class QrImageDecoder {
             return false;
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
+#else
+        decoded = Array.Empty<QrDecoded>();
+        return false;
+#endif
+    }
+
+    /// <summary>
+    /// Attempts to decode all QR codes from common image formats (PNG/BMP/PPM/TGA).
+    /// </summary>
+    public static bool TryDecodeAllImage(byte[] image, QrPixelDecodeOptions? options, out QrDecoded[] decoded) {
+#if NET8_0_OR_GREATER
+        if (image is null) throw new ArgumentNullException(nameof(image));
+        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            decoded = Array.Empty<QrDecoded>();
+            return false;
+        }
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
         decoded = Array.Empty<QrDecoded>();
         return false;
@@ -81,6 +139,20 @@ public static class QrImageDecoder {
     }
 
     /// <summary>
+    /// Attempts to decode a QR code from an image stream (PNG/BMP/PPM/TGA).
+    /// </summary>
+    public static bool TryDecodeImage(Stream stream, QrPixelDecodeOptions? options, out QrDecoded decoded) {
+#if NET8_0_OR_GREATER
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
+#else
+        decoded = null!;
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// Attempts to decode all QR codes from an image stream (PNG/BMP/PPM/TGA).
     /// </summary>
     public static bool TryDecodeAllImage(Stream stream, out QrDecoded[] decoded) {
@@ -88,6 +160,20 @@ public static class QrImageDecoder {
         if (stream is null) throw new ArgumentNullException(nameof(stream));
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
+#else
+        decoded = Array.Empty<QrDecoded>();
+        return false;
+#endif
+    }
+
+    /// <summary>
+    /// Attempts to decode all QR codes from an image stream (PNG/BMP/PPM/TGA).
+    /// </summary>
+    public static bool TryDecodeAllImage(Stream stream, QrPixelDecodeOptions? options, out QrDecoded[] decoded) {
+#if NET8_0_OR_GREATER
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
         decoded = Array.Empty<QrDecoded>();
         return false;

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -74,6 +74,25 @@ public static class QrImageDecoder {
     }
 
     /// <summary>
+    /// Attempts to decode a QR code from common image formats (PNG/BMP/PPM/TGA), with diagnostics and profile options.
+    /// </summary>
+    public static bool TryDecodeImage(byte[] image, out QrDecoded decoded, out QrPixelDecodeInfo info, QrPixelDecodeOptions? options = null) {
+#if NET8_0_OR_GREATER
+        if (image is null) throw new ArgumentNullException(nameof(image));
+        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            decoded = null!;
+            info = default;
+            return false;
+        }
+        return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options);
+#else
+        decoded = null!;
+        info = default;
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// Attempts to decode a QR code from common image formats (PNG/BMP/PPM/TGA).
     /// </summary>
     public static bool TryDecodeImage(byte[] image, QrPixelDecodeOptions? options, out QrDecoded decoded) {
@@ -134,6 +153,21 @@ public static class QrImageDecoder {
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
 #else
         decoded = null!;
+        return false;
+#endif
+    }
+
+    /// <summary>
+    /// Attempts to decode a QR code from an image stream (PNG/BMP/PPM/TGA), with diagnostics and profile options.
+    /// </summary>
+    public static bool TryDecodeImage(Stream stream, out QrDecoded decoded, out QrPixelDecodeInfo info, QrPixelDecodeOptions? options = null) {
+#if NET8_0_OR_GREATER
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
+        return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options);
+#else
+        decoded = null!;
+        info = default;
         return false;
 #endif
     }

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -223,10 +223,24 @@ public static class QrImageDecoder {
     }
 
     /// <summary>
+    /// Attempts to decode a QR code from a raw pixel buffer.
+    /// </summary>
+    public static bool TryDecode(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded decoded) {
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, out decoded);
+    }
+
+    /// <summary>
     /// Attempts to decode all QR codes from a raw pixel buffer.
     /// </summary>
     public static bool TryDecodeAll(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, out QrDecoded[] decoded) {
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, out decoded);
+    }
+
+    /// <summary>
+    /// Attempts to decode all QR codes from a raw pixel buffer.
+    /// </summary>
+    public static bool TryDecodeAll(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded[] decoded) {
+        return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, out decoded);
     }
 #endif
 }

--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ if (QrImageDecoder.TryDecodeImage(File.ReadAllBytes("code.bmp"), out var decoded
 ```csharp
 using CodeGlyphX;
 
+var options = new QrPixelDecodeOptions { Profile = QrDecodeProfile.Fast };
+if (QrImageDecoder.TryDecodeImage(File.ReadAllBytes("screen.png"), options, out var decoded)) {
+    Console.WriteLine(decoded.Text);
+}
+```
+
+```csharp
+using CodeGlyphX;
+
 if (CodeGlyph.TryDecodeAllPng(File.ReadAllBytes("unknown.png"), out var results)) {
     foreach (var item in results) Console.WriteLine($"{item.Kind}: {item.Text}");
 }

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ if (QrImageDecoder.TryDecodeImage(File.ReadAllBytes("screen.png"), options, out 
 ```csharp
 using CodeGlyphX;
 
+if (!QrImageDecoder.TryDecodeImage(File.ReadAllBytes("screen.png"), out var decoded, out var info)) {
+    QrDiagnosticsDump.WriteText("decode-diagnostics.txt", info, source: "screen.png");
+}
+```
+
+```csharp
+using CodeGlyphX;
+
 if (CodeGlyph.TryDecodeAllPng(File.ReadAllBytes("unknown.png"), out var results)) {
     foreach (var item in results) Console.WriteLine($"{item.Kind}: {item.Text}");
 }


### PR DESCRIPTION
## Summary
- Add QR diagnostics dump helper and decode overloads that return QrPixelDecodeInfo
- Add ReadOnlySpan decode overloads that accept QrPixelDecodeOptions
- Add screen-capture decode example + README snippet for diagnostics
- Add robustness tests for low-contrast + false finder clusters and crop+perspective
- Add ScreenScan WPF profile toggle (Fast/Balanced/Robust)

## Testing
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0
