### PR TITLE
Expand QR/barcode features and performance

### DIFF
--- a/CodeGlyphX.Tests/QrParsedPayloadTests.cs
+++ b/CodeGlyphX.Tests/QrParsedPayloadTests.cs
@@ -55,4 +55,23 @@ public sealed class QrParsedPayloadTests {
         Assert.Equal("+14155550198", sms.Number);
         Assert.Equal("Hello", sms.Body);
     }
+
+    [Fact]
+    public void Parse_Bookmark() {
+        var raw = QrPayloads.Bookmark("example.com", "Example").Text;
+        Assert.True(QrPayloadParser.TryParse(raw, out var parsed));
+        Assert.Equal(QrPayloadType.Bookmark, parsed.Type);
+        Assert.True(parsed.TryGet<QrParsedData.Bookmark>(out var bookmark));
+        Assert.Equal("http://example.com", bookmark.Url);
+        Assert.Equal("Example", bookmark.Title);
+    }
+
+    [Fact]
+    public void Parse_Strict_InvalidEmail_FailsValidation() {
+        var raw = "mailto:invalid";
+        var ok = QrPayloadParser.TryParse(raw, new QrPayloadParseOptions { Strict = true }, out _, out var validation);
+        Assert.False(ok);
+        Assert.False(validation.IsValid);
+        Assert.NotEmpty(validation.Errors);
+    }
 }

--- a/CodeGlyphX.Tests/QrPayloadParserTests.cs
+++ b/CodeGlyphX.Tests/QrPayloadParserTests.cs
@@ -35,7 +35,7 @@ public sealed class QrPayloadParserTests {
         Assert.Equal(new byte[] { (byte)'a', (byte)'b', (byte)'c' }, payload);
         Assert.Single(segments);
         Assert.Equal(QrTextEncoding.Utf8, segments[0].Encoding);
-        Assert.Equal(new byte[] { (byte)'a', (byte)'b', (byte)'c' }, segments[0].Bytes);
+        Assert.True(segments[0].Span.SequenceEqual(new byte[] { (byte)'a', (byte)'b', (byte)'c' }));
         Assert.False(structuredAppend.HasValue);
         Assert.Equal(QrFnc1Mode.None, fnc1Mode);
     }
@@ -71,7 +71,7 @@ public sealed class QrPayloadParserTests {
         Assert.Equal(new byte[] { (byte)'A', (byte)'1', (byte)'-' }, payload);
         Assert.Single(segments);
         Assert.Equal(QrTextEncoding.Latin1, segments[0].Encoding);
-        Assert.Equal(new byte[] { (byte)'A', (byte)'1', (byte)'-' }, segments[0].Bytes);
+        Assert.True(segments[0].Span.SequenceEqual(new byte[] { (byte)'A', (byte)'1', (byte)'-' }));
         Assert.False(structuredAppend.HasValue);
         Assert.Equal(QrFnc1Mode.None, fnc1Mode);
     }
@@ -147,7 +147,7 @@ public sealed class QrPayloadParserTests {
         Assert.Equal(new byte[] { 0x80, 0xFF }, payload);
         Assert.Single(segments);
         Assert.Equal(QrTextEncoding.Latin1, segments[0].Encoding);
-        Assert.Equal(new byte[] { 0x80, 0xFF }, segments[0].Bytes);
+        Assert.True(segments[0].Span.SequenceEqual(new byte[] { 0x80, 0xFF }));
         Assert.False(structuredAppend.HasValue);
         Assert.Equal(QrFnc1Mode.None, fnc1Mode);
     }
