### PR TITLE
Optimize style board assets and docs

### DIFF
--- a/Assets/Templates/pages/docs.html
+++ b/Assets/Templates/pages/docs.html
@@ -81,6 +81,17 @@
             <h3>1D Linear Barcodes</h3>
             <p>Code 128, GS1-128, Code 39, Code 93, Code 11, Codabar, MSI, Plessey, EAN-8, EAN-13, UPC-A, UPC-E, ITF-14</p>
 
+            <h2>Documentation Map</h2>
+            <ul style="color: var(--text-muted); margin-left: 1.5rem;">
+                <li><strong>QR &amp; Micro QR</strong> - Core encoding, error correction, and QR specifics. <a href="#qr">QR docs</a></li>
+                <li><strong>Styling &amp; presets</strong> - Module shapes, palettes, logos, and the style board gallery. <a href="#styling-options">Styling options</a></li>
+                <li><strong>Payload helpers</strong> - WiFi, vCards, OTP, SEPA, and more. <a href="#payloads">Payload helpers</a></li>
+                <li><strong>Image decoding</strong> - Decode from images and screenshots. <a href="#decoding">Image decoding</a></li>
+                <li><strong>Output formats</strong> - PNG, SVG, PDF, EPS, HTML, and more. <a href="#renderers">Output formats</a></li>
+                <li><strong>API Reference</strong> - Full type and method documentation. <a href="/api/">API reference</a></li>
+                <li><strong>FAQ</strong> - Common questions and troubleshooting. <a href="/faq/">FAQ</a></li>
+            </ul>
+
             <h2>Quick Example</h2>
             <pre class="code-block">using CodeGlyphX;
 

--- a/CodeGlyphX.Website/Layout/MainLayout.razor
+++ b/CodeGlyphX.Website/Layout/MainLayout.razor
@@ -166,7 +166,6 @@
         new NavLink("/", "Home", true),
         new NavLink("/playground/", "Playground", true),
         new NavLink("/docs/", "Docs", true),
-        new NavLink("/faq/", "FAQ", true),
         new NavLink("/benchmarks/", "Benchmarks", false),
         new NavLink("/showcase/", "Showcase", true)
     };

--- a/CodeGlyphX.Website/Pages/Docs.razor
+++ b/CodeGlyphX.Website/Pages/Docs.razor
@@ -91,6 +91,17 @@
             <h3>1D Linear Barcodes</h3>
             <p>Code 128, GS1-128, Code 39, Code 93, Code 11, Codabar, MSI, Plessey, EAN-8, EAN-13, UPC-A, UPC-E, ITF-14</p>
 
+            <h2>Documentation Map</h2>
+            <ul style="color: var(--text-muted); margin-left: 1.5rem;">
+                <li><strong>QR &amp; Micro QR</strong> - Core encoding, error correction, and QR specifics. <a href="/docs/qr">QR docs</a></li>
+                <li><strong>Styling &amp; presets</strong> - Module shapes, palettes, logos, and the style board gallery. <a href="/docs/qr#styling-options">Styling options</a></li>
+                <li><strong>Payload helpers</strong> - WiFi, vCards, OTP, SEPA, and more. <a href="/docs/payloads">Payload helpers</a></li>
+                <li><strong>Image decoding</strong> - Decode from images and screenshots. <a href="/docs/decoding">Image decoding</a></li>
+                <li><strong>Output formats</strong> - PNG, SVG, PDF, EPS, HTML, and more. <a href="/docs/renderers">Output formats</a></li>
+                <li><strong>API Reference</strong> - Full type and method documentation. <a href="/docs/api">API reference</a></li>
+                <li><strong>FAQ</strong> - Common questions and troubleshooting. <a href="/faq/">FAQ</a></li>
+            </ul>
+
             <h2>Quick Example</h2>
             <pre class="code-block">using CodeGlyphX;
 

--- a/CodeGlyphX.Website/wwwroot/api-fragments/header.html
+++ b/CodeGlyphX.Website/wwwroot/api-fragments/header.html
@@ -20,7 +20,6 @@
                 <a href="/">Home</a>
                 <a href="/playground/">Playground</a>
                 <a href="/docs/">Docs</a>
-                <a href="/faq/">FAQ</a>
                 <a href="/benchmarks/">Benchmarks</a>
                 <a href="/showcase/">Showcase</a>
             </div>

--- a/CodeGlyphX.Website/wwwroot/benchmarks/index.html
+++ b/CodeGlyphX.Website/wwwroot/benchmarks/index.html
@@ -66,7 +66,6 @@
                 <a href="/">Home</a>
                 <a href="/playground/">Playground</a>
                 <a href="/docs/">Docs</a>
-                <a href="/faq/">FAQ</a>
                 <a href="/benchmarks/">Benchmarks</a>
                 <a href="/showcase/">Showcase</a>
             </div>

--- a/CodeGlyphX.Website/wwwroot/data/site-nav.json
+++ b/CodeGlyphX.Website/wwwroot/data/site-nav.json
@@ -3,7 +3,6 @@
     { "href": "/", "text": "Home", "spa": true },
     { "href": "/playground/", "text": "Playground", "spa": true },
     { "href": "/docs/", "text": "Docs", "spa": true },
