### PR TITLE
Protect functional patterns and quiet zone in QR art rendering

### DIFF
--- a/CodeGlyphX.Examples/Program.cs
+++ b/CodeGlyphX.Examples/Program.cs
@@ -33,6 +33,7 @@ internal static class Program {
         runner.Run("QR (payloads)", QrPayloadsExample.Run);
         runner.Run("QR (styling)", QrFancyExample.Run);
         runner.Run("QR (connected)", QrConnectedExample.Run);
+        runner.Run("QR (glow eyes)", QrGlowExample.Run);
         runner.Run("QR (style board)", QrStyleBoardExample.Run);
         runner.Run("QR (print)", QrPrintExample.Run);
         runner.Run("QR (logo)", EvotecExamples.Run);

--- a/CodeGlyphX.Examples/Program.cs
+++ b/CodeGlyphX.Examples/Program.cs
@@ -32,6 +32,7 @@ internal static class Program {
         runner.Run("QR (ascii console)", QrAsciiExample.Run);
         runner.Run("QR (payloads)", QrPayloadsExample.Run);
         runner.Run("QR (styling)", QrFancyExample.Run);
+        runner.Run("QR (connected)", QrConnectedExample.Run);
         runner.Run("QR (style board)", QrStyleBoardExample.Run);
         runner.Run("QR (print)", QrPrintExample.Run);
         runner.Run("QR (logo)", EvotecExamples.Run);

--- a/CodeGlyphX.Examples/QrAsciiExample.cs
+++ b/CodeGlyphX.Examples/QrAsciiExample.cs
@@ -8,14 +8,14 @@ internal static class QrAsciiExample {
     public static void Run(string outputDir) {
         var payload = "https://example.com/console";
         var ascii = QR.Ascii(payload, new MatrixAsciiRenderOptions {
-            Dark = "##",
-            Light = "  ",
-            ModuleWidth = 1,
+            QuietZone = 4,
+            UseUnicodeBlocks = true,
+            Scale = 2,
+            ModuleWidth = 2,
             ModuleHeight = 1
         });
 
-        Console.WriteLine("ASCII QR preview:");
+        Console.WriteLine("ASCII QR preview (increase Scale for phone scanning):");
         Console.WriteLine(ascii);
     }
 }
-

--- a/CodeGlyphX.Examples/QrAsciiExample.cs
+++ b/CodeGlyphX.Examples/QrAsciiExample.cs
@@ -8,16 +8,7 @@ namespace CodeGlyphX.Examples;
 internal static class QrAsciiExample {
     public static void Run(string outputDir) {
         var payload = "https://example.com/console";
-        var ascii = QR.Ascii(payload, new MatrixAsciiRenderOptions {
-            QuietZone = 4,
-            UseUnicodeBlocks = true,
-            UseAnsiColors = true,
-            UseAnsiTrueColor = true,
-            AnsiDarkColor = new Rgba32(16, 16, 16),
-            Scale = 3,
-            ModuleWidth = 2,
-            ModuleHeight = 1
-        });
+        var ascii = QR.Ascii(payload, AsciiPresets.Console(scale: 4, darkColor: new Rgba32(12, 12, 12)));
 
         Console.WriteLine("ANSI ASCII QR preview (increase Scale for phone scanning):");
         Console.WriteLine(ascii);

--- a/CodeGlyphX.Examples/QrAsciiExample.cs
+++ b/CodeGlyphX.Examples/QrAsciiExample.cs
@@ -1,6 +1,7 @@
 using System;
 using CodeGlyphX;
 using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX.Examples;
 
@@ -10,12 +11,15 @@ internal static class QrAsciiExample {
         var ascii = QR.Ascii(payload, new MatrixAsciiRenderOptions {
             QuietZone = 4,
             UseUnicodeBlocks = true,
-            Scale = 2,
+            UseAnsiColors = true,
+            UseAnsiTrueColor = true,
+            AnsiDarkColor = new Rgba32(16, 16, 16),
+            Scale = 3,
             ModuleWidth = 2,
             ModuleHeight = 1
         });
 
-        Console.WriteLine("ASCII QR preview (increase Scale for phone scanning):");
+        Console.WriteLine("ANSI ASCII QR preview (increase Scale for phone scanning):");
         Console.WriteLine(ascii);
     }
 }

--- a/CodeGlyphX.Examples/QrConnectedExample.cs
+++ b/CodeGlyphX.Examples/QrConnectedExample.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using CodeGlyphX;
+using CodeGlyphX.Payloads;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Examples;
+
+internal static class QrConnectedExample {
+    public static void Run(string outputDir) {
+        var payload = QrPayload.Url("https://example.com/qr/connected");
+
+        var options = new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.H,
+            ModuleSize = 10,
+            QuietZone = 4,
+            Foreground = new Rgba32(88, 120, 255),
+            Background = new Rgba32(250, 252, 255),
+            ModuleShape = QrPngModuleShape.ConnectedRounded,
+            ModuleScale = 0.9,
+            ModuleScaleMap = new QrPngModuleScaleMapOptions {
+                Mode = QrPngModuleScaleMode.Radial,
+                MinScale = 0.86,
+                MaxScale = 1.0,
+                RingSize = 2,
+            },
+            ForegroundPalette = new QrPngPaletteOptions {
+                Mode = QrPngPaletteMode.Cycle,
+                RingSize = 2,
+                ApplyToEyes = false,
+                Colors = new[] {
+                    new Rgba32(88, 120, 255),
+                    new Rgba32(120, 96, 255),
+                    new Rgba32(88, 210, 255),
+                },
+            },
+            Eyes = new QrPngEyeOptions {
+                UseFrame = true,
+                FrameStyle = QrPngEyeFrameStyle.Target,
+                OuterShape = QrPngModuleShape.Rounded,
+                InnerShape = QrPngModuleShape.Circle,
+                OuterColor = new Rgba32(88, 120, 255),
+                InnerColor = new Rgba32(88, 210, 255),
+                OuterCornerRadiusPx = 6,
+                InnerCornerRadiusPx = 4,
+            },
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = 24,
+                CornerRadiusPx = 26,
+                BackgroundGradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.DiagonalDown,
+                    StartColor = new Rgba32(14, 18, 42),
+                    EndColor = new Rgba32(28, 20, 76),
+                },
+                BorderPx = 2,
+                BorderColor = new Rgba32(255, 255, 255, 48),
+                ShadowOffsetX = 6,
+                ShadowOffsetY = 8,
+                ShadowColor = new Rgba32(0, 0, 0, 60),
+            },
+        };
+
+        QR.Save(payload, Path.Combine(outputDir, "qr-connected-rounded.png"), options);
+        QR.SavePdf(payload, Path.Combine(outputDir, "qr-connected-rounded.pdf"), options, RenderMode.Raster);
+        QR.SaveEps(payload, Path.Combine(outputDir, "qr-connected-rounded.eps"), options, RenderMode.Raster);
+    }
+}
+

