### PR TITLE
Fix playground sticky preview

### DIFF
--- a/CodeGlyphX.Website/wwwroot/css/app.css
+++ b/CodeGlyphX.Website/wwwroot/css/app.css
@@ -2470,7 +2470,7 @@ main, .main {
     width: 100%;
     max-width: 100vw;
     min-width: 0;
-    overflow-x: hidden;
+    overflow-x: visible;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary\n- allow sticky preview to work by avoiding overflow-x clipping on main wrapper\n\n## Testing\n- not run (CSS change only)