@@ -185,9 +185,9 @@ public sealed class QrPayloadParserTests {
         Assert.Equal(new byte[] { 0xC2, 0xA2, 0xA3 }, payload);
         Assert.Equal(2, segments.Length);
         Assert.Equal(QrTextEncoding.Utf8, segments[0].Encoding);
-        Assert.Equal(new byte[] { 0xC2, 0xA2 }, segments[0].Bytes);
+        Assert.True(segments[0].Span.SequenceEqual(new byte[] { 0xC2, 0xA2 }));
         Assert.Equal(QrTextEncoding.Latin1, segments[1].Encoding);
-        Assert.Equal(new byte[] { 0xA3 }, segments[1].Bytes);
+        Assert.True(segments[1].Span.SequenceEqual(new byte[] { 0xA3 }));
         Assert.False(structuredAppend.HasValue);
         Assert.Equal(QrFnc1Mode.None, fnc1Mode);
 

--- a/CodeGlyphX.Tests/QrPayloadsCoreTests.cs
+++ b/CodeGlyphX.Tests/QrPayloadsCoreTests.cs
@@ -17,6 +17,18 @@ public sealed class QrPayloadsCoreTests {
     }
 
     [Fact]
+    public void QrPayloads_Bookmark_NormalizesUrl_And_Title() {
+        var payload = QrPayloads.Bookmark("example.com", "Example").Text;
+        Assert.Equal("MEBKM:TITLE:Example;URL:http\\://example.com;;", payload);
+    }
+
+    [Fact]
+    public void QrPayloads_Bookmark_OmitsEmptyTitle() {
+        var payload = QrPayloads.Bookmark("example.com", string.Empty).Text;
+        Assert.Equal("MEBKM:URL:http\\://example.com;;", payload);
+    }
+
+    [Fact]
     public void QrPayloads_Contact_Calendar_And_Otp_AreNonEmpty() {
         var contact = QrPayloads.Contact(
             QrContactOutputType.VCard3,

--- a/CodeGlyphX.Tests/QrPayloadsPaymentsTests.cs
+++ b/CodeGlyphX.Tests/QrPayloadsPaymentsTests.cs
@@ -9,4 +9,36 @@ public sealed class QrPayloadsPaymentsTests {
         var payload = QrPayloads.Upi("alice@upi", name: "Alice", amount: 12.5m).Text;
         Assert.Equal("upi://pay?pa=alice%40upi&pn=Alice&am=12.5&cu=INR", payload);
     }
+
+    [Fact]
+    public void QrPayloads_BezahlCode_SinglePaymentSepa_BuildsExpectedUri() {
+        var payload = QrPayloads.BezahlCodeSinglePaymentSepa(
+            "Alice",
+            "DE12500105170648489890",
+            "BANKDEFF",
+            12.5m,
+            reason: "Invoice-1").Text;
+
+        Assert.Equal(
+            "bank://singlepaymentsepa?name=Alice&amount=12,50&reason=Invoice-1&currency=EUR&iban=DE12500105170648489890&bic=BANKDEFF",
+            payload);
+    }
+
+    [Fact]
+    public void QrPayloads_RussiaPaymentOrder_BuildsExpectedText() {
+        var payload = QrPayloads.RussiaPaymentOrder(
+            "ACME LLC",
+            "40702810900000000001",
+            "ACME BANK",
+            "044525225",
+            "30101810400000000225",
+            "7700000000",
+            "770001001",
+            123.45m,
+            "Invoice 123").Text;
+
+        Assert.Equal(
+            "ST00012|Name=ACME LLC|PersonalAcc=40702810900000000001|BankName=ACME BANK|BIC=044525225|CorrespAcc=30101810400000000225|PayeeINN=7700000000|KPP=770001001|Sum=12345|Purpose=Invoice 123",
+            payload);
+    }
 }

--- a/CodeGlyphX/Aztec/AztecDecoder.cs
+++ b/CodeGlyphX/Aztec/AztecDecoder.cs
@@ -1,0 +1,8 @@
+namespace CodeGlyphX.Aztec;
+
+internal static class AztecDecoder {
+    public static bool TryDecode(BitMatrix modules, out string value) {
+        value = string.Empty;
+        return false;
+    }
+}

--- a/CodeGlyphX/Aztec/AztecEncodeOptions.cs
+++ b/CodeGlyphX/Aztec/AztecEncodeOptions.cs
@@ -1,0 +1,21 @@
+namespace CodeGlyphX.Aztec;
+
+/// <summary>
+/// Options for future Aztec encoding support.
+/// </summary>
+public sealed class AztecEncodeOptions {
+    /// <summary>
+    /// Target number of layers. When null, the encoder will choose automatically.
+    /// </summary>
+    public int? Layers { get; set; }
+
+    /// <summary>
+    /// Target error correction percentage. When null, the encoder will choose automatically.
+    /// </summary>
+    public int? ErrorCorrectionPercent { get; set; }
+
+    /// <summary>
+    /// When true, encode as compact Aztec when possible.
+    /// </summary>
+    public bool? Compact { get; set; }
+}

--- a/CodeGlyphX/Aztec/AztecEncoder.cs
+++ b/CodeGlyphX/Aztec/AztecEncoder.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace CodeGlyphX.Aztec;
+
+internal static class AztecEncoder {
+    public static BitMatrix Encode(string text, AztecEncodeOptions? options = null) {
+        if (text is null) throw new ArgumentNullException(nameof(text));
+        throw new NotSupportedException("Aztec encoding is not implemented yet.");
+    }
+}

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -1,0 +1,23 @@
+using System;
+using CodeGlyphX.Aztec;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// Aztec code helpers (scaffolded).
+/// </summary>
+public static class AztecCode {
+    /// <summary>
+    /// Encodes a text payload as Aztec.
+    /// </summary>
+    public static BitMatrix Encode(string text, AztecEncodeOptions? options = null) {
+        return AztecEncoder.Encode(text, options);
+    }
+
+    /// <summary>
+    /// Attempts to decode an Aztec symbol from a module matrix.
+    /// </summary>
+    public static bool TryDecode(BitMatrix modules, out string value) {
+        return AztecDecoder.TryDecode(modules, out value);
+    }
+}

--- a/CodeGlyphX/BarcodeDecodeOptions.cs
+++ b/CodeGlyphX/BarcodeDecodeOptions.cs
@@ -8,6 +8,18 @@ public sealed class BarcodeDecodeOptions {
     /// Controls how Code39 checksum characters are handled during decode.
     /// </summary>
     public Code39ChecksumPolicy Code39Checksum { get; set; } = Code39ChecksumPolicy.None;
+    /// <summary>
+    /// Controls how MSI checksum digits are handled during decode.
+    /// </summary>
+    public MsiChecksumPolicy MsiChecksum { get; set; } = MsiChecksumPolicy.None;
+    /// <summary>
+    /// Controls how Code 11 checksum characters are handled during decode.
+    /// </summary>
+    public Code11ChecksumPolicy Code11Checksum { get; set; } = Code11ChecksumPolicy.None;
+    /// <summary>
+    /// Controls whether Plessey CRC validation is required during decode.
+    /// </summary>
+    public PlesseyChecksumPolicy PlesseyChecksum { get; set; } = PlesseyChecksumPolicy.RequireValid;
 }
 
 /// <summary>
@@ -24,6 +36,60 @@ public enum Code39ChecksumPolicy {
     StripIfValid,
     /// <summary>
     /// Require a valid checksum and strip it; otherwise decoding fails.
+    /// </summary>
+    RequireValid
+}
+
+/// <summary>
+/// Policy for handling optional MSI checksum digits.
+/// </summary>
+public enum MsiChecksumPolicy {
+    /// <summary>
+    /// Do not strip checksum digits (default, avoids accidental data loss).
+    /// </summary>
+    None,
+    /// <summary>
+    /// Strip trailing checksum digit(s) when valid.
+    /// </summary>
+    StripIfValid,
+    /// <summary>
+    /// Require valid checksum digit(s); otherwise decoding fails.
+    /// </summary>
+    RequireValid
+}
+
+/// <summary>
+/// Policy for handling optional Code 11 checksum characters.
+/// </summary>
+public enum Code11ChecksumPolicy {
+    /// <summary>
+    /// Do not strip checksum characters (default, avoids accidental data loss).
+    /// </summary>
+    None,
+    /// <summary>
+    /// Strip trailing checksum character(s) when valid.
+    /// </summary>
+    StripIfValid,
+    /// <summary>
+    /// Require valid checksum character(s); otherwise decoding fails.
+    /// </summary>
+    RequireValid
+}
+
+/// <summary>
+/// Policy for handling Plessey CRC validation.
+/// </summary>
+public enum PlesseyChecksumPolicy {
+    /// <summary>
+    /// Do not validate CRC.
+    /// </summary>
+    None,
+    /// <summary>
+    /// Validate CRC and ignore mismatches.
+    /// </summary>
+    StripIfValid,
+    /// <summary>
+    /// Require valid CRC; otherwise decoding fails.
     /// </summary>
     RequireValid
 }

--- a/CodeGlyphX/BarcodeEasy.cs
+++ b/CodeGlyphX/BarcodeEasy.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// One-line barcode helpers with sane defaults.
+/// </summary>
+public static class BarcodeEasy {
+    /// <summary>
+    /// Encodes a barcode value using the specified <see cref="BarcodeType"/>.
+    /// </summary>
+    public static Barcode1D Encode(BarcodeType type, string content) {
+        if (content is null) throw new ArgumentNullException(nameof(content));
+        return BarcodeEncoder.Encode(type, content);
+    }
+
+    /// <summary>
+    /// Renders a barcode as PNG.
+    /// </summary>
+    public static byte[] RenderPng(BarcodeType type, string content, BarcodeOptions? options = null) =>
+        Barcode.Png(type, content, options);
+
+    /// <summary>
+    /// Renders a barcode as SVG.
+    /// </summary>
+    public static string RenderSvg(BarcodeType type, string content, BarcodeOptions? options = null) =>
+        Barcode.Svg(type, content, options);
+
+    /// <summary>
+    /// Renders a barcode as HTML.
+    /// </summary>
+    public static string RenderHtml(BarcodeType type, string content, BarcodeOptions? options = null) =>
+        Barcode.Html(type, content, options);
+
+    /// <summary>
+    /// Renders a barcode as JPEG.
+    /// </summary>
+    public static byte[] RenderJpeg(BarcodeType type, string content, BarcodeOptions? options = null) =>
+        Barcode.Jpeg(type, content, options);
+
+    /// <summary>
+    /// Renders a barcode as BMP.
+    /// </summary>
+    public static byte[] RenderBmp(BarcodeType type, string content, BarcodeOptions? options = null) =>
+        Barcode.Bmp(type, content, options);
+
+    /// <summary>
+    /// Renders a barcode as PDF.
+    /// </summary>
+    public static byte[] RenderPdf(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
+        Barcode.Pdf(type, content, options, mode);
+
+    /// <summary>
+    /// Renders a barcode as EPS.
+    /// </summary>
+    public static string RenderEps(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
+        Barcode.Eps(type, content, options, mode);
+
+    /// <summary>
+    /// Renders a barcode as ASCII text.
+    /// </summary>
+    public static string RenderAscii(BarcodeType type, string content, BarcodeAsciiRenderOptions? options = null) =>
+        Barcode.Ascii(type, content, options);
+
+    /// <summary>
+    /// Renders a barcode as PNG to a stream.
+    /// </summary>
+    public static void RenderPngToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
+        Barcode.SavePng(type, content, stream, options);
+
+    /// <summary>
+    /// Renders a barcode as SVG to a stream.
+    /// </summary>
+    public static void RenderSvgToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
+        Barcode.SaveSvg(type, content, stream, options);
+
+    /// <summary>
+    /// Renders a barcode as HTML to a stream.
+    /// </summary>
+    public static void RenderHtmlToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, string? title = null) =>
+        Barcode.SaveHtml(type, content, stream, options, title);
+
+    /// <summary>
+    /// Renders a barcode as JPEG to a stream.
+    /// </summary>
+    public static void RenderJpegToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
+        Barcode.SaveJpeg(type, content, stream, options);
+
+    /// <summary>
+    /// Renders a barcode as BMP to a stream.
+    /// </summary>
+    public static void RenderBmpToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
+        Barcode.SaveBmp(type, content, stream, options);
+
+    /// <summary>
+    /// Renders a barcode as PDF to a stream.
+    /// </summary>
+    public static void RenderPdfToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
+        Barcode.SavePdf(type, content, stream, options, mode);
+
+    /// <summary>
+    /// Renders a barcode as EPS to a stream.
+    /// </summary>
+    public static void RenderEpsToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
+        Barcode.SaveEps(type, content, stream, options, mode);
+
+    /// <summary>
+    /// Renders a barcode as PNG to a file.
+    /// </summary>
+    public static string RenderPngToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
+        Barcode.SavePng(type, content, path, options);
+
+    /// <summary>
+    /// Renders a barcode as SVG to a file.
+    /// </summary>
+    public static string RenderSvgToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
+        Barcode.SaveSvg(type, content, path, options);
+
+    /// <summary>
+    /// Renders a barcode as HTML to a file.
+    /// </summary>
+    public static string RenderHtmlToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) =>
+        Barcode.SaveHtml(type, content, path, options, title);
+
+    /// <summary>
+    /// Renders a barcode as JPEG to a file.
+    /// </summary>
+    public static string RenderJpegToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
+        Barcode.SaveJpeg(type, content, path, options);
+
+    /// <summary>
+    /// Renders a barcode as BMP to a file.
+    /// </summary>
+    public static string RenderBmpToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
+        Barcode.SaveBmp(type, content, path, options);
+
+    /// <summary>
+    /// Renders a barcode as PDF to a file.
+    /// </summary>
+    public static string RenderPdfToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
+        Barcode.SavePdf(type, content, path, options, mode);
+
+    /// <summary>
+    /// Renders a barcode as EPS to a file.
+    /// </summary>
+    public static string RenderEpsToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
+        Barcode.SaveEps(type, content, path, options, mode);
+
+    /// <summary>
+    /// Renders a barcode as ASCII text to a file.
+    /// </summary>
+    public static string RenderAsciiToFile(BarcodeType type, string content, string path, BarcodeAsciiRenderOptions? options = null) =>
+        Barcode.SaveAscii(type, content, path, options);
+
+    /// <summary>
+    /// Saves a barcode to a file based on the output extension.
+    /// </summary>
+    public static string RenderToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) =>
+        Barcode.Save(type, content, path, options, title);
+}

--- a/CodeGlyphX/BarcodeEncoder.cs
+++ b/CodeGlyphX/BarcodeEncoder.cs
@@ -1,9 +1,13 @@
 using System;
+using CodeGlyphX.Code11;
 using CodeGlyphX.Code128;
 using CodeGlyphX.Code39;
 using CodeGlyphX.Code93;
+using CodeGlyphX.Codabar;
 using CodeGlyphX.Ean;
 using CodeGlyphX.Itf;
+using CodeGlyphX.Msi;
+using CodeGlyphX.Plessey;
 using CodeGlyphX.UpcA;
 using CodeGlyphX.UpcE;
 
@@ -27,6 +31,10 @@ public static class BarcodeEncoder {
             BarcodeType.UPCA => UpcAEncoder.Encode(value),
             BarcodeType.UPCE => UpcEEncoder.Encode(value, UpcENumberSystem.Zero),
             BarcodeType.ITF14 => Itf14Encoder.Encode(value),
+            BarcodeType.Codabar => CodabarEncoder.Encode(value),
+            BarcodeType.MSI => MsiEncoder.Encode(value, MsiChecksumType.Mod10),
+            BarcodeType.Code11 => Code11Encoder.Encode(value, includeChecksum: true),
+            BarcodeType.Plessey => PlesseyEncoder.Encode(value),
             BarcodeType.KixCode => throw new NotSupportedException("BarcodeType.KixCode is a 2D barcode. Use MatrixBarcodeEncoder."),
             BarcodeType.DataMatrix => throw new NotSupportedException("BarcodeType.DataMatrix is a 2D barcode. Use MatrixBarcodeEncoder."),
             BarcodeType.PDF417 => throw new NotSupportedException("BarcodeType.PDF417 is a 2D barcode. Use MatrixBarcodeEncoder."),
@@ -67,4 +75,27 @@ public static class BarcodeEncoder {
     /// Encodes an ITF-14 barcode.
     /// </summary>
     public static Barcode1D EncodeItf14(string value) => Itf14Encoder.Encode(value);
+
+    /// <summary>
+    /// Encodes a Codabar barcode.
+    /// </summary>
+    public static Barcode1D EncodeCodabar(string value, char start = 'A', char stop = 'B') =>
+        CodabarEncoder.Encode(value, start, stop);
+
+    /// <summary>
+    /// Encodes an MSI barcode.
+    /// </summary>
+    public static Barcode1D EncodeMsi(string value, MsiChecksumType checksum = MsiChecksumType.Mod10) =>
+        MsiEncoder.Encode(value, checksum);
+
+    /// <summary>
+    /// Encodes a Code 11 barcode.
+    /// </summary>
+    public static Barcode1D EncodeCode11(string value, bool includeChecksum = true) =>
+        Code11Encoder.Encode(value, includeChecksum);
+
+    /// <summary>
+    /// Encodes a Plessey barcode.
+    /// </summary>
+    public static Barcode1D EncodePlessey(string value) => PlesseyEncoder.Encode(value);
 }

--- a/CodeGlyphX/BarcodeType.cs
+++ b/CodeGlyphX/BarcodeType.cs
@@ -37,6 +37,22 @@ public enum BarcodeType {
     /// </summary>
     ITF14,
     /// <summary>
+    /// Codabar (implemented).
+    /// </summary>
+    Codabar,
+    /// <summary>
+    /// MSI (implemented).
+    /// </summary>
+    MSI,
+    /// <summary>
+    /// Code 11 (implemented).
+    /// </summary>
+    Code11,
+    /// <summary>
+    /// Plessey (implemented).
+    /// </summary>
+    Plessey,
+    /// <summary>
     /// KIX Code (planned).
     /// </summary>
     KixCode,

--- a/CodeGlyphX/Codabar/CodabarEncoder.cs
+++ b/CodeGlyphX/Codabar/CodabarEncoder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using CodeGlyphX.Internal;
+
+namespace CodeGlyphX.Codabar;
+
+/// <summary>
+/// Encodes Codabar barcodes.
+/// </summary>
+public static class CodabarEncoder {
+    /// <summary>
+    /// Encodes a Codabar barcode.
+    /// </summary>
+    public static Barcode1D Encode(string content, char start = 'A', char stop = 'B') {
+        if (content is null) throw new ArgumentNullException(nameof(content));
+
+        content = content.Trim();
+        if (content.Length >= 2 && IsStartStop(content[0]) && IsStartStop(content[content.Length - 1])) {
+            start = NormalizeStartStop(content[0]);
+            stop = NormalizeStartStop(content[content.Length - 1]);
+            content = content.Substring(1, content.Length - 2);
+        }
+
+        start = NormalizeStartStop(start);
+        stop = NormalizeStartStop(stop);
+
+        var segments = new List<BarSegment>((content.Length + 2) * 16);
+
+        AppendChar(segments, start);
+        for (var i = 0; i < content.Length; i++) {
+            BarcodeSegments.AppendBit(segments, false);
+            AppendChar(segments, NormalizeData(content[i]));
+        }
+        BarcodeSegments.AppendBit(segments, false);
+        AppendChar(segments, stop);
+
+        return new Barcode1D(segments);
+    }
+
+    private static void AppendChar(List<BarSegment> segments, char ch) {
+        if (!CodabarTables.EncodingTable.TryGetValue(ch, out var pattern)) {
+            throw new InvalidOperationException($"Invalid Codabar character: '{ch}'.");
+        }
+
+        for (var i = 0; i < pattern.Length; i++) {
+            var isBar = (i % 2) == 0;
+            var width = pattern[i] == '1' ? 2 : 1;
+            for (var m = 0; m < width; m++) {
+                BarcodeSegments.AppendBit(segments, isBar);
+            }
+        }
+    }
+
+    private static bool IsStartStop(char ch) {
+        ch = char.ToUpperInvariant(ch);
+        return CodabarTables.StartStopChars.Contains(ch);
+    }
+
+    private static char NormalizeStartStop(char ch) {
+        ch = char.ToUpperInvariant(ch);
+        if (!CodabarTables.StartStopChars.Contains(ch)) {
+            throw new InvalidOperationException($"Invalid Codabar start/stop: '{ch}'.");
+        }
+        return ch;
+    }
+
+    private static char NormalizeData(char ch) {
+        ch = char.ToUpperInvariant(ch);
+        if (!CodabarTables.EncodingTable.ContainsKey(ch) || CodabarTables.StartStopChars.Contains(ch)) {
+            throw new InvalidOperationException($"Invalid Codabar data character: '{ch}'.");
+        }
+        return ch;
+    }
+}

--- a/CodeGlyphX/Codabar/CodabarTables.cs
+++ b/CodeGlyphX/Codabar/CodabarTables.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace CodeGlyphX.Codabar;
+
+internal static class CodabarTables {
+    public static readonly IReadOnlyDictionary<char, string> EncodingTable = new Dictionary<char, string> {
+        { '0', "0000011" },
+        { '1', "0000110" },
+        { '2', "0001001" },
+        { '3', "1100000" },
+        { '4', "0010010" },
+        { '5', "1000010" },
+        { '6', "0100001" },
+        { '7', "0100100" },
+        { '8', "0110000" },
+        { '9', "1001000" },
+        { 'A', "0011010" },
+        { 'B', "0101001" },
+        { 'C', "0001011" },
+        { 'D', "0001110" },
+        { '-', "0001100" },
+        { '$', "0011000" },
+        { '.', "1010100" },
+        { '/', "1010001" },
+        { ':', "1000101" },
+        { '+', "0010101" }
+    };
+
+    public static readonly HashSet<char> StartStopChars = new() { 'A', 'B', 'C', 'D' };
+}

--- a/CodeGlyphX/Code11/Code11Encoder.cs
+++ b/CodeGlyphX/Code11/Code11Encoder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CodeGlyphX.Internal;
+
+namespace CodeGlyphX.Code11;
+
+/// <summary>
+/// Encodes Code 11 barcodes.
+/// </summary>
+public static class Code11Encoder {
+    /// <summary>
+    /// Encodes a Code 11 barcode.
+    /// </summary>
+    public static Barcode1D Encode(string content, bool includeChecksum = true) {
+        if (content is null) throw new ArgumentNullException(nameof(content));
+        if (content.Length == 0) throw new InvalidOperationException("Code 11 content cannot be empty.");
+
+        for (var i = 0; i < content.Length; i++) {
+            if (!Code11Tables.ValueTable.ContainsKey(content[i])) {
+                throw new InvalidOperationException($"Invalid Code 11 character: '{content[i]}'.");
+            }
+        }
+
+        var data = new StringBuilder(content);
+        if (includeChecksum) {
+            var c = CalcChecksum(data.ToString(), 10);
+            data.Append(c);
+            if (content.Length >= 10) {
+                var k = CalcChecksum(data.ToString(), 9);
+                data.Append(k);
+            }
+        }
+
+        var segments = new List<BarSegment>(data.Length * 12 + 16);
+        AppendPattern(segments, Code11Tables.StartStopPattern);
+        for (var i = 0; i < data.Length; i++) {
+            BarcodeSegments.AppendBit(segments, false);
+            AppendPattern(segments, Code11Tables.EncodingTable[data[i]]);
+        }
+        BarcodeSegments.AppendBit(segments, false);
+        AppendPattern(segments, Code11Tables.StartStopPattern);
+
+        return new Barcode1D(segments);
+    }
+
+    private static void AppendPattern(List<BarSegment> segments, string pattern) {
+        for (var i = 0; i < pattern.Length; i++) {
+            var isBar = (i % 2) == 0;
+            var width = pattern[i] == '1' ? 2 : 1;
+            for (var m = 0; m < width; m++) {
+                BarcodeSegments.AppendBit(segments, isBar);
+            }
+        }
+    }
+
+    private static char CalcChecksum(string content, int maxWeight) {
+        var sum = 0;
+        var weight = 1;
+        for (var i = content.Length - 1; i >= 0; i--) {
+            var ch = content[i];
+            if (!Code11Tables.ValueTable.TryGetValue(ch, out var value)) return '-';
+            sum += value * weight;
+            weight++;
+            if (weight > maxWeight) weight = 1;
+        }
+        var check = sum % 11;
+        return check == 10 ? '-' : (char)('0' + check);
+    }
+}

--- a/CodeGlyphX/Code11/Code11Tables.cs
+++ b/CodeGlyphX/Code11/Code11Tables.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace CodeGlyphX.Code11;
+
+internal static class Code11Tables {
+    public const string StartStopPattern = "00110";
+
+    public static readonly IReadOnlyDictionary<char, string> EncodingTable = new Dictionary<char, string> {
+        { '0', "00001" },
+        { '1', "10001" },
+        { '2', "01001" },
+        { '3', "11000" },
+        { '4', "00101" },
+        { '5', "10100" },
+        { '6', "01100" },
+        { '7', "00011" },
+        { '8', "10010" },
+        { '9', "10000" },
+        { '-', "00100" }
+    };
+
+    public static readonly IReadOnlyDictionary<char, int> ValueTable = new Dictionary<char, int> {
+        { '0', 0 },
+        { '1', 1 },
+        { '2', 2 },
+        { '3', 3 },
+        { '4', 4 },
+        { '5', 5 },
+        { '6', 6 },
+        { '7', 7 },
+        { '8', 8 },
+        { '9', 9 },
+        { '-', 10 }
+    };
+}

--- a/CodeGlyphX/Code128/Code128Tables.cs
+++ b/CodeGlyphX/Code128/Code128Tables.cs
@@ -3,8 +3,10 @@ using System;
 namespace CodeGlyphX.Code128;
 
 internal static class Code128Tables {
+    public const int StartA = 103;
     public const int StartB = 104;
     public const int StartC = 105;
+    public const int CodeA = 101;
     public const int CodeC = 99;
     public const int CodeB = 100;
     public const int Fnc1 = 102;

--- a/CodeGlyphX/CodeGlyphX.csproj
+++ b/CodeGlyphX/CodeGlyphX.csproj
@@ -10,6 +10,11 @@
     <IsTrimmable>true</IsTrimmable>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\\README.md" Pack="true" PackagePath="\\" />

--- a/CodeGlyphX/Internal/EncodingUtils.cs
+++ b/CodeGlyphX/Internal/EncodingUtils.cs
@@ -3,6 +3,8 @@ using System.Text;
 namespace CodeGlyphX.Internal;
 
 internal static class EncodingUtils {
+    internal static Encoding Utf8Strict { get; } = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     internal static Encoding Latin1 {
         get {
 #if NET7_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER

--- a/CodeGlyphX/Internal/QrEncoding.cs
+++ b/CodeGlyphX/Internal/QrEncoding.cs
@@ -78,20 +78,28 @@ internal static class QrEncoding {
 
     public static string Decode(QrTextEncoding encoding, byte[] bytes) {
         if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-        if (bytes.Length == 0) return string.Empty;
+        return Decode(encoding, bytes, 0, bytes.Length);
+    }
+
+    public static string Decode(QrTextEncoding encoding, byte[] bytes, int offset, int length) {
+        if (bytes is null) throw new ArgumentNullException(nameof(bytes));
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+        if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+        if (offset + length > bytes.Length) throw new ArgumentOutOfRangeException(nameof(length));
+        if (length == 0) return string.Empty;
 
         return encoding switch {
-            QrTextEncoding.Utf8 => Encoding.UTF8.GetString(bytes),
-            QrTextEncoding.Ascii => Encoding.ASCII.GetString(bytes),
-            QrTextEncoding.Latin1 => DecodeSingleByte(bytes, LATIN1),
-            QrTextEncoding.Iso8859_2 => DecodeSingleByte(bytes, ISO8859_2),
-            QrTextEncoding.Iso8859_4 => DecodeSingleByte(bytes, ISO8859_4),
-            QrTextEncoding.Iso8859_5 => DecodeSingleByte(bytes, ISO8859_5),
-            QrTextEncoding.Iso8859_7 => DecodeSingleByte(bytes, ISO8859_7),
-            QrTextEncoding.Iso8859_10 => DecodeSingleByte(bytes, ISO8859_10),
-            QrTextEncoding.Iso8859_15 => DecodeSingleByte(bytes, ISO8859_15),
-            QrTextEncoding.ShiftJis => QrShiftJis.Decode(bytes),
-            _ => Encoding.UTF8.GetString(bytes)
+            QrTextEncoding.Utf8 => Encoding.UTF8.GetString(bytes, offset, length),
+            QrTextEncoding.Ascii => Encoding.ASCII.GetString(bytes, offset, length),
+            QrTextEncoding.Latin1 => DecodeSingleByte(bytes, offset, length, LATIN1),
+            QrTextEncoding.Iso8859_2 => DecodeSingleByte(bytes, offset, length, ISO8859_2),
+            QrTextEncoding.Iso8859_4 => DecodeSingleByte(bytes, offset, length, ISO8859_4),
+            QrTextEncoding.Iso8859_5 => DecodeSingleByte(bytes, offset, length, ISO8859_5),
+            QrTextEncoding.Iso8859_7 => DecodeSingleByte(bytes, offset, length, ISO8859_7),
+            QrTextEncoding.Iso8859_10 => DecodeSingleByte(bytes, offset, length, ISO8859_10),
+            QrTextEncoding.Iso8859_15 => DecodeSingleByte(bytes, offset, length, ISO8859_15),
+            QrTextEncoding.ShiftJis => QrShiftJis.Decode(bytes, offset, length),
+            _ => Encoding.UTF8.GetString(bytes, offset, length)
         };
     }
 
@@ -120,10 +128,10 @@ internal static class QrEncoding {
         return true;
     }
 
-    private static string DecodeSingleByte(byte[] bytes, char[] table) {
-        var chars = new char[bytes.Length];
-        for (var i = 0; i < bytes.Length; i++) {
-            chars[i] = table[bytes[i]];
+    private static string DecodeSingleByte(byte[] bytes, int offset, int length, char[] table) {
+        var chars = new char[length];
+        for (var i = 0; i < length; i++) {
+            chars[i] = table[bytes[offset + i]];
         }
         return new string(chars);
     }

--- a/CodeGlyphX/Msi/MsiEncoder.cs
+++ b/CodeGlyphX/Msi/MsiEncoder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using CodeGlyphX.Internal;
+
+namespace CodeGlyphX.Msi;
+
+/// <summary>
+/// Encodes MSI (Modified Plessey) barcodes.
+/// </summary>
+public static class MsiEncoder {
+    /// <summary>
+    /// Encodes an MSI barcode.
+    /// </summary>
+    public static Barcode1D Encode(string content, MsiChecksumType checksum = MsiChecksumType.Mod10) {
+        if (content is null) throw new ArgumentNullException(nameof(content));
+        if (content.Length == 0) throw new InvalidOperationException("MSI content cannot be empty.");
+
+        for (var i = 0; i < content.Length; i++) {
+            if (!char.IsDigit(content[i])) {
+                throw new InvalidOperationException("MSI supports digits only.");
+            }
+        }
+
+        var data = content;
+        switch (checksum) {
+            case MsiChecksumType.None:
+                break;
+            case MsiChecksumType.Mod10:
+                data += CalcMod10(data);
+                break;
+            case MsiChecksumType.Mod10Mod10:
+                data += CalcMod10(data);
+                data += CalcMod10(data);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(checksum));
+        }
+
+        var segments = new List<BarSegment>(data.Length * 12 + 16);
+        AppendPattern(segments, MsiTables.Start);
+        for (var i = 0; i < data.Length; i++) {
+            if (!MsiTables.DigitPatterns.TryGetValue(data[i], out var pattern)) {
+                throw new InvalidOperationException("MSI supports digits only.");
+            }
+            AppendPattern(segments, pattern);
+        }
+        AppendPattern(segments, MsiTables.Stop);
+
+        return new Barcode1D(segments);
+    }
+
+    private static void AppendPattern(List<BarSegment> segments, string pattern) {
+        for (var i = 0; i < pattern.Length; i++) {
+            BarcodeSegments.AppendBit(segments, pattern[i] == '1');
+        }
+    }
+
+    private static char CalcMod10(string content) {
+        var sum = 0;
+        var doubleIt = true;
+        for (var i = content.Length - 1; i >= 0; i--) {
+            var digit = content[i] - '0';
+            if (doubleIt) {
+                digit *= 2;
+                if (digit > 9) digit = (digit / 10) + (digit % 10);
+            }
+            sum += digit;
+            doubleIt = !doubleIt;
+        }
+        var mod = sum % 10;
+        var check = mod == 0 ? 0 : 10 - mod;
+        return (char)('0' + check);
+    }
+}

--- a/CodeGlyphX/Msi/MsiTables.cs
+++ b/CodeGlyphX/Msi/MsiTables.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace CodeGlyphX.Msi;
+
+internal static class MsiTables {
+    public const string Start = "110";
+    public const string Stop = "1001";
+
+    public static readonly IReadOnlyDictionary<char, string> DigitPatterns = new Dictionary<char, string> {
+        { '0', "100100100100" },
+        { '1', "100100100110" },
+        { '2', "100100110100" },
+        { '3', "100100110110" },
+        { '4', "100110100100" },
+        { '5', "100110100110" },
+        { '6', "100110110100" },
+        { '7', "100110110110" },
+        { '8', "110100100100" },
+        { '9', "110100100110" }
+    };
+}

--- a/CodeGlyphX/MsiChecksumType.cs
+++ b/CodeGlyphX/MsiChecksumType.cs
@@ -1,0 +1,19 @@
+namespace CodeGlyphX;
+
+/// <summary>
+/// Checksum variants for MSI barcodes.
+/// </summary>
+public enum MsiChecksumType {
+    /// <summary>
+    /// No checksum digit.
+    /// </summary>
+    None,
+    /// <summary>
+    /// Mod 10 (Luhn-style) checksum.
+    /// </summary>
+    Mod10,
+    /// <summary>
+    /// Two consecutive Mod 10 checksum digits.
+    /// </summary>
+    Mod10Mod10
+}

--- a/CodeGlyphX/Payloads/QrParsedData.cs
+++ b/CodeGlyphX/Payloads/QrParsedData.cs
@@ -41,4 +41,7 @@ public static class QrParsedData {
 
     /// <summary>Social profile payload.</summary>
     public sealed record Social(string Raw, string? Network, string? HandleOrUrl);
+
+    /// <summary>Bookmark payload.</summary>
+    public sealed record Bookmark(string Url, string? Title);
 }

--- a/CodeGlyphX/Payloads/QrPayloadEnums.cs
+++ b/CodeGlyphX/Payloads/QrPayloadEnums.cs
@@ -259,6 +259,30 @@ public enum QrBezahlAuthorityType {
 }
 
 /// <summary>
+/// BezahlCode periodic time unit.
+/// </summary>
+public enum QrBezahlPeriodicUnit {
+    /// <summary>
+    /// Weekly interval.
+    /// </summary>
+    Weekly,
+    /// <summary>
+    /// Monthly interval.
+    /// </summary>
+    Monthly
+}
+
+/// <summary>
+/// Encoding marker for Russia payment order payloads.
+/// </summary>
+public enum QrRussiaPaymentEncoding {
+    /// <summary>
+    /// UTF-8 (ST00012).
+    /// </summary>
+    Utf8
+}
+
+/// <summary>
 /// Swiss QR currency codes.
 /// </summary>
 public enum QrSwissCurrency {

--- a/CodeGlyphX/Payloads/QrPayloadParseOptions.cs
+++ b/CodeGlyphX/Payloads/QrPayloadParseOptions.cs
@@ -1,0 +1,15 @@
+namespace CodeGlyphX.Payloads;
+
+/// <summary>
+/// Options controlling payload parsing and validation.
+/// </summary>
+public sealed class QrPayloadParseOptions {
+    /// <summary>
+    /// When enabled, parsed payloads are validated against stricter schema rules.
+    /// </summary>
+    public bool Strict { get; set; }
+    /// <summary>
+    /// Whether unknown Wi-Fi auth types are allowed in strict mode.
+    /// </summary>
+    public bool AllowUnknownWifiAuth { get; set; } = false;
+}

--- a/CodeGlyphX/Payloads/QrPayloadType.cs
+++ b/CodeGlyphX/Payloads/QrPayloadType.cs
@@ -31,5 +31,7 @@ public enum QrPayloadType {
     /// <summary>App Store payload.</summary>
     AppStore,
     /// <summary>Social profile payload.</summary>
-    Social
+    Social,
+    /// <summary>Bookmark payload.</summary>
+    Bookmark
 }

--- a/CodeGlyphX/Payloads/QrPayloadValidation.cs
+++ b/CodeGlyphX/Payloads/QrPayloadValidation.cs
@@ -60,4 +60,72 @@ internal static class QrPayloadValidation {
         }
         return (10 - carry) % 10 == digits[digits.Length - 1] - '0';
     }
+
+    public static bool IsValidEmail(string? address) {
+        if (address is null) return false;
+        if (IsWhiteSpace(address)) return false;
+        var at = address.IndexOf('@');
+        if (at <= 0 || at == address.Length - 1) return false;
+        var dot = address.IndexOf('.', at + 1);
+        return dot > at + 1 && dot < address.Length - 1;
+    }
+
+    public static bool IsValidPhone(string? number) {
+        if (number is null) return false;
+        if (IsWhiteSpace(number)) return false;
+        var digits = 0;
+        for (var i = 0; i < number.Length; i++) {
+            var ch = number[i];
+            if (char.IsDigit(ch)) {
+                digits++;
+                continue;
+            }
+            if (ch is '+' or '-' or ' ' or '(' or ')' or '.') continue;
+            return false;
+        }
+        return digits >= 3;
+    }
+
+    public static bool IsValidUrl(string? url) {
+        if (url is null) return false;
+        if (IsWhiteSpace(url)) return false;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
+    }
+
+    public static bool IsValidCurrency(string? currency) {
+        if (currency is null) return false;
+        if (IsWhiteSpace(currency)) return false;
+        if (currency.Length != 3) return false;
+        for (var i = 0; i < currency.Length; i++) {
+            if (!char.IsLetter(currency[i])) return false;
+        }
+        return true;
+    }
+
+    public static bool IsValidUpiVpa(string? vpa) {
+        if (vpa is null) return false;
+        if (IsWhiteSpace(vpa)) return false;
+        var at = vpa.IndexOf('@');
+        if (at <= 0 || at == vpa.Length - 1) return false;
+        if (vpa.IndexOf(' ') >= 0) return false;
+        return true;
+    }
+
+    public static bool IsValidWifiAuth(string? auth) {
+        if (auth is null) return true;
+        if (IsWhiteSpace(auth)) return true;
+        return auth.Equals("WEP", StringComparison.OrdinalIgnoreCase)
+               || auth.Equals("WPA", StringComparison.OrdinalIgnoreCase)
+               || auth.Equals("WPA2", StringComparison.OrdinalIgnoreCase)
+               || auth.Equals("WPA3", StringComparison.OrdinalIgnoreCase)
+               || auth.Equals("nopass", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsWhiteSpace(string value) {
+        for (var i = 0; i < value.Length; i++) {
+            if (!char.IsWhiteSpace(value[i])) return false;
+        }
+        return true;
+    }
 }

--- a/CodeGlyphX/Payloads/QrPayloadValidationResult.cs
+++ b/CodeGlyphX/Payloads/QrPayloadValidationResult.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace CodeGlyphX.Payloads;
+
+/// <summary>
+/// Validation result for parsed QR payloads.
+/// </summary>
+public sealed class QrPayloadValidationResult {
+    private readonly List<string> _errors = new();
+
+    /// <summary>
+    /// Gets validation errors, if any.
+    /// </summary>
+    public IReadOnlyList<string> Errors => _errors;
+
+    /// <summary>
+    /// Returns true when there are no validation errors.
+    /// </summary>
+    public bool IsValid => _errors.Count == 0;
+
+    internal void Add(string message) {
+        _errors.Add(message);
+    }
+}

--- a/CodeGlyphX/Payloads/QrPayloads.Core.cs
+++ b/CodeGlyphX/Payloads/QrPayloads.Core.cs
@@ -23,7 +23,12 @@ public static partial class QrPayloads {
     /// Builds a bookmark payload (MEBKM).
     /// </summary>
     public static QrPayloadData Bookmark(string url, string title) {
-        var payload = "MEBKM:TITLE:" + EscapeInput(title ?? string.Empty) + ";URL:" + EscapeInput(url ?? string.Empty) + ";;";
+        if (string.IsNullOrWhiteSpace(url)) throw new ArgumentException("URL must not be empty.", nameof(url));
+        var safeUrl = EscapeInput(NormalizeUrl(url));
+        var safeTitle = EscapeInput(title ?? string.Empty);
+        var payload = string.IsNullOrEmpty(safeTitle)
+            ? "MEBKM:URL:" + safeUrl + ";;"
+            : "MEBKM:TITLE:" + safeTitle + ";URL:" + safeUrl + ";;";
         return new QrPayloadData(payload);
     }
 

--- a/CodeGlyphX/Payloads/QrPayloads.Wrappers.cs
+++ b/CodeGlyphX/Payloads/QrPayloads.Wrappers.cs
@@ -18,6 +18,14 @@ public static partial class QrPayloads {
     }
 
     /// <summary>
+    /// Builds a Russia payment order payload.
+    /// </summary>
+    public static QrPayloadData RussiaPaymentOrder(RussiaPaymentOrderPayload payload) {
+        if (payload is null) throw new System.ArgumentNullException(nameof(payload));
+        return payload.ToPayloadData();
+    }
+
+    /// <summary>
     /// Builds a BezahlCode payload (contact).
     /// </summary>
     public static QrPayloadData BezahlCode(

--- a/CodeGlyphX/Payloads/RussiaPaymentOrderPayload.cs
+++ b/CodeGlyphX/Payloads/RussiaPaymentOrderPayload.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace CodeGlyphX.Payloads;
+
+/// <summary>
+/// Russia payment order payload (ST00012, UTF-8).
+/// </summary>
+public sealed class RussiaPaymentOrderPayload {
+    private readonly Dictionary<string, string> _additionalFields = new();
+    private readonly QrRussiaPaymentEncoding _encoding;
+    private readonly string _name;
+    private readonly string _personalAcc;
+    private readonly string _bankName;
+    private readonly string _bic;
+    private readonly string _correspAcc;
+    private readonly string _payeeInn;
+    private readonly string _kpp;
+    private readonly long _sumKopeks;
+    private readonly string _purpose;
+
+    /// <summary>
+    /// Optional payer last name.
+    /// </summary>
+    public string? LastName { get; set; }
+    /// <summary>
+    /// Optional payer first name.
+    /// </summary>
+    public string? FirstName { get; set; }
+    /// <summary>
+    /// Optional payer middle name.
+    /// </summary>
+    public string? MiddleName { get; set; }
+    /// <summary>
+    /// Optional payer address.
+    /// </summary>
+    public string? PayerAddress { get; set; }
+    /// <summary>
+    /// Optional KPP (tax registration reason code).
+    /// </summary>
+    public string? Kpp => _kpp;
+    /// <summary>
+    /// Optional OKTMO code.
+    /// </summary>
+    public string? Oktmo { get; set; }
+    /// <summary>
+    /// Optional CBC (budget classification code).
+    /// </summary>
+    public string? Cbc { get; set; }
+    /// <summary>
+    /// Optional UIN (unique accrual identifier).
+    /// </summary>
+    public string? Uin { get; set; }
+    /// <summary>
+    /// Optional AIP identifier.
+    /// </summary>
+    public string? Aip { get; set; }
+
+    /// <summary>
+    /// Additional custom fields appended to the payload.
+    /// </summary>
+    public IDictionary<string, string> AdditionalFields => _additionalFields;
+
+    /// <summary>
+    /// Creates a Russia payment order payload.
+    /// </summary>
+    public RussiaPaymentOrderPayload(
+        string name,
+        string personalAcc,
+        string bankName,
+        string bic,
+        string correspAcc,
+        string payeeInn,
+        string kpp,
+        decimal sum,
+        string purpose,
+        QrRussiaPaymentEncoding encoding = QrRussiaPaymentEncoding.Utf8) {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name must not be empty.", nameof(name));
+        if (string.IsNullOrWhiteSpace(personalAcc)) throw new ArgumentException("PersonalAcc must not be empty.", nameof(personalAcc));
+        if (string.IsNullOrWhiteSpace(bankName)) throw new ArgumentException("BankName must not be empty.", nameof(bankName));
+        if (string.IsNullOrWhiteSpace(bic)) throw new ArgumentException("BIC must not be empty.", nameof(bic));
+        if (string.IsNullOrWhiteSpace(correspAcc)) throw new ArgumentException("CorrespAcc must not be empty.", nameof(correspAcc));
+        if (string.IsNullOrWhiteSpace(payeeInn)) throw new ArgumentException("PayeeINN must not be empty.", nameof(payeeInn));
+        if (string.IsNullOrWhiteSpace(kpp)) throw new ArgumentException("KPP must not be empty.", nameof(kpp));
+        if (string.IsNullOrWhiteSpace(purpose)) throw new ArgumentException("Purpose must not be empty.", nameof(purpose));
+
+        _name = name;
+        _personalAcc = personalAcc;
+        _bankName = bankName;
+        _bic = bic;
+        _correspAcc = correspAcc;
+        _payeeInn = payeeInn;
+        _kpp = kpp;
+        _purpose = purpose;
+        _encoding = encoding;
+        _sumKopeks = ToKopeks(sum);
+    }
+
+    /// <summary>
+    /// Returns the Russia payment order payload string.
+    /// </summary>
+    public string ToPayloadString() {
+        var sb = new StringBuilder();
+        sb.Append("ST0001").Append(MapEncoding(_encoding));
+
+        AppendField(sb, "Name", _name);
+        AppendField(sb, "PersonalAcc", _personalAcc);
+        AppendField(sb, "BankName", _bankName);
+        AppendField(sb, "BIC", _bic);
+        AppendField(sb, "CorrespAcc", _correspAcc);
+        AppendField(sb, "PayeeINN", _payeeInn);
+        AppendField(sb, "KPP", _kpp);
+        AppendField(sb, "CBC", Cbc);
+        AppendField(sb, "OKTMO", Oktmo);
+        AppendField(sb, "Sum", _sumKopeks.ToString(CultureInfo.InvariantCulture));
+        AppendField(sb, "LastName", LastName);
+        AppendField(sb, "FirstName", FirstName);
+        AppendField(sb, "MiddleName", MiddleName);
+        AppendField(sb, "PayerAddress", PayerAddress);
+        AppendField(sb, "AIP", Aip);
+        AppendField(sb, "UIN", Uin);
+        AppendField(sb, "Purpose", _purpose);
+
+        foreach (var kvp in _additionalFields) {
+            AppendField(sb, kvp.Key, kvp.Value);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Converts the payload to a QR payload wrapper.
+    /// </summary>
+    public QrPayloadData ToPayloadData() {
+        return new QrPayloadData(ToPayloadString(), QrErrorCorrectionLevel.M, textEncoding: QrTextEncoding.Utf8);
+    }
+
+    private static void AppendField(StringBuilder sb, string key, string? value) {
+        if (value is null || value.Length == 0) return;
+        if (value.IndexOf('|') >= 0 || value.IndexOf('=') >= 0) {
+            throw new ArgumentException("Field values cannot contain '|' or '='.");
+        }
+        sb.Append('|').Append(key).Append('=').Append(value);
+    }
+
+    private static string MapEncoding(QrRussiaPaymentEncoding encoding) {
+        return encoding switch {
+            QrRussiaPaymentEncoding.Utf8 => "2",
+            _ => "2"
+        };
+    }
+
+    private static long ToKopeks(decimal amount) {
+        if (amount <= 0) throw new ArgumentOutOfRangeException(nameof(amount), "Amount must be greater than zero.");
+        var kopeks = decimal.Round(amount * 100m, 0, MidpointRounding.AwayFromZero);
+        return (long)kopeks;
+    }
+}

--- a/CodeGlyphX/Plessey/PlesseyEncoder.cs
+++ b/CodeGlyphX/Plessey/PlesseyEncoder.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using CodeGlyphX.Internal;
+
+namespace CodeGlyphX.Plessey;
+
+/// <summary>
+/// Encodes Plessey barcodes.
+/// </summary>
+public static class PlesseyEncoder {
+    /// <summary>
+    /// Encodes a Plessey barcode (hex digits only).
+    /// </summary>
+    public static Barcode1D Encode(string content) {
+        if (content is null) throw new ArgumentNullException(nameof(content));
+        if (content.Length == 0) throw new InvalidOperationException("Plessey content cannot be empty.");
+
+        var bits = new List<bool>(content.Length * 4 + 16);
+        for (var i = 0; i < content.Length; i++) {
+            var ch = char.ToUpperInvariant(content[i]);
+            if (!PlesseyTables.HexValues.TryGetValue(ch, out var value)) {
+                throw new InvalidOperationException($"Invalid Plessey hex digit: '{content[i]}'.");
+            }
+            for (var b = 0; b < 4; b++) {
+                bits.Add(((value >> b) & 1) != 0);
+            }
+        }
+
+        var crc = CalcCrc(bits);
+        for (var b = 0; b < 8; b++) {
+            bits.Add(((crc >> b) & 1) != 0);
+        }
+
+        var segments = new List<BarSegment>(bits.Count * 4 + 32);
+        AppendBits(segments, PlesseyTables.StartBits, reverse: false);
+        for (var i = 0; i < bits.Count; i++) {
+            AppendBitPair(segments, bits[i]);
+        }
+        AppendTerminationBar(segments);
+        AppendBits(segments, PlesseyTables.StopBits, reverse: true);
+
+        return new Barcode1D(segments);
+    }
+
+    private static void AppendBits(List<BarSegment> segments, string bits, bool reverse) {
+        for (var i = 0; i < bits.Length; i++) {
+            AppendBitPair(segments, bits[i] == '1', reverse);
+        }
+    }
+
+    private static void AppendBitPair(List<BarSegment> segments, bool bit, bool reverse = false) {
+        var wideBar = bit ? 2 : 1;
+        var wideSpace = bit ? 1 : 2;
+        if (!reverse) {
+            AppendElements(segments, true, wideBar);
+            AppendElements(segments, false, wideSpace);
+        } else {
+            AppendElements(segments, false, wideSpace);
+            AppendElements(segments, true, wideBar);
+        }
+    }
+
+    private static void AppendTerminationBar(List<BarSegment> segments) {
+        AppendElements(segments, true, 2);
+    }
+
+    private static void AppendElements(List<BarSegment> segments, bool isBar, int width) {
+        for (var i = 0; i < width; i++) {
+            BarcodeSegments.AppendBit(segments, isBar);
+        }
+    }
+
+    private static byte CalcCrc(List<bool> bits) {
+        const int poly = 0x1E9;
+        var crc = 0;
+        for (var i = 0; i < bits.Count; i++) {
+            crc = (crc << 1) | (bits[i] ? 1 : 0);
+            if ((crc & 0x100) != 0) crc ^= poly;
+        }
+        for (var i = 0; i < 8; i++) {
+            crc <<= 1;
+            if ((crc & 0x100) != 0) crc ^= poly;
+        }
+        return (byte)(crc & 0xFF);
+    }
+}

--- a/CodeGlyphX/Plessey/PlesseyTables.cs
+++ b/CodeGlyphX/Plessey/PlesseyTables.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace CodeGlyphX.Plessey;
+
+internal static class PlesseyTables {
+    public const string StartBits = "1101";
+    public const string StopBits = "0011";
+
+    public static readonly IReadOnlyDictionary<char, int> HexValues = new Dictionary<char, int> {
+        { '0', 0 }, { '1', 1 }, { '2', 2 }, { '3', 3 }, { '4', 4 }, { '5', 5 }, { '6', 6 }, { '7', 7 },
+        { '8', 8 }, { '9', 9 }, { 'A', 10 }, { 'B', 11 }, { 'C', 12 }, { 'D', 13 }, { 'E', 14 }, { 'F', 15 }
+    };
+}

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -523,6 +523,13 @@ public static class QR {
     }
 
     /// <summary>
+    /// Attempts to parse a raw QR payload into a structured representation with optional validation.
+    /// </summary>
+    public static bool TryParsePayload(string payload, QrPayloadParseOptions? options, out QrParsedPayload parsed, out QrPayloadValidationResult validation) {
+        return QrPayloadParser.TryParse(payload, options, out parsed, out validation);
+    }
+
+    /// <summary>
     /// Parses a raw QR payload into a structured representation.
     /// </summary>
     public static QrParsedPayload ParsePayload(string payload) {

--- a/CodeGlyphX/Qr/QrDecoder.cs
+++ b/CodeGlyphX/Qr/QrDecoder.cs
@@ -715,6 +715,6 @@ public static class QrDecoder {
     }
 
     private static string DecodeSegment(QrPayloadSegment segment) {
-        return QrEncoding.Decode(segment.Encoding, segment.Bytes);
+        return QrEncoding.Decode(segment.Encoding, segment.Buffer, segment.Offset, segment.Length);
     }
 }

--- a/CodeGlyphX/Qr/QrPayloadParser.cs
+++ b/CodeGlyphX/Qr/QrPayloadParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using CodeGlyphX;
 
@@ -6,12 +7,21 @@ namespace CodeGlyphX.Qr;
 
 internal readonly struct QrPayloadSegment {
     public QrTextEncoding Encoding { get; }
-    public byte[] Bytes { get; }
+    public byte[] Buffer { get; }
+    public int Offset { get; }
+    public int Length { get; }
 
-    public QrPayloadSegment(QrTextEncoding encoding, byte[] bytes) {
+    public QrPayloadSegment(QrTextEncoding encoding, byte[] buffer, int offset, int length) {
         Encoding = encoding;
-        Bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+        Buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+        if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+        if (offset + length > buffer.Length) throw new ArgumentOutOfRangeException(nameof(length));
+        Offset = offset;
+        Length = length;
     }
+
+    public ReadOnlySpan<byte> Span => new ReadOnlySpan<byte>(Buffer, Offset, Length);
 }
 
 internal static class QrPayloadParser {
@@ -42,214 +52,254 @@ internal static class QrPayloadParser {
             return val;
         }
 
-        var bytes = new List<byte>(64);
-        var segmentBytes = new List<byte>(64);
-        var segmentList = new List<QrPayloadSegment>(4);
+        var segmentList = new List<(QrTextEncoding encoding, int start, int length)>(4);
         var encoding = QrTextEncoding.Latin1;
+        var segmentStart = 0;
+        var segmentLength = 0;
+        var buffer = ArrayPool<byte>.Shared.Rent(64);
+        var count = 0;
 
         void AddByte(byte b) {
-            bytes.Add(b);
-            segmentBytes.Add(b);
+            if (count == buffer.Length) {
+                var next = ArrayPool<byte>.Shared.Rent(buffer.Length * 2);
+                Buffer.BlockCopy(buffer, 0, next, 0, count);
+                ArrayPool<byte>.Shared.Return(buffer);
+                buffer = next;
+            }
+            buffer[count++] = b;
+            segmentLength++;
         }
 
         void FlushSegment() {
-            if (segmentBytes.Count == 0) return;
-            segmentList.Add(new QrPayloadSegment(encoding, segmentBytes.ToArray()));
-            segmentBytes.Clear();
+            if (segmentLength == 0) return;
+            segmentList.Add((encoding, segmentStart, segmentLength));
+            segmentStart = count;
+            segmentLength = 0;
         }
 
-        while (true) {
-            var mode = ReadBits(4);
-            if (mode < 0) {
-                // Some encoders omit an explicit terminator if the payload exactly fills the available space,
-                // or leave <4 padding bits that can't form a mode indicator. Accept only zero padding.
-                var remaining = bitLen - bitPos;
-                if (remaining <= 0) break;
-                if (remaining < 4 && AreRemainingBitsZero(dataCodewords, bitPos, bitLen)) break;
+        try {
+            while (true) {
+                var mode = ReadBits(4);
+                if (mode < 0) {
+                    // Some encoders omit an explicit terminator if the payload exactly fills the available space,
+                    // or leave <4 padding bits that can't form a mode indicator. Accept only zero padding.
+                    var remaining = bitLen - bitPos;
+                    if (remaining <= 0) break;
+                    if (remaining < 4 && AreRemainingBitsZero(dataCodewords, bitPos, bitLen)) break;
+                    return false;
+                }
+
+                if (mode == 0) {
+                    FlushSegment();
+                    payload = count == 0 ? Array.Empty<byte>() : SliceBuffer(buffer, count);
+                    if (segmentList.Count == 0) {
+                        segments = Array.Empty<QrPayloadSegment>();
+                    } else {
+                        segments = new QrPayloadSegment[segmentList.Count];
+                        for (var i = 0; i < segmentList.Count; i++) {
+                            var seg = segmentList[i];
+                            segments[i] = new QrPayloadSegment(seg.encoding, payload, seg.start, seg.length);
+                        }
+                    }
+                    return true;
+                }
+
+                if (mode == 0b0101) {
+                    // FNC1 (first position)
+                    fnc1Mode = QrFnc1Mode.FirstPosition;
+                    continue;
+                }
+
+                if (mode == 0b1001) {
+                    // FNC1 (second position)
+                    fnc1Mode = QrFnc1Mode.SecondPosition;
+                    continue;
+                }
+
+                if (mode == 0b0100) {
+                    var countBits = QrTables.GetByteModeCharCountBits(version);
+                    var charCount = ReadBits(countBits);
+                    if (charCount < 0) return false;
+
+                    for (var i = 0; i < charCount; i++) {
+                        var b = ReadBits(8);
+                        if (b < 0) return false;
+                        AddByte((byte)b);
+                    }
+
+                    continue;
+                }
+
+                if (mode == 0b1000) {
+                    // Kanji mode (Shift-JIS JIS X 0208)
+                    var countBits = QrTables.GetKanjiModeCharCountBits(version);
+                    var charCount = ReadBits(countBits);
+                    if (charCount < 0) return false;
+
+                    FlushSegment();
+                    var previousEncoding = encoding;
+                    encoding = QrTextEncoding.ShiftJis;
+
+                    for (var i = 0; i < charCount; i++) {
+                        var v = ReadBits(13);
+                        if (v < 0) return false;
+                        var assembled = ((v / 0xC0) << 8) | (v % 0xC0);
+                        var sjis = assembled < 0x1F00 ? assembled + 0x8140 : assembled + 0xC140;
+                        AddByte((byte)(sjis >> 8));
+                        AddByte((byte)sjis);
+                    }
+
+                    FlushSegment();
+                    encoding = previousEncoding;
+                    continue;
+                }
+
+                if (mode == 0b0011) {
+                    // Structured append: 8-bit sequence indicator + 8-bit parity.
+                    var sequence = ReadBits(8);
+                    var parity = ReadBits(8);
+                    if (sequence < 0 || parity < 0) return false;
+
+                    var index = (sequence >> 4) & 0x0F;
+                    var total = sequence & 0x0F;
+                    structuredAppend = new QrStructuredAppend(index, total, parity);
+                    continue;
+                }
+
+                if (mode == 0b0001) {
+                    // Numeric mode
+                    var countBits = QrTables.GetNumericModeCharCountBits(version);
+                    var charCount = ReadBits(countBits);
+                    if (charCount < 0) return false;
+
+                    var remaining = charCount;
+                    while (remaining >= 3) {
+                        var v = ReadBits(10);
+                        if (v < 0 || v > 999) return false;
+                        AddByte((byte)('0' + (v / 100)));
+                        AddByte((byte)('0' + ((v / 10) % 10)));
+                        AddByte((byte)('0' + (v % 10)));
+                        remaining -= 3;
+                    }
+
+                    if (remaining == 2) {
+                        var v = ReadBits(7);
+                        if (v < 0 || v > 99) return false;
+                        AddByte((byte)('0' + (v / 10)));
+                        AddByte((byte)('0' + (v % 10)));
+                    } else if (remaining == 1) {
+                        var v = ReadBits(4);
+                        if (v < 0 || v > 9) return false;
+                        AddByte((byte)('0' + v));
+                    }
+
+                    continue;
+                }
+
+                if (mode == 0b0010) {
+                    // Alphanumeric mode
+                    var countBits = QrTables.GetAlphanumericModeCharCountBits(version);
+                    var charCount = ReadBits(countBits);
+                    if (charCount < 0) return false;
+
+                    var remaining = charCount;
+                    var raw = ArrayPool<byte>.Shared.Rent(charCount > 0 ? charCount : 1);
+                    var rawLen = 0;
+                    try {
+                        while (remaining >= 2) {
+                            var v = ReadBits(11);
+                            if (v < 0 || v >= 45 * 45) return false;
+                            var a = v / 45;
+                            var b = v % 45;
+                            raw[rawLen++] = (byte)AlphanumericTable[a];
+                            raw[rawLen++] = (byte)AlphanumericTable[b];
+                            remaining -= 2;
+                        }
+
+                        if (remaining == 1) {
+                            var v = ReadBits(6);
+                            if (v < 0 || v >= 45) return false;
+                            raw[rawLen++] = (byte)AlphanumericTable[v];
+                        }
+
+                        if (fnc1Mode != QrFnc1Mode.None) {
+                            for (var i = 0; i < rawLen; i++) {
+                                var b = raw[i];
+                                if (b == (byte)'%') {
+                                    if (i + 1 < rawLen && raw[i + 1] == (byte)'%') {
+                                        AddByte((byte)'%');
+                                        i++;
+                                        continue;
+                                    }
+                                    AddByte(0x1D); // GS separator
+                                    continue;
+                                }
+                                AddByte(b);
+                            }
+                        } else {
+                            for (var i = 0; i < rawLen; i++) {
+                                AddByte(raw[i]);
+                            }
+                        }
+                    } finally {
+                        ArrayPool<byte>.Shared.Return(raw);
+                    }
+
+                    continue;
+                }
+
+                if (mode == 0b0111) {
+                    if (!TryReadEciAssignmentNumber(ReadBits, out var assignmentNumber)) return false;
+
+                    // Minimal set for OTP / URL QR use cases.
+                    var newEncoding = assignmentNumber switch {
+                        3 => QrTextEncoding.Latin1,      // ISO-8859-1
+                        4 => QrTextEncoding.Iso8859_2,   // ISO-8859-2
+                        6 => QrTextEncoding.Iso8859_4,   // ISO-8859-4
+                        7 => QrTextEncoding.Iso8859_5,   // ISO-8859-5
+                        9 => QrTextEncoding.Iso8859_7,   // ISO-8859-7
+                        12 => QrTextEncoding.Iso8859_10, // ISO-8859-10
+                        15 => QrTextEncoding.Iso8859_15, // ISO-8859-15
+                        20 => QrTextEncoding.ShiftJis,   // Shift-JIS
+                        26 => QrTextEncoding.Utf8,       // UTF-8
+                        27 => QrTextEncoding.Ascii,      // US-ASCII
+                        _ => encoding,
+                    };
+
+                    if (newEncoding != encoding) {
+                        FlushSegment();
+                        encoding = newEncoding;
+                    }
+
+                    // Unknown ECI: accept but keep current encoding (best-effort).
+                    continue;
+                }
+
                 return false;
             }
 
-            if (mode == 0) {
-                FlushSegment();
-                payload = bytes.Count == 0 ? Array.Empty<byte>() : bytes.ToArray();
-                segments = segmentList.Count == 0 ? Array.Empty<QrPayloadSegment>() : segmentList.ToArray();
-                return true;
-            }
-
-            if (mode == 0b0101) {
-                // FNC1 (first position)
-                fnc1Mode = QrFnc1Mode.FirstPosition;
-                continue;
-            }
-
-            if (mode == 0b1001) {
-                // FNC1 (second position)
-                fnc1Mode = QrFnc1Mode.SecondPosition;
-                continue;
-            }
-
-            if (mode == 0b0100) {
-                var countBits = QrTables.GetByteModeCharCountBits(version);
-                var count = ReadBits(countBits);
-                if (count < 0) return false;
-
-                for (var i = 0; i < count; i++) {
-                    var b = ReadBits(8);
-                    if (b < 0) return false;
-                    AddByte((byte)b);
+            FlushSegment();
+            payload = count == 0 ? Array.Empty<byte>() : SliceBuffer(buffer, count);
+            if (segmentList.Count == 0) {
+                segments = Array.Empty<QrPayloadSegment>();
+            } else {
+                segments = new QrPayloadSegment[segmentList.Count];
+                for (var i = 0; i < segmentList.Count; i++) {
+                    var seg = segmentList[i];
+                    segments[i] = new QrPayloadSegment(seg.encoding, payload, seg.start, seg.length);
                 }
-
-                continue;
             }
-
-            if (mode == 0b1000) {
-                // Kanji mode (Shift-JIS JIS X 0208)
-                var countBits = QrTables.GetKanjiModeCharCountBits(version);
-                var count = ReadBits(countBits);
-                if (count < 0) return false;
-
-                FlushSegment();
-                var previousEncoding = encoding;
-                encoding = QrTextEncoding.ShiftJis;
-
-                for (var i = 0; i < count; i++) {
-                    var v = ReadBits(13);
-                    if (v < 0) return false;
-                    var assembled = ((v / 0xC0) << 8) | (v % 0xC0);
-                    var sjis = assembled < 0x1F00 ? assembled + 0x8140 : assembled + 0xC140;
-                    AddByte((byte)(sjis >> 8));
-                    AddByte((byte)sjis);
-                }
-
-                FlushSegment();
-                encoding = previousEncoding;
-                continue;
-            }
-
-            if (mode == 0b0011) {
-                // Structured append: 8-bit sequence indicator + 8-bit parity.
-                var sequence = ReadBits(8);
-                var parity = ReadBits(8);
-                if (sequence < 0 || parity < 0) return false;
-
-                var index = (sequence >> 4) & 0x0F;
-                var total = sequence & 0x0F;
-                structuredAppend = new QrStructuredAppend(index, total, parity);
-                continue;
-            }
-
-            if (mode == 0b0001) {
-                // Numeric mode
-                var countBits = QrTables.GetNumericModeCharCountBits(version);
-                var count = ReadBits(countBits);
-                if (count < 0) return false;
-
-                var remaining = count;
-                while (remaining >= 3) {
-                    var v = ReadBits(10);
-                    if (v < 0 || v > 999) return false;
-                    AddByte((byte)('0' + (v / 100)));
-                    AddByte((byte)('0' + ((v / 10) % 10)));
-                    AddByte((byte)('0' + (v % 10)));
-                    remaining -= 3;
-                }
-
-                if (remaining == 2) {
-                    var v = ReadBits(7);
-                    if (v < 0 || v > 99) return false;
-                    AddByte((byte)('0' + (v / 10)));
-                    AddByte((byte)('0' + (v % 10)));
-                } else if (remaining == 1) {
-                    var v = ReadBits(4);
-                    if (v < 0 || v > 9) return false;
-                    AddByte((byte)('0' + v));
-                }
-
-                continue;
-            }
-
-            if (mode == 0b0010) {
-                // Alphanumeric mode
-                var countBits = QrTables.GetAlphanumericModeCharCountBits(version);
-                var count = ReadBits(countBits);
-                if (count < 0) return false;
-
-                var remaining = count;
-                var raw = new byte[count];
-                var rawLen = 0;
-                while (remaining >= 2) {
-                    var v = ReadBits(11);
-                    if (v < 0 || v >= 45 * 45) return false;
-                    var a = v / 45;
-                    var b = v % 45;
-                    raw[rawLen++] = (byte)AlphanumericTable[a];
-                    raw[rawLen++] = (byte)AlphanumericTable[b];
-                    remaining -= 2;
-                }
-
-                if (remaining == 1) {
-                    var v = ReadBits(6);
-                    if (v < 0 || v >= 45) return false;
-                    raw[rawLen++] = (byte)AlphanumericTable[v];
-                }
-
-                if (fnc1Mode != QrFnc1Mode.None) {
-                    for (var i = 0; i < rawLen; i++) {
-                        var b = raw[i];
-                        if (b == (byte)'%') {
-                            if (i + 1 < rawLen && raw[i + 1] == (byte)'%') {
-                                AddByte((byte)'%');
-                                i++;
-                                continue;
-                            }
-                            AddByte(0x1D); // GS separator
-                            continue;
-                        }
-                        AddByte(b);
-                    }
-                } else {
-                    for (var i = 0; i < rawLen; i++) {
-                        AddByte(raw[i]);
-                    }
-                }
-
-                continue;
-            }
-
-            if (mode == 0b0111) {
-                if (!TryReadEciAssignmentNumber(ReadBits, out var assignmentNumber)) return false;
-
-                // Minimal set for OTP / URL QR use cases.
-                var newEncoding = assignmentNumber switch {
-                    3 => QrTextEncoding.Latin1,      // ISO-8859-1
-                    4 => QrTextEncoding.Iso8859_2,   // ISO-8859-2
-                    6 => QrTextEncoding.Iso8859_4,   // ISO-8859-4
-                    7 => QrTextEncoding.Iso8859_5,   // ISO-8859-5
-                    9 => QrTextEncoding.Iso8859_7,   // ISO-8859-7
-                    12 => QrTextEncoding.Iso8859_10, // ISO-8859-10
-                    15 => QrTextEncoding.Iso8859_15, // ISO-8859-15
-                    20 => QrTextEncoding.ShiftJis,   // Shift-JIS
-                    26 => QrTextEncoding.Utf8,       // UTF-8
-                    27 => QrTextEncoding.Ascii,      // US-ASCII
-                    _ => encoding,
-                };
-
-                if (newEncoding != encoding) {
-                    FlushSegment();
-                    encoding = newEncoding;
-                }
-
-                // Unknown ECI: accept but keep current encoding (best-effort).
-                continue;
-            }
-
-            return false;
+            return true;
+        } finally {
+            ArrayPool<byte>.Shared.Return(buffer);
         }
+    }
 
-        FlushSegment();
-        payload = bytes.Count == 0 ? Array.Empty<byte>() : bytes.ToArray();
-        segments = segmentList.Count == 0 ? Array.Empty<QrPayloadSegment>() : segmentList.ToArray();
-        return true;
+    private static byte[] SliceBuffer(byte[] buffer, int count) {
+        if (count == 0) return Array.Empty<byte>();
+        var result = new byte[count];
+        Buffer.BlockCopy(buffer, 0, result, 0, count);
+        return result;
     }
 
     private static bool TryReadEciAssignmentNumber(Func<int, int> readBits, out int assignmentNumber) {

--- a/CodeGlyphX/Rendering/RenderExtensions.cs
+++ b/CodeGlyphX/Rendering/RenderExtensions.cs
@@ -134,4 +134,28 @@ public static class RenderExtensions {
         if (string.IsNullOrWhiteSpace(mimeType)) throw new ArgumentException("Mime type cannot be null, empty, or whitespace.", nameof(mimeType));
         return "data:" + mimeType + ";base64," + Convert.ToBase64String(data);
     }
+
+    /// <summary>
+    /// Encodes PNG bytes as a Base64 data URI.
+    /// </summary>
+    public static string ToPngDataUri(this byte[] data) => data.ToDataUri("image/png");
+
+    /// <summary>
+    /// Encodes JPEG bytes as a Base64 data URI.
+    /// </summary>
+    public static string ToJpegDataUri(this byte[] data) => data.ToDataUri("image/jpeg");
+
+    /// <summary>
+    /// Encodes BMP bytes as a Base64 data URI.
+    /// </summary>
+    public static string ToBmpDataUri(this byte[] data) => data.ToDataUri("image/bmp");
+
+    /// <summary>
+    /// Encodes SVG content as a Base64 data URI.
+    /// </summary>
+    public static string ToSvgDataUri(this string svg, Encoding? encoding = null) {
+        if (svg is null) throw new ArgumentNullException(nameof(svg));
+        var enc = encoding ?? Encoding.UTF8;
+        return "data:image/svg+xml;base64," + Convert.ToBase64String(enc.GetBytes(svg));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ CodeGlyphX is a fast, dependency-free toolkit for QR codes and barcodes, with ro
 
 **CodeGlyphX** is a no-deps QR + barcode toolkit for .NET with:
 - Reliable QR decoding (ECI, FNC1/GS1, Kanji, structured append, Micro QR)
-- 1D barcode encoding/decoding (Code128/GS1-128, Code39, Code93, EAN/UPC, ITF-14)
+- 1D barcode encoding/decoding (Code128/GS1-128, Code39, Code93, Code11, Codabar, MSI, Plessey, EAN/UPC, ITF-14)
 - 2D encoding/decoding (Data Matrix, PDF417)
 - Renderers (SVG / HTML / PNG / JPEG / BMP / PDF / EPS / ASCII) and image decoding (PNG/JPEG/GIF/BMP/PPM/TGA)
 - OTP helpers (otpauth://totp + Base32)
@@ -81,15 +81,20 @@ dotnet add package CodeGlyphX
 | --- | --- | --- | --- | --- |
 | QR | ✅ | ✅ | All (see Output formats) | ECI, FNC1/GS1, Kanji, structured append |
 | Micro QR | ✅ | ✅ | All (see Output formats) | Versions M1–M4 |
-| Code128 | ✅ | ✅ | All (see Output formats) | Set B/C |
+| Code128 | ✅ | ✅ | All (see Output formats) | Set A/B/C |
 | GS1-128 | ✅ | ✅ | All (see Output formats) | FNC1 + AI helpers |
 | Code39 | ✅ | ✅ | All (see Output formats) | Optional checksum |
 | Code93 | ✅ | ✅ | All (see Output formats) | Optional checksum |
+| Code11 | ✅ | ✅ | All (see Output formats) | Optional checksum |
+| Codabar | ✅ | ✅ | All (see Output formats) | A/B/C/D start/stop |
+| MSI | ✅ | ✅ | All (see Output formats) | Mod10 / Mod10Mod10 |
+| Plessey | ✅ | ✅ | All (see Output formats) | CRC |
 | EAN-8 / EAN-13 | ✅ | ✅ | All (see Output formats) | Checksum validation |
 | UPC-A / UPC-E | ✅ | ✅ | All (see Output formats) | Checksum validation |
 | ITF-14 | ✅ | ✅ | All (see Output formats) | Checksum validation |
 | Data Matrix | ✅ | ✅ | All (see Output formats) | ASCII/C40/Text/X12/EDIFACT/Base256 |
 | PDF417 | ✅ | ✅ | All (see Output formats) | Full encode/decode |
+| Aztec | 🚧 | 🚧 | All (see Output formats) | Scaffolded (planned) |
 
 ## Features
 
@@ -99,9 +104,15 @@ dotnet add package CodeGlyphX
 - [x] Data Matrix + PDF417 encode + decode
 - [x] SVG / HTML / PNG / JPEG / BMP / PDF / EPS / ASCII renderers
 - [x] Image decode: PNG / JPEG / GIF / BMP / PPM / TGA
-- [x] Base64 helpers for rendered outputs
+- [x] Base64 + data URI helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone, SMS, Contact, Calendar, OTP, Social)
 - [x] WPF controls and demo apps
+- [ ] Aztec (planned)
+
+## AOT & trimming
+
+CodeGlyphX is AOT-friendly (no reflection, no runtime codegen) and ships with trimming/AOT analyzers enabled for .NET 8+ targets.  
+Recommended publish flags: `PublishAot=true` (native), or `PublishTrimmed=true` (size) for app projects.
 
 ## Output formats (Save by extension)
 
@@ -131,7 +142,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 | Contacts | vCard / MeCard |
 | OTP | TOTP / HOTP (otpauth://) |
 | Social & Stores | App Store (Apple/Google), Facebook, X/Twitter, TikTok, LinkedIn, WhatsApp |
-| Payments | UPI, SEPA Girocode (EPC), BezahlCode, Swiss QR Bill, Slovenian UPN |
+| Payments | UPI, SEPA Girocode (EPC), BezahlCode (contact/payment/debit/periodic), Swiss QR Bill, Slovenian UPN, Russia Payment Order (ST00012) |
 | Crypto & Network | Bitcoin / Bitcoin Cash / Litecoin, Monero, ShadowSocks |
 
 ## Image decoding (for readers)
@@ -169,6 +180,13 @@ using CodeGlyphX;
 Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.png");
 Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.pdf");
 Barcode.Save(BarcodeType.Code128, "CODE128-12345", "code128.eps");
+```
+
+```csharp
+using CodeGlyphX;
+
+// One-liners with defaults
+var png = BarcodeEasy.RenderPng(BarcodeType.Code128, "CODE128-12345");
 ```
 
 ```csharp

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,7 @@
 ## Phase 4 — 1D barcode completeness (weeks)
 - [x] Encode: Code39, Code93, EAN-8/13, UPC-A, UPC-E, ITF-14.
 - [x] Encode: GS1-128 (FNC1 + AI helpers).
+- [x] Encode/Decode: Codabar, MSI, Code11, Plessey.
 - [x] Decode: ITF-14 scanline.
 - [x] Decode: 1D scanline decode + checksum validation (EAN/UPC first).
 - [x] Render: optional label text beneath bars.
@@ -40,12 +41,13 @@
 - [x] DataMatrix: encode C40/Text/X12/EDIFACT (ECC200).
 - [x] PDF417: full encode/decode + ECC tuning.
 - [x] PDF417: validate perspective warp sampling on skewed screenshots (test + tuning).
-- [ ] Aztec + MaxiCode (advanced, optional).
+- [ ] Aztec + MaxiCode (advanced, optional) — Aztec scaffolded.
 
 ## Phase 5b — Payload completeness (parallel)
-- [ ] Payments: RussiaPaymentOrder payload (GOST R 56042-2014).
-- [ ] Payments: additional BezahlCode authorities (single payment/direct debit).
-- [ ] Extras: QR "bookmark" title normalization + extended schema validation.
+- [x] Payments: RussiaPaymentOrder payload (ST00012).
+- [x] Payments: additional BezahlCode authorities (single payment/direct debit/periodic).
+- [x] Extras: QR "bookmark" title normalization.
+- [x] Extras: extended schema validation.
 
 ## Phase 6 — Screen reader robustness (hard)
 - [x] Multi-QR detection per frame.
@@ -60,16 +62,16 @@
 - [x] Unified “CodeGlyph” detect for QR/1D/DataMatrix/PDF417.
 - [x] Presets: OTP/Logo/WiFi/Contact with safe defaults.
 - [x] Fluent API + static API + options objects (with easy defaults).
-- [ ] Output formats: ASCII renderer (text/lines).
-- [ ] Output formats: Base64 (raw + data URI) for PNG/JPEG/BMP.
-- [ ] Output formats: BMP writer (24-bit/32-bit).
-- [ ] Output formats: PDF byte writer (single-page, vector or image).
-- [ ] Output formats: PostScript/EPS writer (vector).
+- [x] Output formats: ASCII renderer (text/lines).
+- [x] Output formats: Base64 (raw + data URI) for PNG/JPEG/BMP.
+- [x] Output formats: BMP writer (24-bit/32-bit).
+- [x] Output formats: PDF byte writer (single-page, vector or image).
+- [x] Output formats: PostScript/EPS writer (vector).
 
 ## Phase 8 — Performance + AOT polish
-- [ ] Reduce allocations in hot decode loops.
-- [ ] Span-friendly paths where possible.
-- [ ] AOT + trimming hints (no reflection).
+- [x] Reduce allocations in hot decode loops.
+- [x] Span-friendly paths where possible.
+- [x] AOT + trimming hints (no reflection).
 - [ ] Optional SIMD for thresholding if worthwhile.
 - [x] Image decode: JPEG baseline (SOF0).
 - [x] Image decode: JPEG progressive (SOF2) + EXIF orientation.


### PR DESCRIPTION
## Summary
- Add more 1D barcode types/decoding (Codabar, MSI, Code11, Plessey, Code128 Set A) and payload helpers.
- Improve QR/DataMatrix/PDF417 decoding robustness and reduce allocations in hot paths.
- Add Aztec scaffold, BarcodeEasy one-liners, and AOT/trim analyzers.

## Testing
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release
- dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release -f net472