--- a/CodeGlyphX.Examples/QrGlowExample.cs
+++ b/CodeGlyphX.Examples/QrGlowExample.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using CodeGlyphX;
+using CodeGlyphX.Payloads;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Examples;
+
+internal static class QrGlowExample {
+    public static void Run(string outputDir) {
+        var payload = QrPayload.Url("https://example.com/qr/glow");
+
+        var options = new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.H,
+            ModuleSize = 10,
+            QuietZone = 4,
+            Foreground = new Rgba32(0, 255, 240),
+            Background = new Rgba32(255, 255, 255),
+            ModuleShape = QrPngModuleShape.Dot,
+            ModuleScale = 0.9,
+            ModuleScaleMap = new QrPngModuleScaleMapOptions {
+                Mode = QrPngModuleScaleMode.Radial,
+                MinScale = 0.82,
+                MaxScale = 1.0,
+                RingSize = 2,
+            },
+            ForegroundPalette = new QrPngPaletteOptions {
+                Mode = QrPngPaletteMode.Cycle,
+                RingSize = 2,
+                ApplyToEyes = false,
+                Colors = new[] {
+                    new Rgba32(0, 255, 240),
+                    new Rgba32(0, 170, 255),
+                    new Rgba32(255, 92, 255),
+                },
+            },
+            Eyes = new QrPngEyeOptions {
+                UseFrame = true,
+                FrameStyle = QrPngEyeFrameStyle.Glow,
+                OuterShape = QrPngModuleShape.Rounded,
+                InnerShape = QrPngModuleShape.Circle,
+                OuterColor = new Rgba32(0, 255, 240),
+                InnerColor = new Rgba32(255, 92, 255),
+                OuterCornerRadiusPx = 6,
+                InnerCornerRadiusPx = 4,
+                GlowRadiusPx = 30,
+                GlowAlpha = 130,
+                GlowColor = new Rgba32(0, 200, 255, 200),
+            },
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = 24,
+                CornerRadiusPx = 26,
+                BackgroundGradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.DiagonalDown,
+                    StartColor = new Rgba32(8, 10, 28),
+                    EndColor = new Rgba32(28, 18, 64),
+                },
+                BorderPx = 2,
+                BorderColor = new Rgba32(255, 255, 255, 48),
+                ShadowOffsetX = 6,
+                ShadowOffsetY = 8,
+                ShadowColor = new Rgba32(0, 0, 0, 60),
+            },
+        };
+
+        QR.Save(payload, Path.Combine(outputDir, "qr-glow.png"), options);
+        QR.SavePdf(payload, Path.Combine(outputDir, "qr-glow.pdf"), options, RenderMode.Raster);
+        QR.SaveEps(payload, Path.Combine(outputDir, "qr-glow.eps"), options, RenderMode.Raster);
+    }
+}
+

--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -158,6 +158,14 @@ internal static class QrStyleBoardExample {
                 eyes: Eye(QrPngEyeFrameStyle.Badge, R(30, 30, 30), R(80, 80, 80)),
                 canvas: CanvasPattern(R(255, 255, 255), Pattern(QrPngBackgroundPatternType.Grid, R(30, 30, 30, 18))))),
 
