### PR TITLE
Fix playground dropzone and preview UX

### DIFF
--- a/CodeGlyphX.Playground/Playground.Decode.cs
+++ b/CodeGlyphX.Playground/Playground.Decode.cs
@@ -24,6 +24,7 @@ public partial class Playground {
         DecodeError = null;
         DecodeImageDataUri = null;
         DecodeStatus = string.Empty;
+        IsDropActive = false;
 
         var file = args.File;
         if (file is null)

--- a/CodeGlyphX.Playground/PlaygroundConfig.razor
+++ b/CodeGlyphX.Playground/PlaygroundConfig.razor
@@ -35,8 +35,10 @@ else
                     <InputFile class="drop-input"
                                OnChange="Host.OnDecodeFileChanged"
                                accept="image/*"
-                               @ondragenter="@(() => Host.IsDropActive = true)"
+                                @ondragenter="@(() => Host.IsDropActive = true)"
+                               @ondragenter:preventDefault="true"
                                @ondragleave="@(() => Host.IsDropActive = false)"
+                               @ondragleave:preventDefault="true"
                                @ondrop="@(() => Host.IsDropActive = false)"
                                @ondragover:preventDefault="true" />
                     <div class="dropzone-inner">

--- a/CodeGlyphX.Playground/PlaygroundConfig.razor
+++ b/CodeGlyphX.Playground/PlaygroundConfig.razor
@@ -31,13 +31,14 @@ else
         {
             <div class="form-group">
                 <label>Image File</label>
-                <div class="dropzone @(Host.IsDropActive ? "active" : string.Empty)"
-                     @ondragenter="@(() => Host.IsDropActive = true)"
-                     @ondragleave="@(() => Host.IsDropActive = false)"
-                     @ondrop="@(() => Host.IsDropActive = false)"
-                     @ondragover:preventDefault="true"
-                     @ondrop:preventDefault="true">
-                    <InputFile class="drop-input" OnChange="Host.OnDecodeFileChanged" accept="image/*" />
+                <div class="dropzone @(Host.IsDropActive ? "active" : string.Empty)">
+                    <InputFile class="drop-input"
+                               OnChange="Host.OnDecodeFileChanged"
+                               accept="image/*"
+                               @ondragenter="@(() => Host.IsDropActive = true)"
+                               @ondragleave="@(() => Host.IsDropActive = false)"
+                               @ondrop="@(() => Host.IsDropActive = false)"
+                               @ondragover:preventDefault="true" />
                     <div class="dropzone-inner">
                         <strong>Drop an image here</strong>
                         <span>or click to select</span>

--- a/CodeGlyphX.Playground/PlaygroundConfig.razor
+++ b/CodeGlyphX.Playground/PlaygroundConfig.razor
@@ -35,12 +35,10 @@ else
                     <InputFile class="drop-input"
                                OnChange="Host.OnDecodeFileChanged"
                                accept="image/*"
-                                @ondragenter="@(() => Host.IsDropActive = true)"
-                               @ondragenter:preventDefault="true"
+                               @ondragenter="@(() => Host.IsDropActive = true)"
                                @ondragleave="@(() => Host.IsDropActive = false)"
-                               @ondragleave:preventDefault="true"
-                               @ondrop="@(() => Host.IsDropActive = false)"
-                               @ondragover:preventDefault="true" />
+                               @ondragover:preventDefault="true"
+                               @ondrop:preventDefault="true" />
                     <div class="dropzone-inner">
                         <strong>Drop an image here</strong>
                         <span>or click to select</span>

--- a/CodeGlyphX.Playground/PlaygroundPreview.razor
+++ b/CodeGlyphX.Playground/PlaygroundPreview.razor
@@ -9,9 +9,14 @@
 }
 else
 {
-    <div class="card">
+    <div class="card playground-preview-card">
         <h2>@(Host.SelectedMode == "Decode" ? "Decode Result" : "Preview")</h2>
-        <div class="output-preview">
+        @{
+            var isEmpty = Host.SelectedMode == "Decode"
+                ? string.IsNullOrEmpty(Host.DecodeImageDataUri)
+                : string.IsNullOrEmpty(Host.ImageDataUri);
+        }
+        <div class="output-preview @(isEmpty ? "output-preview-empty" : string.Empty)">
             @if (!string.IsNullOrEmpty(Host.ErrorMessage))
             {
                 <div style="text-align: center; color: #ef4444;">

--- a/CodeGlyphX.Website/wwwroot/css/app.css
+++ b/CodeGlyphX.Website/wwwroot/css/app.css
@@ -3125,19 +3125,6 @@ section {
     }
 }
 
-[data-theme="light"] .output-preview.output-preview-empty {
-    background: var(--bg-input);
-    border: 1px dashed var(--border);
-    box-shadow: none;
-}
-
-@media (prefers-color-scheme: light) {
-    [data-theme="auto"] .output-preview.output-preview-empty {
-        background: var(--bg-input);
-        border: 1px dashed var(--border);
-        box-shadow: none;
-    }
-}
 
 [data-theme="light"] .btn-primary {
     box-shadow: 0 0 30px rgba(124, 58, 237, 0.2);

--- a/CodeGlyphX.Website/wwwroot/css/app.css
+++ b/CodeGlyphX.Website/wwwroot/css/app.css
@@ -2050,6 +2050,14 @@ body.using-keyboard .showcase-hero h1:focus-visible {
     }
 }
 
+@media (min-width: 901px) {
+    .playground-preview-card {
+        position: sticky;
+        top: 6rem;
+        align-self: start;
+    }
+}
+
 .playground .card {
     background: var(--bg-card);
     border: 1px solid var(--border);
@@ -2994,6 +3002,12 @@ section {
     box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
+.output-preview.output-preview-empty {
+    background: var(--bg-input);
+    border: 1px dashed var(--border);
+    box-shadow: none;
+}
+
 .output-preview img {
     max-width: 100%;
     max-height: 380px;
@@ -3108,6 +3122,20 @@ section {
     [data-theme="auto"] .output-preview {
         background: var(--preview-bg);
         box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.03);
+    }
+}
+
+[data-theme="light"] .output-preview.output-preview-empty {
+    background: var(--bg-input);
+    border: 1px dashed var(--border);
+    box-shadow: none;
+}
+
+@media (prefers-color-scheme: light) {
+    [data-theme="auto"] .output-preview.output-preview-empty {
+        background: var(--bg-input);
+        border: 1px dashed var(--border);
+        box-shadow: none;
     }
 }
 


### PR DESCRIPTION
## Summary\n- fix decode dropzone drag/drop events so file drops trigger InputFile\n- add empty-state styling for preview to avoid harsh white panel in dark theme\n- make preview card sticky on desktop so it stays visible while scrolling settings\n\n## Testing\n- not run (CSS/markup-only changes)