### PR TITLE
chore(pages): ✨ Add .nojekyll file and update carousel data generation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Verify website output
         run: |
+          test -f site/.nojekyll
           test -f site/index.html
           test -f site/docs/index.html
           test -f site/playground/index.html

--- a/Build/Generate-StaticPages.ps1
+++ b/Build/Generate-StaticPages.ps1
@@ -381,11 +381,12 @@ if (-not (Test-Path $showcaseJsonPath)) {
         [void]$showcaseHtml.AppendLine('            </div>')
 
         # Carousel data
+        $carouselJson = @{
+            dark  = @($item.images.dark | ForEach-Object { $_.caption })
+            light = @($item.images.light | ForEach-Object { $_.caption })
+        } | ConvertTo-Json -Compress -Depth 4
         [void]$showcaseHtml.AppendLine("            <script type=`"application/json`" class=`"carousel-data`" data-carousel=`"$carouselId`">")
-        [void]$showcaseHtml.AppendLine('            {')
-        [void]$showcaseHtml.AppendLine("                `"dark`": [$(($item.images.dark | ForEach-Object { '\"' + $_.caption + '\"' }) -join ', ')],")
-        [void]$showcaseHtml.AppendLine("                `"light`": [$(($item.images.light | ForEach-Object { '\"' + $_.caption + '\"' }) -join ', ')]")
-        [void]$showcaseHtml.AppendLine('            }')
+        [void]$showcaseHtml.AppendLine("            $carouselJson")
         [void]$showcaseHtml.AppendLine('            </script>')
 
         # Actions

--- a/Build/Publish-WebsitePages.ps1
+++ b/Build/Publish-WebsitePages.ps1
@@ -112,6 +112,8 @@ New-Item -ItemType Directory -Path $publishRoot -Force | Out-Null
 Write-Host "Copying static assets..." -ForegroundColor Cyan
 Copy-Item -Path (Join-Path $wwwrootSource "*") -Destination $publishRoot -Recurse -Force
 
+New-Item -ItemType File -Path (Join-Path $publishRoot ".nojekyll") -Force | Out-Null
+
 $staticPagesScript = Join-Path $PSScriptRoot "Generate-StaticPages.ps1"
 Invoke-Step "Generating static pages..." @("pwsh",$staticPagesScript,"-OutputPath",$publishRoot)
 


### PR DESCRIPTION
* Introduced a `.nojekyll` file to prevent Jekyll processing on GitHub Pages.
* Refactored carousel data generation in `Generate-StaticPages.ps1` for improved readability and efficiency.