+            new("Connected Melt", StyleDocs("connected-melt"), () => BaseSticker(
+                fg: R(88, 120, 255),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(88, 120, 255), R(120, 96, 255), R(88, 210, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: Eye(QrPngEyeFrameStyle.Target, R(88, 120, 255), R(88, 210, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.86, 1.0),
+                canvas: CanvasGradient(R(14, 18, 42), R(28, 20, 76)))),
+
             new("Center Pop", StyleDocs("center-pop"), () => BaseSticker(
                 fg: R(35, 54, 89),
                 palette: Palette(QrPngPaletteMode.Cycle, 0, R(35, 54, 89), R(60, 90, 140)),

--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -55,6 +55,22 @@ internal static class QrStyleBoardExample {
                 eyes: Eye(QrPngEyeFrameStyle.Target, R(0, 255, 213), R(255, 59, 255)),
                 canvas: CanvasGradient(R(18, 18, 28), R(48, 23, 72)))),
 
+            new("Neon Glow", StyleDocs("neon-glow"), () => BaseSticker(
+                fg: R(0, 255, 240),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(0, 255, 240), R(0, 170, 255), R(255, 92, 255)),
+                shape: QrPngModuleShape.Dot,
+                eyes: EyeGlow(R(0, 255, 240), R(255, 92, 255), R(0, 200, 255, 200)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.82, 1.0),
+                canvas: CanvasGradient(R(8, 10, 28), R(28, 18, 64)))),
+
+            new("Liquid Glass", StyleDocs("liquid-glass"), () => BaseSticker(
+                fg: R(120, 210, 255),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(120, 210, 255), R(160, 160, 255), R(210, 170, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: EyeGlow(R(120, 210, 255), R(210, 170, 255), R(120, 210, 255, 190)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.86, 1.0),
+                canvas: CanvasGradient(R(14, 18, 46), R(32, 26, 82)))),
+
             new("Candy Checker", StyleDocs("candy-checker"), () => BaseSticker(
                 fg: R(255, 107, 107),
                 palette: Palette(QrPngPaletteMode.Checker, 0, R(255, 107, 107), R(255, 217, 61)),
@@ -166,6 +182,14 @@ internal static class QrStyleBoardExample {
                 scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.86, 1.0),
                 canvas: CanvasGradient(R(14, 18, 42), R(28, 20, 76)))),
 
+            new("Minimal Mono", StyleDocs("minimal-mono"), () => BaseSticker(
+                fg: R(18, 18, 18),
+                palette: null,
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: EyeGlow(R(18, 18, 18), R(18, 18, 18), R(120, 120, 120, 150)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0),
+                canvas: CanvasBorder(R(255, 255, 255), R(18, 18, 18)))),
+
             new("Center Pop", StyleDocs("center-pop"), () => BaseSticker(
                 fg: R(35, 54, 89),
                 palette: Palette(QrPngPaletteMode.Cycle, 0, R(35, 54, 89), R(60, 90, 140)),
@@ -223,6 +247,14 @@ internal static class QrStyleBoardExample {
             OuterCornerRadiusPx = 6,
             InnerCornerRadiusPx = 4,
         };
+    }
+
+    private static QrPngEyeOptions EyeGlow(Rgba32 outer, Rgba32 inner, Rgba32? glow = null) {
+        var eyes = Eye(QrPngEyeFrameStyle.Glow, outer, inner);
+        eyes.GlowRadiusPx = 28;
+        eyes.GlowAlpha = 125;
+        eyes.GlowColor = glow ?? outer;
+        return eyes;
     }
 
     private static QrPngPaletteOptions Palette(QrPngPaletteMode mode, int seed, params Rgba32[] colors) {

--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -116,6 +116,14 @@ internal static class QrStyleBoardExample {
                 scaleMap: ScaleMap(QrPngModuleScaleMode.Rings, 0.7, 1.0),
                 canvas: CanvasGradient(R(7, 21, 28), R(9, 42, 54)))),
 
+            new("Cut Corner Tech", StyleDocs("cut-corner-tech"), () => BaseSticker(
+                fg: R(80, 220, 255),
+                palette: Palette(QrPngPaletteMode.Random, 5120, R(80, 220, 255), R(100, 140, 255), R(220, 120, 255)),
+                shape: QrPngModuleShape.Rounded,
+                eyes: EyeCutCorner(R(80, 220, 255), R(220, 120, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.78, 1.0),
+                canvas: CanvasGradient(R(10, 18, 40), R(22, 38, 72)))),
+
             new("Sunset Sticker", StyleDocs("sunset-sticker"), () => BaseSticker(
                 fg: R(255, 93, 93),
                 palette: Palette(QrPngPaletteMode.Cycle, 0, R(255, 93, 93), R(255, 180, 60), R(255, 76, 193)),
@@ -268,6 +276,15 @@ internal static class QrStyleBoardExample {
     private static QrPngEyeOptions EyeInsetRing(Rgba32 outer, Rgba32 inner) {
         var eyes = Eye(QrPngEyeFrameStyle.InsetRing, outer, inner);
         eyes.InnerScale = 0.92;
+        return eyes;
+    }
+
+    private static QrPngEyeOptions EyeCutCorner(Rgba32 outer, Rgba32 inner) {
+        var eyes = Eye(QrPngEyeFrameStyle.CutCorner, outer, inner);
+        eyes.OuterShape = QrPngModuleShape.Square;
+        eyes.InnerShape = QrPngModuleShape.Rounded;
+        eyes.OuterCornerRadiusPx = 0;
+        eyes.InnerCornerRadiusPx = 4;
         return eyes;
     }
 

--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -86,6 +86,14 @@ internal static class QrStyleBoardExample {
                 scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.65, 1.0),
                 canvas: CanvasPattern(R(245, 248, 255), Pattern(QrPngBackgroundPatternType.Checker, R(121, 134, 255, 20))))),
 
+            new("Inset Rings", StyleDocs("inset-rings"), () => BaseSticker(
+                fg: R(96, 120, 255),
+                palette: Palette(QrPngPaletteMode.Rings, 0, R(96, 120, 255), R(140, 110, 255), R(120, 210, 255)),
+                shape: QrPngModuleShape.Squircle,
+                eyes: EyeInsetRing(R(96, 120, 255), R(120, 210, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.78, 1.0),
+                canvas: CanvasGradient(R(18, 20, 60), R(36, 28, 96)))),
+
             new("Ocean Grid", StyleDocs("ocean-grid"), () => BaseSticker(
                 fg: R(0, 133, 255),
                 palette: Palette(QrPngPaletteMode.Cycle, 0, R(0, 133, 255), R(0, 201, 255), R(0, 255, 196)),
@@ -254,6 +262,12 @@ internal static class QrStyleBoardExample {
         eyes.GlowRadiusPx = 28;
         eyes.GlowAlpha = 125;
         eyes.GlowColor = glow ?? outer;
+        return eyes;
+    }
+
+    private static QrPngEyeOptions EyeInsetRing(Rgba32 outer, Rgba32 inner) {
+        var eyes = Eye(QrPngEyeFrameStyle.InsetRing, outer, inner);
+        eyes.InnerScale = 0.92;
         return eyes;
     }
 

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -528,6 +528,50 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_With_Eye_CutCorner_Clears_Corner_Pixels() {
+        var qr = QrCodeEncoder.EncodeText("HELLO", QrErrorCorrectionLevel.H);
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = 6,
+            QuietZone = 4,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Eyes = new QrPngEyeOptions {
+                UseFrame = true,
+                FrameStyle = QrPngEyeFrameStyle.CutCorner,
+                OuterShape = QrPngModuleShape.Square,
+                InnerShape = QrPngModuleShape.Rounded,
+                OuterColor = Rgba32.Black,
+                InnerColor = Rgba32.Black,
+                OuterCornerRadiusPx = 0,
+                InnerCornerRadiusPx = 4,
+            },
+        };
+
+        var png = QrPngRenderer.Render(qr.Modules, opts);
+        var (rgba, _, _, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var baseX = opts.QuietZone * opts.ModuleSize;
+        var baseY = opts.QuietZone * opts.ModuleSize;
+
+        var cornerX = baseX + 1;
+        var cornerY = baseY + 1;
+        var corner = cornerY * stride + cornerX * 4;
+
+        var edgeX = baseX + 3 * opts.ModuleSize + opts.ModuleSize / 2;
+        var edgeY = baseY + opts.ModuleSize / 2;
+        var edge = edgeY * stride + edgeX * 4;
+
+        Assert.Equal(255, rgba[corner + 0]);
+        Assert.Equal(255, rgba[corner + 1]);
+        Assert.Equal(255, rgba[corner + 2]);
+
+        Assert.Equal(0, rgba[edge + 0]);
+        Assert.Equal(0, rgba[edge + 1]);
+        Assert.Equal(0, rgba[edge + 2]);
+    }
+
+    [Fact]
     public void Render_With_ScaleMap_ApplyToEyes_Affects_Eye_Modules() {
         var qr = QrCodeEncoder.EncodeText("HELLO", QrErrorCorrectionLevel.H);
 

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -159,6 +159,51 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_With_ConnectedRounded_Connects_Adjacent_Modules() {
+        var matrix = new BitMatrix(2, 2);
+        matrix[0, 0] = true;
+        matrix[1, 0] = true;
+
+        const int moduleSize = 12;
+        const int sampleY = moduleSize / 2;
+        const int sampleX = moduleSize - 1;
+
+        var rounded = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = 0,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            ModuleShape = QrPngModuleShape.Rounded,
+            ModuleScale = 0.6,
+        };
+
+        var connected = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = 0,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            ModuleShape = QrPngModuleShape.ConnectedRounded,
+            ModuleScale = 0.6,
+        };
+
+        var roundedPng = QrPngRenderer.Render(matrix, rounded);
+        var (roundedRgba, _, _, roundedStride) = PngTestDecoder.DecodeRgba32(roundedPng);
+        var connectedPng = QrPngRenderer.Render(matrix, connected);
+        var (connectedRgba, _, _, connectedStride) = PngTestDecoder.DecodeRgba32(connectedPng);
+
+        var roundedIndex = sampleY * roundedStride + sampleX * 4;
+        var connectedIndex = sampleY * connectedStride + sampleX * 4;
+
+        Assert.Equal(255, roundedRgba[roundedIndex + 0]);
+        Assert.Equal(255, roundedRgba[roundedIndex + 1]);
+        Assert.Equal(255, roundedRgba[roundedIndex + 2]);
+
+        Assert.Equal(0, connectedRgba[connectedIndex + 0]);
+        Assert.Equal(0, connectedRgba[connectedIndex + 1]);
+        Assert.Equal(0, connectedRgba[connectedIndex + 2]);
+    }
+
+    [Fact]
     public void Render_With_Foreground_Palette_Checker_Alternates_Modules() {
         var matrix = new BitMatrix(2, 2);
         matrix[0, 0] = true;

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -483,6 +483,51 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_With_Eye_InsetRing_Leaves_Center_Light_And_Ring_Dark() {
+        var qr = QrCodeEncoder.EncodeText("HELLO", QrErrorCorrectionLevel.H);
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = 6,
+            QuietZone = 4,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Eyes = new QrPngEyeOptions {
+                UseFrame = true,
+                FrameStyle = QrPngEyeFrameStyle.InsetRing,
+                OuterShape = QrPngModuleShape.Rounded,
+                InnerShape = QrPngModuleShape.Rounded,
+                OuterColor = Rgba32.Black,
+                InnerColor = Rgba32.Black,
+                OuterCornerRadiusPx = 6,
+                InnerCornerRadiusPx = 4,
+                InnerScale = 0.92,
+            },
+        };
+
+        var png = QrPngRenderer.Render(qr.Modules, opts);
+        var (rgba, _, _, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var baseX = opts.QuietZone * opts.ModuleSize;
+        var baseY = opts.QuietZone * opts.ModuleSize;
+
+        var centerPx = baseX + 3 * opts.ModuleSize + opts.ModuleSize / 2;
+        var centerPy = baseY + 3 * opts.ModuleSize + opts.ModuleSize / 2;
+        var center = centerPy * stride + centerPx * 4;
+
+        var ringPx = baseX + 3 * opts.ModuleSize + opts.ModuleSize / 2;
+        var ringPy = baseY + opts.ModuleSize / 2;
+        var ring = ringPy * stride + ringPx * 4;
+
+        Assert.Equal(255, rgba[center + 0]);
+        Assert.Equal(255, rgba[center + 1]);
+        Assert.Equal(255, rgba[center + 2]);
+
+        Assert.Equal(0, rgba[ring + 0]);
+        Assert.Equal(0, rgba[ring + 1]);
+        Assert.Equal(0, rgba[ring + 2]);
+    }
+
+    [Fact]
     public void Render_With_ScaleMap_ApplyToEyes_Affects_Eye_Modules() {
         var qr = QrCodeEncoder.EncodeText("HELLO", QrErrorCorrectionLevel.H);
 

--- a/CodeGlyphX.Tests/QrStylizedRoundTripTests.cs
+++ b/CodeGlyphX.Tests/QrStylizedRoundTripTests.cs
@@ -19,6 +19,16 @@ public sealed class QrStylizedRoundTripTests {
         RoundTripLargeStylized("https://example.com/candy-checker", CreateCandyCheckerOptions(targetSize), maxDimension, budgetMs);
     }
 
+    [Fact]
+    public void QrDecode_NewArtPresets_RoundTrip() {
+        const int targetSize = 1600;
+        const int maxDimension = 1600;
+        const int budgetMs = 9000;
+
+        RoundTripLargeStylized("https://example.com/connected-melt", CreateConnectedMeltOptions(targetSize), maxDimension, budgetMs);
+        RoundTripLargeStylized("https://example.com/neon-glow", CreateNeonGlowOptions(targetSize), maxDimension, budgetMs);
+    }
+
     private static void RoundTripLargeStylized(string payload, QrEasyOptions options, int maxDimension, int budgetMs) {
         var png = RenderPng(payload, options);
         Assert.True(ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height));
@@ -127,6 +137,101 @@ public sealed class QrStylizedRoundTripTests {
                     ThicknessPx = 1,
                     SnapToModuleSize = true,
                     ModuleStep = 2
+                }
+            }
+        };
+    }
+
+    private static QrEasyOptions CreateConnectedMeltOptions(int targetSizePx) {
+        return new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.H,
+            TargetSizePx = targetSizePx,
+            TargetSizeIncludesQuietZone = true,
+            ModuleSize = 10,
+            QuietZone = 4,
+            Foreground = R(88, 120, 255),
+            Background = R(255, 255, 255),
+            BackgroundSupersample = 2,
+            ModuleShape = QrPngModuleShape.ConnectedRounded,
+            ModuleScale = 0.9,
+            ModuleScaleMap = new QrPngModuleScaleMapOptions {
+                Mode = QrPngModuleScaleMode.Radial,
+                MinScale = 0.86,
+                MaxScale = 1.0,
+                RingSize = 2,
+            },
+            ForegroundPalette = new QrPngPaletteOptions {
+                Mode = QrPngPaletteMode.Cycle,
+                RingSize = 2,
+                ApplyToEyes = false,
+                Colors = new[] { R(88, 120, 255), R(120, 96, 255), R(88, 210, 255) }
+            },
+            Eyes = new QrPngEyeOptions {
+                UseFrame = true,
+                FrameStyle = QrPngEyeFrameStyle.Target,
+                OuterShape = QrPngModuleShape.Rounded,
+                InnerShape = QrPngModuleShape.Circle,
+                OuterColor = R(88, 120, 255),
+                InnerColor = R(88, 210, 255),
+                OuterCornerRadiusPx = 6,
+                InnerCornerRadiusPx = 4,
+            },
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = 24,
+                CornerRadiusPx = 26,
+                BackgroundGradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.DiagonalDown,
+                    StartColor = R(14, 18, 42),
+                    EndColor = R(28, 20, 76),
+                }
+            }
+        };
+    }
+
+    private static QrEasyOptions CreateNeonGlowOptions(int targetSizePx) {
+        return new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.H,
+            TargetSizePx = targetSizePx,
+            TargetSizeIncludesQuietZone = true,
+            ModuleSize = 10,
+            QuietZone = 4,
+            Foreground = R(0, 255, 240),
+            Background = R(255, 255, 255),
+            BackgroundSupersample = 2,
+            ModuleShape = QrPngModuleShape.Dot,
+            ModuleScale = 0.9,
+            ModuleScaleMap = new QrPngModuleScaleMapOptions {
+                Mode = QrPngModuleScaleMode.Radial,
+                MinScale = 0.82,
+                MaxScale = 1.0,
+                RingSize = 2,
+            },
+            ForegroundPalette = new QrPngPaletteOptions {
+                Mode = QrPngPaletteMode.Cycle,
+                RingSize = 2,
+                ApplyToEyes = false,
+                Colors = new[] { R(0, 255, 240), R(0, 170, 255), R(255, 92, 255) }
+            },
+            Eyes = new QrPngEyeOptions {
+                UseFrame = true,
+                FrameStyle = QrPngEyeFrameStyle.Glow,
+                OuterShape = QrPngModuleShape.Rounded,
+                InnerShape = QrPngModuleShape.Circle,
+                OuterColor = R(0, 255, 240),
+                InnerColor = R(255, 92, 255),
+                OuterCornerRadiusPx = 6,
+                InnerCornerRadiusPx = 4,
+                GlowRadiusPx = 30,
+                GlowAlpha = 130,
+                GlowColor = R(0, 200, 255, 200),
+            },
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = 24,
+                CornerRadiusPx = 26,
+                BackgroundGradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.DiagonalDown,
+                    StartColor = R(8, 10, 28),
+                    EndColor = R(28, 18, 64),
                 }
             }
         };

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -103,6 +103,15 @@ public sealed class RendererFormatTests {
     }
 
     [Fact]
+    public void Qr_Ascii_ConsolePreset_Is_Scan_Friendly() {
+        var payload = "https://example.com";
+        var ascii = QrEasy.RenderAscii(payload, AsciiPresets.Console(scale: 3));
+
+        Assert.Contains("█", ascii, StringComparison.Ordinal);
+        Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Qr_Ascii_Scale_Increases_Output_Size() {
         var payload = "https://example.com";
         var baseAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -112,6 +112,15 @@ public sealed class RendererFormatTests {
     }
 
     [Fact]
+    public void Qr_Ascii_ConsoleWrapper_Uses_Preset() {
+        var payload = "https://example.com";
+        var ascii = QrEasy.RenderAsciiConsole(payload, scale: 3);
+
+        Assert.Contains("█", ascii, StringComparison.Ordinal);
+        Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Qr_Ascii_Scale_Increases_Output_Size() {
         var payload = "https://example.com";
         var baseAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -79,6 +79,36 @@ public sealed class RendererFormatTests {
     }
 
     [Fact]
+    public void Qr_Ascii_UnicodeBlocks_Uses_Block_Glyphs() {
+        var payload = "https://example.com";
+        var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
+            QuietZone = 1,
+            UseUnicodeBlocks = true
+        });
+
+        Assert.Contains("█", ascii, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Qr_Ascii_Scale_Increases_Output_Size() {
+        var payload = "https://example.com";
+        var baseAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
+            QuietZone = 1,
+            ModuleWidth = 1,
+            ModuleHeight = 1,
+            Scale = 1
+        });
+        var scaledAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
+            QuietZone = 1,
+            ModuleWidth = 1,
+            ModuleHeight = 1,
+            Scale = 2
+        });
+
+        Assert.True(scaledAscii.Length > baseAscii.Length);
+    }
+
+    [Fact]
     public void Qr_Ico_Respects_MultiSize_Options() {
         var payload = "https://example.com";
         var opts = new QrEasyOptions {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -90,6 +90,19 @@ public sealed class RendererFormatTests {
     }
 
     [Fact]
+    public void Qr_Ascii_AnsiColors_Emits_Escape_Codes() {
+        var payload = "https://example.com";
+        var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
+            QuietZone = 1,
+            UseUnicodeBlocks = true,
+            UseAnsiColors = true,
+            UseAnsiTrueColor = false
+        });
+
+        Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Qr_Ascii_Scale_Increases_Output_Size() {
         var payload = "https://example.com";
         var baseAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {

--- a/CodeGlyphX/Qr/QrDecoder.Internal.cs
+++ b/CodeGlyphX/Qr/QrDecoder.Internal.cs
@@ -165,7 +165,7 @@ public static partial class QrDecoder {
 
         if (candidates.Length == 0) return false;
 
-        var functionMask = BuildFunctionMask(version, modules.Width);
+        var functionMask = QrStructureAnalysis.BuildFunctionMask(version, modules.Width);
         var failureEcc = candidates[0].ErrorCorrectionLevel;
         var failureMask = candidates[0].Mask;
         var sawPayloadFailure = false;
@@ -489,73 +489,6 @@ public static partial class QrDecoder {
             return TryCorrectAndExtractData(codewords, rawCodewords, version, ecc, shouldStop, out dataCodewords);
         } finally {
             ArrayPool<byte>.Shared.Return(codewords, clearArray: false);
-        }
-    }
-
-    private static BitMatrix BuildFunctionMask(int version, int size) {
-        var isFunction = new BitMatrix(size, size);
-
-        MarkFinder(0, 0, isFunction);
-        MarkFinder(size - 7, 0, isFunction);
-        MarkFinder(0, size - 7, isFunction);
-
-        // Timing patterns
-        for (var i = 0; i < size; i++) {
-            isFunction[6, i] = true;
-            isFunction[i, 6] = true;
-        }
-
-        // Alignment patterns
-        var align = QrTables.GetAlignmentPatternPositions(version);
-        for (var i = 0; i < align.Length; i++) {
-            for (var j = 0; j < align.Length; j++) {
-                if ((i == 0 && j == 0) || (i == 0 && j == align.Length - 1) || (i == align.Length - 1 && j == 0))
-                    continue;
-                MarkAlignment(align[i], align[j], isFunction);
-            }
-        }
-
-        // Dark module
-        isFunction[8, size - 8] = true;
-
-        // Format info
-        for (var i = 0; i <= 5; i++) isFunction[8, i] = true;
-        isFunction[8, 7] = true;
-        isFunction[8, 8] = true;
-        isFunction[7, 8] = true;
-        for (var i = 9; i < 15; i++) isFunction[14 - i, 8] = true;
-        for (var i = 0; i < 8; i++) isFunction[size - 1 - i, 8] = true;
-        for (var i = 8; i < 15; i++) isFunction[8, size - 15 + i] = true;
-
-        // Version info
-        if (version >= 7) {
-            for (var i = 0; i < 18; i++) {
-                var a = size - 11 + (i % 3);
-                var b = i / 3;
-                isFunction[a, b] = true;
-                isFunction[b, a] = true;
-            }
-        }
-
-        return isFunction;
-    }
-
-    private static void MarkFinder(int x, int y, BitMatrix isFunction) {
-        for (var dy = -1; dy <= 7; dy++) {
-            for (var dx = -1; dx <= 7; dx++) {
-                var xx = x + dx;
-                var yy = y + dy;
-                if ((uint)xx >= (uint)isFunction.Width || (uint)yy >= (uint)isFunction.Height) continue;
-                isFunction[xx, yy] = true;
-            }
-        }
-    }
-
-    private static void MarkAlignment(int x, int y, BitMatrix isFunction) {
-        for (var dy = -2; dy <= 2; dy++) {
-            for (var dx = -2; dx <= 2; dx++) {
-                isFunction[x + dx, y + dy] = true;
-            }
         }
     }
 

--- a/CodeGlyphX/Qr/QrStructureAnalysis.cs
+++ b/CodeGlyphX/Qr/QrStructureAnalysis.cs
@@ -1,0 +1,79 @@
+using CodeGlyphX.Internal;
+
+namespace CodeGlyphX.Qr;
+
+internal static class QrStructureAnalysis {
+    internal static bool TryGetVersionFromSize(int size, out int version) {
+        version = (size - 17) / 4;
+        return version is >= 1 and <= 40 && version * 4 + 17 == size;
+    }
+
+    internal static BitMatrix BuildFunctionMask(int version, int size) {
+        var isFunction = new BitMatrix(size, size);
+
+        MarkFinder(0, 0, isFunction);
+        MarkFinder(size - 7, 0, isFunction);
+        MarkFinder(0, size - 7, isFunction);
+
+        // Timing patterns
+        for (var i = 0; i < size; i++) {
+            isFunction[6, i] = true;
+            isFunction[i, 6] = true;
+        }
+
+        // Alignment patterns
+        var align = QrTables.GetAlignmentPatternPositions(version);
+        for (var i = 0; i < align.Length; i++) {
+            for (var j = 0; j < align.Length; j++) {
+                if ((i == 0 && j == 0) || (i == 0 && j == align.Length - 1) || (i == align.Length - 1 && j == 0)) {
+                    continue;
+                }
+                MarkAlignment(align[i], align[j], isFunction);
+            }
+        }
+
+        // Dark module
+        isFunction[8, size - 8] = true;
+
+        // Format info
+        for (var i = 0; i <= 5; i++) isFunction[8, i] = true;
+        isFunction[8, 7] = true;
+        isFunction[8, 8] = true;
+        isFunction[7, 8] = true;
+        for (var i = 9; i < 15; i++) isFunction[14 - i, 8] = true;
+        for (var i = 0; i < 8; i++) isFunction[size - 1 - i, 8] = true;
+        for (var i = 8; i < 15; i++) isFunction[8, size - 15 + i] = true;
+
+        // Version info
+        if (version >= 7) {
+            for (var i = 0; i < 18; i++) {
+                var a = size - 11 + (i % 3);
+                var b = i / 3;
+                isFunction[a, b] = true;
+                isFunction[b, a] = true;
+            }
+        }
+
+        return isFunction;
+    }
+
+    private static void MarkFinder(int x, int y, BitMatrix isFunction) {
+        for (var dy = -1; dy <= 7; dy++) {
+            for (var dx = -1; dx <= 7; dx++) {
+                var xx = x + dx;
+                var yy = y + dy;
+                if ((uint)xx >= (uint)isFunction.Width || (uint)yy >= (uint)isFunction.Height) continue;
+                isFunction[xx, yy] = true;
+            }
+        }
+    }
+
+    private static void MarkAlignment(int x, int y, BitMatrix isFunction) {
+        for (var dy = -2; dy <= 2; dy++) {
+            for (var dx = -2; dx <= 2; dx++) {
+                isFunction[x + dx, y + dy] = true;
+            }
+        }
+    }
+}
+

--- a/CodeGlyphX/QrArtSafety.cs
+++ b/CodeGlyphX/QrArtSafety.cs
@@ -33,6 +33,14 @@ public enum QrArtWarningKind {
     /// </summary>
     ModuleScaleTooSmall,
     /// <summary>
+    /// Functional patterns are not protected while decorative styling is enabled.
+    /// </summary>
+    FunctionalPatternsUnprotected,
+    /// <summary>
+    /// Background pattern may be drawn into the quiet zone.
+    /// </summary>
+    QuietZonePatterned,
+    /// <summary>
     /// Logo covers too much of the QR area.
     /// </summary>
     LogoTooLarge,
@@ -126,6 +134,22 @@ public static class QrArtSafety {
         }
         if (minScale < 0.8) {
             Add(QrArtWarningKind.ModuleScaleTooSmall, "Module scale below 0.8 can weaken timing/finder clarity.", 10);
+        }
+
+        var hasDecorativeModules = options.ModuleShape != QrPngModuleShape.Square
+            || options.ModuleScale < 1.0
+            || options.ModuleScaleMap is not null
+            || options.ForegroundGradient is not null
+            || options.ForegroundPalette is not null
+            || options.ForegroundPaletteZones is not null
+            || options.Eyes is not null;
+
+        if (!options.ProtectFunctionalPatterns && hasDecorativeModules) {
+            Add(QrArtWarningKind.FunctionalPatternsUnprotected, "Decorative styling without functional pattern protection can reduce scan reliability.", 15);
+        }
+
+        if (options.BackgroundPattern is not null && options.QuietZone > 0 && !options.ProtectQuietZone) {
+            Add(QrArtWarningKind.QuietZonePatterned, "Background patterns should avoid the quiet zone to preserve scan detection.", 20);
         }
 
         var bg = options.BackgroundGradient is null

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -33,6 +33,8 @@ public static partial class QrEasy {
             BackgroundGradient = opts.BackgroundGradient,
             BackgroundPattern = opts.BackgroundPattern,
             BackgroundSupersample = opts.BackgroundSupersample,
+            ProtectFunctionalPatterns = opts.ProtectFunctionalPatterns,
+            ProtectQuietZone = opts.ProtectQuietZone,
             Canvas = opts.Canvas,
             Debug = opts.Debug,
         };
@@ -220,6 +222,8 @@ public static partial class QrEasy {
             ModuleShape = opts.ModuleShape,
             ModuleScale = opts.ModuleScale,
             ModuleScaleMap = opts.ModuleScaleMap,
+            ProtectFunctionalPatterns = opts.ProtectFunctionalPatterns,
+            ProtectQuietZone = opts.ProtectQuietZone,
             ModuleCornerRadiusPx = opts.ModuleCornerRadiusPx,
             ForegroundGradient = opts.ForegroundGradient,
             ForegroundPalette = opts.ForegroundPalette,

--- a/CodeGlyphX/QrEasy.Render.B.cs
+++ b/CodeGlyphX/QrEasy.Render.B.cs
@@ -625,6 +625,34 @@ public static partial class QrEasy {
     }
 
     /// <summary>
+    /// Renders a QR code as console-friendly ASCII using scan-oriented defaults.
+    /// </summary>
+    public static string RenderAsciiConsole(
+        string payload,
+        int scale = 4,
+        bool useAnsiColors = true,
+        bool trueColor = true,
+        Rgba32? darkColor = null,
+        QrEasyOptions? options = null) {
+        var preset = AsciiPresets.Console(scale, useAnsiColors, trueColor, darkColor);
+        return RenderAscii(payload, preset, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as console-friendly ASCII using scan-oriented defaults for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderAsciiConsole(
+        QrPayloadData payload,
+        int scale = 4,
+        bool useAnsiColors = true,
+        bool trueColor = true,
+        Rgba32? darkColor = null,
+        QrEasyOptions? options = null) {
+        var preset = AsciiPresets.Console(scale, useAnsiColors, trueColor, darkColor);
+        return RenderAscii(payload, preset, options);
+    }
+
+    /// <summary>
     /// Renders a QR code to a raw RGBA pixel buffer (no PNG encoding).
     /// </summary>
     public static byte[] RenderPixels(string payload, out int widthPx, out int heightPx, out int stride, QrEasyOptions? options = null) {

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -108,6 +108,16 @@ public sealed class QrEasyOptions {
     public QrPngModuleScaleMapOptions? ModuleScaleMap { get; set; }
 
     /// <summary>
+    /// When true, keeps non-eye functional patterns at a stable, scan-friendly style.
+    /// </summary>
+    public bool ProtectFunctionalPatterns { get; set; } = true;
+
+    /// <summary>
+    /// When true and a background pattern is enabled, preserves a clean quiet zone.
+    /// </summary>
+    public bool ProtectQuietZone { get; set; } = true;
+
+    /// <summary>
     /// Overrides the module corner radius in pixels.
     /// </summary>
     public int? ModuleCornerRadiusPx { get; set; }

--- a/CodeGlyphX/Rendering/Ascii/AsciiPresets.cs
+++ b/CodeGlyphX/Rendering/Ascii/AsciiPresets.cs
@@ -1,0 +1,35 @@
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Ready-to-use ASCII render presets tuned for console readability.
+/// </summary>
+public static class AsciiPresets {
+    /// <summary>
+    /// Creates a console-friendly preset that is much easier to scan from a terminal.
+    /// </summary>
+    /// <param name="scale">Scale multiplier applied to module size (try 3-5 for phones).</param>
+    /// <param name="useAnsiColors">Whether to emit ANSI color escape codes.</param>
+    /// <param name="trueColor">Whether to use ANSI truecolor (24-bit) output.</param>
+    /// <param name="darkColor">Optional ANSI color for dark modules.</param>
+    public static MatrixAsciiRenderOptions Console(
+        int scale = 3,
+        bool useAnsiColors = true,
+        bool trueColor = true,
+        Rgba32? darkColor = null) {
+        if (scale <= 0) scale = 1;
+
+        return new MatrixAsciiRenderOptions {
+            QuietZone = RenderDefaults.QrQuietZone,
+            UseUnicodeBlocks = true,
+            UseAnsiColors = useAnsiColors,
+            UseAnsiTrueColor = trueColor,
+            AnsiDarkColor = darkColor ?? new Rgba32(16, 16, 16),
+            Scale = scale,
+            ModuleWidth = 2,
+            ModuleHeight = 1,
+        };
+    }
+}

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX.Rendering.Ascii;
 
@@ -50,4 +51,29 @@ public sealed partial class MatrixAsciiRenderOptions {
     /// When true, swaps dark and light output.
     /// </summary>
     public bool Invert { get; set; }
+
+    /// <summary>
+    /// When true, emits ANSI color escape codes for dark (and optionally light) modules.
+    /// </summary>
+    public bool UseAnsiColors { get; set; }
+
+    /// <summary>
+    /// When true, uses 24-bit ANSI colors; otherwise maps to ANSI 256-color.
+    /// </summary>
+    public bool UseAnsiTrueColor { get; set; } = true;
+
+    /// <summary>
+    /// ANSI color for dark modules.
+    /// </summary>
+    public Rgba32 AnsiDarkColor { get; set; } = new(0, 0, 0);
+
+    /// <summary>
+    /// ANSI color for light modules.
+    /// </summary>
+    public Rgba32 AnsiLightColor { get; set; } = new(255, 255, 255);
+
+    /// <summary>
+    /// When true, also colorizes light modules; otherwise leaves them uncolored.
+    /// </summary>
+    public bool AnsiColorizeLight { get; set; }
 }

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
@@ -22,6 +22,11 @@ public sealed partial class MatrixAsciiRenderOptions {
     public int ModuleHeight { get; set; } = 1;
 
     /// <summary>
+    /// Additional scale multiplier applied to both module width and height.
+    /// </summary>
+    public int Scale { get; set; } = 1;
+
+    /// <summary>
     /// Character(s) used for dark modules.
     /// </summary>
     public string Dark { get; set; } = "#";
@@ -35,4 +40,14 @@ public sealed partial class MatrixAsciiRenderOptions {
     /// Line separator used between rows.
     /// </summary>
     public string NewLine { get; set; } = Environment.NewLine;
+
+    /// <summary>
+    /// When true, prefers Unicode block glyphs (for example, █) when defaults are used.
+    /// </summary>
+    public bool UseUnicodeBlocks { get; set; }
+
+    /// <summary>
+    /// When true, swaps dark and light output.
+    /// </summary>
+    public bool Invert { get; set; }
 }

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -15,11 +15,25 @@ public static class MatrixAsciiRenderer {
         var opts = options ?? new MatrixAsciiRenderOptions();
 
         var quiet = Math.Max(0, opts.QuietZone);
-        var moduleWidth = Math.Max(1, opts.ModuleWidth);
-        var moduleHeight = Math.Max(1, opts.ModuleHeight);
+        var scale = Math.Max(1, opts.Scale);
+        var moduleWidth = Math.Max(1, opts.ModuleWidth) * scale;
+        var moduleHeight = Math.Max(1, opts.ModuleHeight) * scale;
         var dark = string.IsNullOrEmpty(opts.Dark) ? "#" : opts.Dark;
         var light = string.IsNullOrEmpty(opts.Light) ? " " : opts.Light;
         var newline = NormalizeNewLine(opts.NewLine) ?? Environment.NewLine;
+
+        if (opts.UseUnicodeBlocks) {
+            if (string.IsNullOrEmpty(opts.Dark) || string.Equals(opts.Dark, "#", StringComparison.Ordinal)) {
+                dark = "█";
+            }
+            if (string.IsNullOrEmpty(opts.Light) || string.Equals(opts.Light, " ", StringComparison.Ordinal)) {
+                light = " ";
+            }
+        }
+
+        if (opts.Invert) {
+            (dark, light) = (light, dark);
+        }
 
         var widthModules = modules.Width + quiet * 2;
         var heightModules = modules.Height + quiet * 2;

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX.Rendering.Ascii;
 
@@ -21,6 +22,11 @@ public static class MatrixAsciiRenderer {
         var dark = string.IsNullOrEmpty(opts.Dark) ? "#" : opts.Dark;
         var light = string.IsNullOrEmpty(opts.Light) ? " " : opts.Light;
         var newline = NormalizeNewLine(opts.NewLine) ?? Environment.NewLine;
+        var useAnsi = opts.UseAnsiColors;
+        var ansiTrueColor = opts.UseAnsiTrueColor;
+        var ansiDarkColor = opts.AnsiDarkColor;
+        var ansiLightColor = opts.AnsiLightColor;
+        var ansiColorizeLight = opts.AnsiColorizeLight;
 
         if (opts.UseUnicodeBlocks) {
             if (string.IsNullOrEmpty(opts.Dark) || string.Equals(opts.Dark, "#", StringComparison.Ordinal)) {
@@ -33,14 +39,30 @@ public static class MatrixAsciiRenderer {
 
         if (opts.Invert) {
             (dark, light) = (light, dark);
+            (ansiDarkColor, ansiLightColor) = (ansiLightColor, ansiDarkColor);
+        }
+
+        if (useAnsi && (string.IsNullOrEmpty(opts.Dark) || string.Equals(opts.Dark, "#", StringComparison.Ordinal))) {
+            dark = "█";
         }
 
         var widthModules = modules.Width + quiet * 2;
         var heightModules = modules.Height + quiet * 2;
         if (widthModules <= 0 || heightModules <= 0) return string.Empty;
 
-        var darkCell = Repeat(dark, moduleWidth);
-        var lightCell = Repeat(light, moduleWidth);
+        var darkContent = Repeat(dark, moduleWidth);
+        var lightContent = Repeat(light, moduleWidth);
+
+        var darkCell = darkContent;
+        var lightCell = lightContent;
+        if (useAnsi) {
+            var darkPrefix = BuildAnsiColorPrefix(CompositeOverWhite(ansiDarkColor), ansiTrueColor);
+            darkCell = darkPrefix + darkContent + AnsiReset;
+            if (ansiColorizeLight) {
+                var lightPrefix = BuildAnsiColorPrefix(CompositeOverWhite(ansiLightColor), ansiTrueColor);
+                lightCell = lightPrefix + lightContent + AnsiReset;
+            }
+        }
 
         var lineCapacity = widthModules * darkCell.Length;
         var sb = new StringBuilder((lineCapacity + newline.Length) * heightModules * moduleHeight);
@@ -72,6 +94,48 @@ public static class MatrixAsciiRenderer {
         var sb = new StringBuilder(text.Length * count);
         for (var i = 0; i < count; i++) sb.Append(text);
         return sb.ToString();
+    }
+
+    private const string AnsiReset = "\u001b[0m";
+
+    private static string BuildAnsiColorPrefix(Rgba32 color, bool trueColor) {
+        if (trueColor) {
+            return $"\u001b[38;2;{color.R};{color.G};{color.B}m";
+        }
+        var index = MapRgbToAnsi256(color.R, color.G, color.B);
+        return $"\u001b[38;5;{index}m";
+    }
+
+    private static Rgba32 CompositeOverWhite(Rgba32 color) {
+        if (color.A == 255) return color;
+        var a = color.A;
+        var invA = 255 - a;
+        var r = (byte)((color.R * a + 255 * invA + 127) / 255);
+        var g = (byte)((color.G * a + 255 * invA + 127) / 255);
+        var b = (byte)((color.B * a + 255 * invA + 127) / 255);
+        return new Rgba32(r, g, b, 255);
+    }
+
+    private static int MapRgbToAnsi256(byte r, byte g, byte b) {
+        if (r == g && g == b) {
+            if (r < 8) return 16;
+            if (r > 248) return 231;
+            var gray = (int)Math.Round((r - 8) / 247.0 * 24.0);
+            if (gray < 0) gray = 0;
+            if (gray > 23) gray = 23;
+            return 232 + gray;
+        }
+
+        var ri = (int)Math.Round(r / 255.0 * 5.0);
+        var gi = (int)Math.Round(g / 255.0 * 5.0);
+        var bi = (int)Math.Round(b / 255.0 * 5.0);
+        if (ri < 0) ri = 0;
+        if (ri > 5) ri = 5;
+        if (gi < 0) gi = 0;
+        if (gi > 5) gi = 5;
+        if (bi < 0) bi = 0;
+        if (bi > 5) bi = 5;
+        return 16 + 36 * ri + 6 * gi + bi;
     }
 
     private static string? NormalizeNewLine(string? value) {

--- a/CodeGlyphX/Rendering/Ascii/RenderOptions.Fluent.cs
+++ b/CodeGlyphX/Rendering/Ascii/RenderOptions.Fluent.cs
@@ -1,3 +1,5 @@
+using CodeGlyphX.Rendering.Png;
+
 namespace CodeGlyphX.Rendering.Ascii;
 
 public sealed partial class MatrixAsciiRenderOptions {
@@ -70,6 +72,46 @@ public sealed partial class MatrixAsciiRenderOptions {
     /// </summary>
     public MatrixAsciiRenderOptions WithInvert(bool enabled = true) {
         Invert = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables ANSI color escape codes.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiColors(bool enabled = true) {
+        UseAnsiColors = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables ANSI truecolor (24-bit) output.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiTrueColor(bool enabled = true) {
+        UseAnsiTrueColor = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the ANSI color for dark modules.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiDarkColor(Rgba32 color) {
+        AnsiDarkColor = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the ANSI color for light modules.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiLightColor(Rgba32 color) {
+        AnsiLightColor = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables ANSI colorization of light modules.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiColorizeLight(bool enabled = true) {
+        AnsiColorizeLight = enabled;
         return this;
     }
 }

--- a/CodeGlyphX/Rendering/Ascii/RenderOptions.Fluent.cs
+++ b/CodeGlyphX/Rendering/Ascii/RenderOptions.Fluent.cs
@@ -26,6 +26,14 @@ public sealed partial class MatrixAsciiRenderOptions {
     }
 
     /// <summary>
+    /// Sets an additional scale multiplier applied to both module width and height.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithScale(int scale) {
+        Scale = scale;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the character(s) used for dark modules.
     /// </summary>
     public MatrixAsciiRenderOptions WithDark(string dark) {
@@ -46,6 +54,22 @@ public sealed partial class MatrixAsciiRenderOptions {
     /// </summary>
     public MatrixAsciiRenderOptions WithNewLine(string newLine) {
         NewLine = newLine;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables Unicode block glyphs when defaults are used.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithUnicodeBlocks(bool enabled = true) {
+        UseUnicodeBlocks = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables inverted output (dark/light swapped).
+    /// </summary>
+    public MatrixAsciiRenderOptions WithInvert(bool enabled = true) {
+        Invert = enabled;
         return this;
     }
 }

--- a/CodeGlyphX/Rendering/Png/QrPngEyeFrameStyle.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngEyeFrameStyle.cs
@@ -28,4 +28,8 @@ public enum QrPngEyeFrameStyle {
     /// Single frame with a soft glow halo behind it.
     /// </summary>
     Glow,
+    /// <summary>
+    /// Outer ring with an inset inner ring and a clear center.
+    /// </summary>
+    InsetRing,
 }

--- a/CodeGlyphX/Rendering/Png/QrPngEyeFrameStyle.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngEyeFrameStyle.cs
@@ -24,4 +24,8 @@ public enum QrPngEyeFrameStyle {
     /// Bold badge frame with thicker border.
     /// </summary>
     Badge,
+    /// <summary>
+    /// Single frame with a soft glow halo behind it.
+    /// </summary>
+    Glow,
 }

--- a/CodeGlyphX/Rendering/Png/QrPngEyeFrameStyle.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngEyeFrameStyle.cs
@@ -32,4 +32,8 @@ public enum QrPngEyeFrameStyle {
     /// Outer ring with an inset inner ring and a clear center.
     /// </summary>
     InsetRing,
+    /// <summary>
+    /// Square frame with corners cut away for a tech-like look.
+    /// </summary>
+    CutCorner,
 }

--- a/CodeGlyphX/Rendering/Png/QrPngEyeOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngEyeOptions.cs
@@ -66,9 +66,26 @@ public sealed class QrPngEyeOptions {
     /// </summary>
     public QrPngGradientOptions? InnerGradient { get; set; }
 
+    /// <summary>
+    /// Optional glow radius in pixels when <see cref="FrameStyle"/> is <see cref="QrPngEyeFrameStyle.Glow"/>.
+    /// A value of 0 uses a reasonable default based on module size.
+    /// </summary>
+    public int GlowRadiusPx { get; set; }
+
+    /// <summary>
+    /// Optional glow color override. Defaults to the outer eye color.
+    /// </summary>
+    public Rgba32? GlowColor { get; set; }
+
+    /// <summary>
+    /// Maximum glow alpha (0..255) when <see cref="FrameStyle"/> is <see cref="QrPngEyeFrameStyle.Glow"/>.
+    /// </summary>
+    public byte GlowAlpha { get; set; } = 110;
+
     internal void Validate() {
         if (OuterScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(OuterScale));
         if (InnerScale is <= 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(InnerScale));
+        if (GlowRadiusPx < 0) throw new ArgumentOutOfRangeException(nameof(GlowRadiusPx));
         OuterGradient?.Validate();
         InnerGradient?.Validate();
     }

--- a/CodeGlyphX/Rendering/Png/QrPngModuleShape.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngModuleShape.cs
@@ -17,6 +17,10 @@ public enum QrPngModuleShape {
     /// </summary>
     Rounded,
     /// <summary>
+    /// Rounded modules that connect to adjacent dark modules.
+    /// </summary>
+    ConnectedRounded,
+    /// <summary>
     /// Diamond-shaped modules.
     /// </summary>
     Diamond,

--- a/CodeGlyphX/Rendering/Png/QrPngRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderOptions.cs
@@ -87,6 +87,17 @@ public sealed partial class QrPngRenderOptions {
     public QrPngModuleScaleMapOptions? ModuleScaleMap { get; set; }
 
     /// <summary>
+    /// When true, keeps non-eye functional patterns (timing/alignment/format/version/dark module)
+    /// at full scale and a stable foreground color for scan reliability.
+    /// </summary>
+    public bool ProtectFunctionalPatterns { get; set; } = true;
+
+    /// <summary>
+    /// When true and a background pattern is enabled, skips drawing the pattern inside the quiet zone.
+    /// </summary>
+    public bool ProtectQuietZone { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the corner radius in pixels for <see cref="QrPngModuleShape.Rounded"/>.
     /// </summary>
     public int ModuleCornerRadiusPx { get; set; }

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
@@ -156,7 +156,7 @@ public static partial class QrPngRenderer {
 
                 if (!protectFunctional
                     && scaleMapInfo.HasValue
-                    && (eyeKind == EyeKind.None || (scaleMapInfo.Value.ApplyToEyes && opts.Eyes is null))) {
+                    && (eyeKind == EyeKind.None || scaleMapInfo.Value.ApplyToEyes)) {
                     var scale = ClampScale(opts.ModuleScale * GetScaleFactor(scaleMapInfo.Value, mx, my));
                     var maskInfo = GetScaleMask(scaleMaskCache!, opts.ModuleSize, opts.ModuleShape, scale, opts.ModuleCornerRadiusPx);
                     useMask = maskInfo.Mask;

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
@@ -233,9 +233,9 @@ public static partial class QrPngRenderer {
         }
 
         if (useFrame && opts.Eyes is not null) {
-            DrawEyeFrame(buffer, widthPx, heightPx, stride, opts, qrOffsetX, qrOffsetY, 0, 0);
-            DrawEyeFrame(buffer, widthPx, heightPx, stride, opts, qrOffsetX, qrOffsetY, size - 7, 0);
-            DrawEyeFrame(buffer, widthPx, heightPx, stride, opts, qrOffsetX, qrOffsetY, 0, size - 7);
+            DrawEyeFrame(buffer, widthPx, heightPx, stride, opts, qrOffsetX, qrOffsetY, qrOriginX, qrOriginY, qrSizePx, 0, 0);
+            DrawEyeFrame(buffer, widthPx, heightPx, stride, opts, qrOffsetX, qrOffsetY, qrOriginX, qrOriginY, qrSizePx, size - 7, 0);
+            DrawEyeFrame(buffer, widthPx, heightPx, stride, opts, qrOffsetX, qrOffsetY, qrOriginX, qrOriginY, qrSizePx, 0, size - 7);
         }
 
         if (opts.Logo is not null) {

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1080,7 +1080,23 @@ public static partial class QrPngRenderer {
                 FillBackgroundGradient(temp, scaledWidth, scaledHeight, scaledStride, scaledOpts.BackgroundGradient);
             }
             if (scaledOpts.BackgroundPattern is not null) {
-                DrawCanvasPattern(temp, scaledWidth, scaledHeight, scaledStride, scaledQrOffsetX, scaledQrOffsetY, scaledQrFullPx, scaledQrFullPx, scaledOpts.ModuleSize, 0, scaledOpts.BackgroundPattern);
+                var quietZonePx = scaledOpts.QuietZone * scaledOpts.ModuleSize;
+                var qrSizePx = Math.Max(0, scaledQrFullPx - quietZonePx * 2);
+                DrawCanvasPattern(
+                    temp,
+                    scaledWidth,
+                    scaledHeight,
+                    scaledStride,
+                    scaledQrOffsetX,
+                    scaledQrOffsetY,
+                    scaledQrFullPx,
+                    scaledQrFullPx,
+                    scaledOpts.ModuleSize,
+                    0,
+                    quietZonePx,
+                    qrSizePx,
+                    scaledOpts.ProtectQuietZone,
+                    scaledOpts.BackgroundPattern);
             }
         } else {
             PngRenderHelpers.FillBackground(temp, scaledWidth, scaledHeight, scaledStride, Rgba32.Transparent);
@@ -1100,6 +1116,8 @@ public static partial class QrPngRenderer {
             BackgroundGradient = opts.BackgroundGradient,
             BackgroundPattern = ScalePattern(opts.BackgroundPattern, scale),
             BackgroundSupersample = 1,
+            ProtectFunctionalPatterns = opts.ProtectFunctionalPatterns,
+            ProtectQuietZone = opts.ProtectQuietZone,
             Canvas = ScaleCanvas(opts.Canvas, scale),
         };
     }

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -205,6 +205,7 @@ public static partial class QrPngRenderer {
                 FillEllipse(scanlines, widthPx, heightPx, stride, x, y, w, h, color);
                 return;
             case QrPngModuleShape.Rounded:
+            case QrPngModuleShape.ConnectedRounded:
                 FillRoundedRect(scanlines, widthPx, heightPx, stride, x, y, w, h, color, radius);
                 return;
             case QrPngModuleShape.Diamond:
@@ -248,6 +249,7 @@ public static partial class QrPngRenderer {
                 FillEllipseGradient(scanlines, widthPx, heightPx, stride, x, y, w, h, gradient);
                 return;
             case QrPngModuleShape.Rounded:
+            case QrPngModuleShape.ConnectedRounded:
                 FillRoundedRectGradient(scanlines, widthPx, heightPx, stride, x, y, w, h, gradient, radius);
                 return;
             case QrPngModuleShape.Diamond:

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -113,6 +113,34 @@ public static partial class QrPngRenderer {
                         qrY1);
                 }
                 goto default;
+            case QrPngEyeFrameStyle.InsetRing:
+                if (outerGradient is null) {
+                    FillShape(scanlines, widthPx, heightPx, stride, outerX, outerY, outerScaled, outerScaled, outerColor, eye.OuterShape, eye.OuterCornerRadiusPx);
+                } else {
+                    FillShapeGradient(scanlines, widthPx, heightPx, stride, outerX, outerY, outerScaled, outerScaled, outerGradient, eye.OuterShape, eye.OuterCornerRadiusPx);
+                }
+                FillShape(scanlines, widthPx, heightPx, stride, innerX, innerY, innerScaled, innerScaled, opts.Background, eye.OuterShape, eye.InnerCornerRadiusPx);
+
+                var insetPadding = Math.Max(1, (int)Math.Round(moduleSize * 0.8));
+                var insetSize = Math.Max(1, innerScaled - insetPadding * 2);
+                var insetX = innerX + (innerScaled - insetSize) / 2;
+                var insetY = innerY + (innerScaled - insetSize) / 2;
+                if (insetSize > 0) {
+                    if (innerGradient is null) {
+                        FillShape(scanlines, widthPx, heightPx, stride, insetX, insetY, insetSize, insetSize, innerColor, eye.InnerShape, eye.InnerCornerRadiusPx);
+                    } else {
+                        FillShapeGradient(scanlines, widthPx, heightPx, stride, insetX, insetY, insetSize, insetSize, innerGradient, eye.InnerShape, eye.InnerCornerRadiusPx);
+                    }
+                }
+
+                var maxHoleSize = insetSize - 2;
+                if (maxHoleSize > 0) {
+                    var holeSize = Math.Max(1, Math.Min(dotScaled, maxHoleSize));
+                    var holeX = x0 + (outerSize - holeSize) / 2;
+                    var holeY = y0 + (outerSize - holeSize) / 2;
+                    FillShape(scanlines, widthPx, heightPx, stride, holeX, holeY, holeSize, holeSize, opts.Background, eye.InnerShape, eye.InnerCornerRadiusPx);
+                }
+                break;
             case QrPngEyeFrameStyle.DoubleRing:
             case QrPngEyeFrameStyle.Target:
                 if (outerGradient is null) {

--- a/CodeGlyphX/Rendering/Svg/SvgQrRenderer.cs
+++ b/CodeGlyphX/Rendering/Svg/SvgQrRenderer.cs
@@ -253,6 +253,7 @@ public static class SvgQrRenderer {
         if (scale <= 0) return;
         if (scale > 1.0) scale = 1.0;
 
+        if (shape == QrPngModuleShape.ConnectedRounded) shape = QrPngModuleShape.Rounded;
         if (shape == QrPngModuleShape.Dot) scale *= QrPngShapeDefaults.DotScale;
         if (shape == QrPngModuleShape.DotGrid) {
             AppendDotGrid(sb, cellX, cellY, cellSize, scale, fill);


### PR DESCRIPTION
## Summary\n- add opt-out protection flags for functional patterns and quiet zone\n- keep timing/alignment/format/version/dark module scan-friendly under heavy styling\n- prevent background patterns from dirtying the quiet zone by default\n- extend QR art safety warnings for these risks\n- add targeted renderer tests\n\n## Testing\n- ran: dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release --filter FullyQualifiedName~QrPngRendererTests (16/16 passed)\n- full suite is not green in this environment due to missing PNGSuite fixtures and the known stylized round-trip failure