-    { "href": "/faq/", "text": "FAQ", "spa": true },
     { "href": "/benchmarks/", "text": "Benchmarks", "spa": false },
     { "href": "/showcase/", "text": "Showcase", "spa": true }
   ],

--- a/CodeGlyphX.Website/wwwroot/docs/index.html
+++ b/CodeGlyphX.Website/wwwroot/docs/index.html
@@ -42,7 +42,6 @@
                 <a href="/">Home</a>
                 <a href="/playground/">Playground</a>
                 <a href="/docs/">Docs</a>
-                <a href="/faq/">FAQ</a>
                 <a href="/benchmarks/">Benchmarks</a>
                 <a href="/showcase/">Showcase</a>
             </div>
@@ -165,6 +164,17 @@
 
             <h3>1D Linear Barcodes</h3>
             <p>Code 128, GS1-128, Code 39, Code 93, Code 11, Codabar, MSI, Plessey, EAN-8, EAN-13, UPC-A, UPC-E, ITF-14</p>
+
+            <h2>Documentation Map</h2>
+            <ul style="color: var(--text-muted); margin-left: 1.5rem;">
+                <li><strong>QR &amp; Micro QR</strong> - Core encoding, error correction, and QR specifics. <a href="#qr">QR docs</a></li>
+                <li><strong>Styling &amp; presets</strong> - Module shapes, palettes, logos, and the style board gallery. <a href="#styling-options">Styling options</a></li>
+                <li><strong>Payload helpers</strong> - WiFi, vCards, OTP, SEPA, and more. <a href="#payloads">Payload helpers</a></li>
+                <li><strong>Image decoding</strong> - Decode from images and screenshots. <a href="#decoding">Image decoding</a></li>
+                <li><strong>Output formats</strong> - PNG, SVG, PDF, EPS, HTML, and more. <a href="#renderers">Output formats</a></li>
+                <li><strong>API Reference</strong> - Full type and method documentation. <a href="/api/">API reference</a></li>
+                <li><strong>FAQ</strong> - Common questions and troubleshooting. <a href="/faq/">FAQ</a></li>
+            </ul>
 
             <h2>Quick Example</h2>
             <pre class="code-block">using CodeGlyphX;

--- a/CodeGlyphX.Website/wwwroot/faq/index.html
+++ b/CodeGlyphX.Website/wwwroot/faq/index.html
@@ -242,7 +242,6 @@
                 <a href="/">Home</a>
                 <a href="/playground/">Playground</a>
                 <a href="/docs/">Docs</a>
-                <a href="/faq/">FAQ</a>
                 <a href="/benchmarks/">Benchmarks</a>
                 <a href="/showcase/">Showcase</a>
             </div>

--- a/CodeGlyphX.Website/wwwroot/showcase/index.html
+++ b/CodeGlyphX.Website/wwwroot/showcase/index.html
@@ -66,7 +66,6 @@
                 <a href="/">Home</a>
                 <a href="/playground/">Playground</a>
                 <a href="/docs/">Docs</a>
-                <a href="/faq/">FAQ</a>
                 <a href="/benchmarks/">Benchmarks</a>
                 <a href="/showcase/">Showcase</a>
             </div>
@@ -222,7 +221,7 @@
                 </div>
             </div>
             <script type="application/json" class="carousel-data" data-carousel="carousel-informationbox">
-            {"light":["Status Tab","Account Tab","OTP Tab (CodeGlyphX)","Troubleshoot Tab"],"dark":["Status Tab","Account Tab","OTP Tab (CodeGlyphX)","Troubleshoot Tab"]}
+            {"dark":["Status Tab","Account Tab","OTP Tab (CodeGlyphX)","Troubleshoot Tab"],"light":["Status Tab","Account Tab","OTP Tab (CodeGlyphX)","Troubleshoot Tab"]}
             </script>
             <div class="showcase-actions">
                 <a href="https://github.com/EvotecIT/InformationBox" target="_blank" rel="noopener" class="btn btn-secondary"><svg viewBox="0 0 24 24" fill="currentColor" class="btn-icon"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>View on GitHub</a>
@@ -343,7 +342,7 @@
                 </div>
             </div>
             <script type="application/json" class="carousel-data" data-carousel="carousel-authimo">
-            {"light":["Minimal Mode","QR Scanning (CodeGlyphX)","Setup Wizard","Account Management"],"dark":["Minimal Mode","QR Scanning (CodeGlyphX)","Setup Wizard","Account Management"]}
+            {"dark":["Minimal Mode","QR Scanning (CodeGlyphX)","Setup Wizard","Account Management"],"light":["Minimal Mode","QR Scanning (CodeGlyphX)","Setup Wizard","Account Management"]}
             </script>
             <div class="showcase-actions">
                 <span class="showcase-status"><span class="status-dot"></span>In Development</span>


### PR DESCRIPTION
## Summary
- align styling links to /docs/qr#styling-options
- expand docs with an 'Other 1D' symbologies section and examples
- refresh style board assets + manifest with updated payload URLs

## Testing
- Build/Update-StyleBoard.ps1
- Build/Generate-StaticPages.ps1 -OutputPath site -Force