### PR TITLE
ScreenScan diagnostics export + blur test

### DIFF
--- a/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml
+++ b/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml
@@ -59,6 +59,8 @@
                 <Button x:Name="SaveBinarizedButton" Content="Save BW…" Click="SaveBinarized_Click" Width="170" />
             </StackPanel>
 
+            <Button x:Name="SaveDiagnosticsButton" Content="Save diagnostics…" Click="SaveDiagnostics_Click" Margin="0,0,0,12" />
+
             <TextBlock Text="Status" FontWeight="Bold" />
             <TextBlock x:Name="StatusText" Text="Idle" Margin="0,0,0,12" />
 

--- a/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml
+++ b/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml
@@ -59,7 +59,10 @@
                 <Button x:Name="SaveBinarizedButton" Content="Save BW…" Click="SaveBinarized_Click" Width="170" />
             </StackPanel>
 
-            <Button x:Name="SaveDiagnosticsButton" Content="Save diagnostics…" Click="SaveDiagnostics_Click" Margin="0,0,0,12" />
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                <Button x:Name="SaveDiagnosticsButton" Content="Save diagnostics…" Click="SaveDiagnostics_Click" Width="170" Margin="0,0,8,0" />
+                <Button x:Name="SaveCaptureBundleButton" Content="Save bundle…" Click="SaveCaptureBundle_Click" Width="170" />
+            </StackPanel>
 
             <TextBlock Text="Status" FontWeight="Bold" />
             <TextBlock x:Name="StatusText" Text="Idle" Margin="0,0,0,12" />

--- a/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml.cs
+++ b/CodeGlyphX.ScreenScan.Wpf/MainWindow.xaml.cs
@@ -208,11 +208,12 @@ public partial class MainWindow : Window {
             FileName = $"diagnostics-{DateTime.Now:yyyyMMdd-HHmmss}.txt",
         };
 
-        if (dialog.ShowDialog(this) != true) return;
+        if (dialog.ShowDialog(this) is not true) return;
 
+        var decodeInfo = _lastDecodeInfo;
         var label = $"ScreenScan ({_decodeProfile})";
         var source = $"Captured region {_lastWidth}×{_lastHeight}";
-        QrDiagnosticsDump.WriteText(dialog.FileName, _lastDecodeInfo, label, source);
+        QrDiagnosticsDump.WriteText(dialog.FileName, decodeInfo, label, source);
         StatusText.Text = $"Saved diagnostics: {Path.GetFileName(dialog.FileName)}";
     }
 
@@ -227,7 +228,7 @@ public partial class MainWindow : Window {
             FileName = $"capture-bundle-{DateTime.Now:yyyyMMdd-HHmmss}.zip",
         };
 
-        if (dialog.ShowDialog(this) != true) return;
+        if (dialog.ShowDialog(this) is not true) return;
 
         var width = _lastWidth;
         var height = _lastHeight;
@@ -251,9 +252,10 @@ public partial class MainWindow : Window {
             }
 
             var diagPath = Path.Combine(tempDir, "diagnostics.txt");
+            var decodeInfo = _lastDecodeInfo;
             var label = $"ScreenScan ({_decodeProfile})";
             var source = $"Captured region {width}×{height}";
-            QrDiagnosticsDump.WriteText(diagPath, _lastDecodeInfo, label, source);
+            QrDiagnosticsDump.WriteText(diagPath, decodeInfo, label, source);
 
             if (File.Exists(dialog.FileName)) File.Delete(dialog.FileName);
             System.IO.Compression.ZipFile.CreateFromDirectory(tempDir, dialog.FileName);

--- a/CodeGlyphX.Tests/QrPixelRobustnessTests.cs
+++ b/CodeGlyphX.Tests/QrPixelRobustnessTests.cs
@@ -333,6 +333,65 @@ public sealed class QrPixelRobustnessTests {
     }
 
     [Fact]
+    public void QrDecode_WithNoiseAndPerspective() {
+        var code = QrCodeEncoder.EncodeText("NoiseSkew");
+        var pixels = QrPngRenderer.RenderPixels(
+            code.Modules,
+            new QrPngRenderOptions { ModuleSize = 5, QuietZone = 2 },
+            out var width,
+            out var height,
+            out var stride);
+
+        var pad = 18;
+        var dstWidth = width + pad * 2;
+        var dstHeight = height + pad * 2;
+        var dstStride = dstWidth * 4;
+        var warped = new byte[dstHeight * dstStride];
+        FillWhite(warped);
+
+        var x0 = pad + 6;
+        var y0 = pad + 4;
+        var x1 = dstWidth - pad - 10;
+        var y1 = pad + 2;
+        var x2 = dstWidth - pad - 4;
+        var y2 = dstHeight - pad - 12;
+        var x3 = pad + 8;
+        var y3 = dstHeight - pad - 6;
+
+        var transform = QrPerspectiveTransform.QuadrilateralToQuadrilateral(
+            x0, y0,
+            x1, y1,
+            x2, y2,
+            x3, y3,
+            0, 0,
+            width - 1, 0,
+            width - 1, height - 1,
+            0, height - 1);
+
+        for (var y = 0; y < dstHeight; y++) {
+            var row = y * dstStride;
+            for (var x = 0; x < dstWidth; x++) {
+                transform.Transform(x, y, out var sx, out var sy);
+                if (double.IsNaN(sx) || double.IsNaN(sy)) continue;
+                var px = (int)Math.Round(sx);
+                var py = (int)Math.Round(sy);
+                if ((uint)px >= (uint)width || (uint)py >= (uint)height) continue;
+
+                var src = py * stride + px * 4;
+                var dst = row + x * 4;
+                warped[dst] = pixels[src];
+                warped[dst + 1] = pixels[src + 1];
+                warped[dst + 2] = pixels[src + 2];
+                warped[dst + 3] = pixels[src + 3];
+            }
+        }
+
+        var noisy = AddSaltPepperNoise(warped, dstWidth, dstHeight, dstStride, probability: 0.01, seed: 2222);
+        Assert.True(QrDecoder.TryDecode(noisy, dstWidth, dstHeight, dstStride, PixelFormat.Rgba32, out var decoded));
+        Assert.Equal("NoiseSkew", decoded.Text);
+    }
+
+    [Fact]
     public void QrDecode_WithFalseFinderNoise() {
         var code = QrCodeEncoder.EncodeText("FinderNoiseTest");
         var pixels = QrPngRenderer.RenderPixels(


### PR DESCRIPTION
## Summary
- Add ScreenScan WPF diagnostics export + bundle export (capture + binarized + diagnostics)
- Snapshot diagnostics data before export to avoid stale concurrent updates
- Add QR robustness tests for blur, motion blur, salt/pepper noise, and noise+perspective

## Testing
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0
