### PR TITLE
Tune aggressive QR finder scan and add hard-art diagnostics

### DIFF
--- a/CodeGlyphX.Examples/ExampleDebug.cs
+++ b/CodeGlyphX.Examples/ExampleDebug.cs
@@ -1,0 +1,18 @@
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX.Examples;
+
+internal static class ExampleDebug {
+    public static void WriteQrDebugImages(byte[] rgba, int width, int height, int stride, string debugDir, string baseName) {
+        var opts = new QrPixelDebugOptions();
+        QrPixelDebug.RenderToFile(rgba, width, height, stride, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin.png", opts);
+
+        var adaptive = new QrPixelDebugOptions {
+            AdaptiveThreshold = true,
+            AdaptiveWindowSize = 15,
+            AdaptiveOffset = 8
+        };
+        QrPixelDebug.RenderToFile(rgba, width, height, stride, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin-adaptive.png", adaptive);
+        QrPixelDebug.RenderToFile(rgba, width, height, stride, PixelFormat.Rgba32, QrPixelDebugMode.Heatmap, debugDir, $"{baseName}-heatmap.png", opts);
+    }
+}

--- a/CodeGlyphX.Examples/ExamplePaths.cs
+++ b/CodeGlyphX.Examples/ExamplePaths.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+
+namespace CodeGlyphX.Examples;
+
+internal static class ExamplePaths {
+    public static string ResolveSamplesDir(string relativePath) {
+        if (string.IsNullOrWhiteSpace(relativePath)) {
+            throw new ArgumentException("Path is required.", nameof(relativePath));
+        }
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 10 && dir is not null; i++) {
+            var candidate = Path.Combine(dir.FullName, relativePath);
+            if (Directory.Exists(candidate)) {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate sample directory '{relativePath}'.");
+    }
+}

--- a/CodeGlyphX.Examples/Program.cs
+++ b/CodeGlyphX.Examples/Program.cs
@@ -19,6 +19,15 @@ internal static class Program {
             return;
         }
 
+        var runHardArtDiagnostics = Environment.GetEnvironmentVariable("CODEGLYPHX_DECODE_HARD_ART");
+        if (!string.IsNullOrEmpty(runHardArtDiagnostics) &&
+            (string.Equals(runHardArtDiagnostics, "1", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(runHardArtDiagnostics, "true", StringComparison.OrdinalIgnoreCase))) {
+            runner.Run("QR (hard art diagnostics)", QrHardArtDiagnosticsExample.Run);
+            runner.PrintSummary();
+            return;
+        }
+
         var runDecodeSamples = Environment.GetEnvironmentVariable("CODEGLYPHX_DECODE_SAMPLES");
         if (!string.IsNullOrEmpty(runDecodeSamples) &&
             (string.Equals(runDecodeSamples, "1", StringComparison.OrdinalIgnoreCase) ||

--- a/CodeGlyphX.Examples/QrDecodeSamplesExample.cs
+++ b/CodeGlyphX.Examples/QrDecodeSamplesExample.cs
@@ -11,7 +11,7 @@ internal static class QrDecodeSamplesExample {
     private static readonly string[] ImageExtensions = { ".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp", ".tga" };
 
     public static void Run(string outputDir) {
-        var sampleDir = ResolveSamplesDir("Assets/DecodingSamples");
+        var sampleDir = ExamplePaths.ResolveSamplesDir("Assets/DecodingSamples");
         var files = Directory.EnumerateFiles(sampleDir)
             .Where(path => ImageExtensions.Contains(Path.GetExtension(path), StringComparer.OrdinalIgnoreCase))
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
@@ -61,17 +61,7 @@ internal static class QrDecodeSamplesExample {
                 lines.Add($"{name}: FAIL {info}");
                 if (debugOutputs && ImageReader.TryDecodeRgba32(bytes, out var rgba, out var width, out var height)) {
                     var baseName = Path.GetFileNameWithoutExtension(name);
-                    var opts = new QrPixelDebugOptions();
-                    QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin.png", opts);
-
-                    var adaptive = new QrPixelDebugOptions {
-                        AdaptiveThreshold = true,
-                        AdaptiveWindowSize = 15,
-                        AdaptiveOffset = 8
-                    };
-                    QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin-adaptive.png", adaptive);
-
-                    QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Heatmap, debugDir, $"{baseName}-heatmap.png", opts);
+                    ExampleDebug.WriteQrDebugImages(rgba, width, height, width * 4, debugDir, baseName);
                 }
             }
         }
@@ -114,23 +104,5 @@ internal static class QrDecodeSamplesExample {
     private static bool ReadBoolEnv(string name, bool fallback) {
         var value = Environment.GetEnvironmentVariable(name);
         return bool.TryParse(value, out var parsed) ? parsed : fallback;
-    }
-
-    private static string ResolveSamplesDir(string relativePath) {
-        if (string.IsNullOrWhiteSpace(relativePath)) {
-            throw new ArgumentException("Path is required.", nameof(relativePath));
-        }
-
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && dir is not null; i++) {
-            var candidate = Path.Combine(dir.FullName, relativePath);
-            if (Directory.Exists(candidate)) {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException($"Could not locate sample directory '{relativePath}'.");
     }
 }

--- a/CodeGlyphX.Examples/QrDecodeSamplesExample.cs
+++ b/CodeGlyphX.Examples/QrDecodeSamplesExample.cs
@@ -17,7 +17,7 @@ internal static class QrDecodeSamplesExample {
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        var options = new QrPixelDecodeOptions {
+        var baseOptions = new QrPixelDecodeOptions {
             Profile = QrDecodeProfile.Robust,
             MaxDimension = 2400,
             BudgetMilliseconds = 2500,
@@ -29,7 +29,7 @@ internal static class QrDecodeSamplesExample {
         var lines = new List<string> {
             $"SampleDir: {sampleDir}",
             $"Files: {files.Length}",
-            $"Options: Profile={options.Profile}, MaxDimension={options.MaxDimension}, BudgetMilliseconds={options.BudgetMilliseconds}, AggressiveSampling={options.AggressiveSampling}, StylizedSampling={options.StylizedSampling}, EnableTileScan={options.EnableTileScan}",
+            $"Options: Profile={baseOptions.Profile}, MaxDimension={baseOptions.MaxDimension}, BudgetMilliseconds={baseOptions.BudgetMilliseconds}, AggressiveSampling={baseOptions.AggressiveSampling}, StylizedSampling={baseOptions.StylizedSampling}, EnableTileScan={baseOptions.EnableTileScan}",
             string.Empty
         };
         var debugOutputs = ReadBoolEnv("CODEGLYPHX_DECODE_SAMPLES_DEBUG", false);
@@ -41,6 +41,7 @@ internal static class QrDecodeSamplesExample {
         foreach (var file in files) {
             var bytes = File.ReadAllBytes(file);
             var name = Path.GetFileName(file);
+            var options = SelectOptionsForSample(name, baseOptions);
 
             if (QrImageDecoder.TryDecodeAllImage(bytes, options, out var decoded) && decoded.Length > 0) {
                 var texts = decoded
@@ -78,6 +79,36 @@ internal static class QrDecodeSamplesExample {
         var outputPath = Path.Combine(outputDir, "qr-decode-samples.txt");
         File.WriteAllLines(outputPath, lines, Encoding.UTF8);
         Console.WriteLine(string.Join(Environment.NewLine, lines));
+    }
+
+    private static QrPixelDecodeOptions SelectOptionsForSample(string fileName, QrPixelDecodeOptions baseOptions) {
+        if (fileName.Contains("screenshot", StringComparison.OrdinalIgnoreCase)) {
+            return new QrPixelDecodeOptions {
+                Profile = QrDecodeProfile.Robust,
+                MaxDimension = 3200,
+                BudgetMilliseconds = 12000,
+                AutoCrop = true,
+                AggressiveSampling = true,
+                StylizedSampling = true,
+                EnableTileScan = true,
+                TileGrid = 6
+            };
+        }
+
+        if (fileName.StartsWith("qr-art-", StringComparison.OrdinalIgnoreCase)) {
+            return new QrPixelDecodeOptions {
+                Profile = QrDecodeProfile.Robust,
+                MaxDimension = 3200,
+                BudgetMilliseconds = 8000,
+                AutoCrop = true,
+                AggressiveSampling = true,
+                StylizedSampling = true,
+                EnableTileScan = true,
+                TileGrid = 4
+            };
+        }
+
+        return baseOptions;
     }
 
     private static bool ReadBoolEnv(string name, bool fallback) {

--- a/CodeGlyphX.Examples/QrHardArtDiagnosticsExample.cs
+++ b/CodeGlyphX.Examples/QrHardArtDiagnosticsExample.cs
@@ -18,7 +18,7 @@ internal static class QrHardArtDiagnosticsExample {
     };
 
     public static void Run(string outputDir) {
-        var sampleDir = ResolveSamplesDir("Assets/DecodingSamples");
+        var sampleDir = ExamplePaths.ResolveSamplesDir("Assets/DecodingSamples");
         var debugDir = Path.Combine(outputDir, "qr-hard-art-debug");
         Directory.CreateDirectory(debugDir);
 
@@ -74,38 +74,11 @@ internal static class QrHardArtDiagnosticsExample {
             }
 
             // Always emit debug renders for these hard-art samples.
-            var debugOpts = new QrPixelDebugOptions();
-            QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin.png", debugOpts);
-
-            var adaptive = new QrPixelDebugOptions {
-                AdaptiveThreshold = true,
-                AdaptiveWindowSize = 15,
-                AdaptiveOffset = 8
-            };
-            QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin-adaptive.png", adaptive);
-            QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Heatmap, debugDir, $"{baseName}-heatmap.png", debugOpts);
+            ExampleDebug.WriteQrDebugImages(rgba, width, height, width * 4, debugDir, baseName);
         }
 
         var outputPath = Path.Combine(outputDir, "qr-hard-art-diagnostics.txt");
         File.WriteAllLines(outputPath, lines, Encoding.UTF8);
         Console.WriteLine(string.Join(Environment.NewLine, lines));
-    }
-
-    private static string ResolveSamplesDir(string relativePath) {
-        if (string.IsNullOrWhiteSpace(relativePath)) {
-            throw new ArgumentException("Path is required.", nameof(relativePath));
-        }
-
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && dir is not null; i++) {
-            var candidate = Path.Combine(dir.FullName, relativePath);
-            if (Directory.Exists(candidate)) {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException($"Could not locate sample directory '{relativePath}'.");
     }
 }

--- a/CodeGlyphX.Examples/QrHardArtDiagnosticsExample.cs
+++ b/CodeGlyphX.Examples/QrHardArtDiagnosticsExample.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX.Examples;
+
+internal static class QrHardArtDiagnosticsExample {
+    private static readonly string[] HardArtFiles = {
+        "qr-art-facebook-splash-grid.png",
+        "qr-art-montage-grid.png",
+        "qr-art-stripe-eye-grid.png",
+        "qr-art-drip-variants.png",
+        "qr-art-solid-bg-grid.png",
+        "qr-art-gear-illustration-grid.png"
+    };
+
+    public static void Run(string outputDir) {
+        var sampleDir = ResolveSamplesDir("Assets/DecodingSamples");
+        var debugDir = Path.Combine(outputDir, "qr-hard-art-debug");
+        Directory.CreateDirectory(debugDir);
+
+        var options = new QrPixelDecodeOptions {
+            Profile = QrDecodeProfile.Robust,
+            MaxDimension = 3200,
+            BudgetMilliseconds = 12000,
+            AutoCrop = true,
+            AggressiveSampling = true,
+            StylizedSampling = true,
+            EnableTileScan = true,
+            TileGrid = 4
+        };
+
+        var lines = new List<string> {
+            $"SampleDir: {sampleDir}",
+            $"DebugDir: {debugDir}",
+            $"Options: Profile={options.Profile}, MaxDimension={options.MaxDimension}, BudgetMilliseconds={options.BudgetMilliseconds}, AutoCrop={options.AutoCrop}, AggressiveSampling={options.AggressiveSampling}, StylizedSampling={options.StylizedSampling}, EnableTileScan={options.EnableTileScan}, TileGrid={options.TileGrid}",
+            string.Empty
+        };
+
+        foreach (var fileName in HardArtFiles) {
+            var path = Path.Combine(sampleDir, fileName);
+            if (!File.Exists(path)) {
+                lines.Add($"{fileName}: SKIP (missing)");
+                continue;
+            }
+
+            var bytes = File.ReadAllBytes(path);
+            if (!ImageReader.TryDecodeRgba32(bytes, out var rgba, out var width, out var height)) {
+                lines.Add($"{fileName}: FAIL (image decode)");
+                continue;
+            }
+
+            var baseName = Path.GetFileNameWithoutExtension(fileName);
+            var okAll = QrDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out var results, out var infoAll, options);
+            if (!okAll || results.Length == 0) {
+                var okSingle = QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out var single, out var infoSingle, options);
+                if (okSingle) {
+                    results = new[] { single };
+                    lines.Add($"{fileName}: OK (single) {single.Text}");
+                } else {
+                    lines.Add($"{fileName}: FAIL {infoAll} | {infoSingle}");
+                }
+            } else {
+                var payloads = results
+                    .Select(r => r.Text)
+                    .Where(t => !string.IsNullOrWhiteSpace(t))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                var payloadSummary = payloads.Length == 0 ? "(no text payloads)" : string.Join(" | ", payloads);
+                lines.Add($"{fileName}: OK ({results.Length}) {payloadSummary}");
+            }
+
+            // Always emit debug renders for these hard-art samples.
+            var debugOpts = new QrPixelDebugOptions();
+            QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin.png", debugOpts);
+
+            var adaptive = new QrPixelDebugOptions {
+                AdaptiveThreshold = true,
+                AdaptiveWindowSize = 15,
+                AdaptiveOffset = 8
+            };
+            QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Binarized, debugDir, $"{baseName}-bin-adaptive.png", adaptive);
+            QrPixelDebug.RenderToFile(rgba, width, height, width * 4, PixelFormat.Rgba32, QrPixelDebugMode.Heatmap, debugDir, $"{baseName}-heatmap.png", debugOpts);
+        }
+
+        var outputPath = Path.Combine(outputDir, "qr-hard-art-diagnostics.txt");
+        File.WriteAllLines(outputPath, lines, Encoding.UTF8);
+        Console.WriteLine(string.Join(Environment.NewLine, lines));
+    }
+
+    private static string ResolveSamplesDir(string relativePath) {
+        if (string.IsNullOrWhiteSpace(relativePath)) {
+            throw new ArgumentException("Path is required.", nameof(relativePath));
+        }
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 10 && dir is not null; i++) {
+            var candidate = Path.Combine(dir.FullName, relativePath);
+            if (Directory.Exists(candidate)) {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate sample directory '{relativePath}'.");
+    }
+}

--- a/CodeGlyphX.Tests/QrDecodingSamplesSweepTests.cs
+++ b/CodeGlyphX.Tests/QrDecodingSamplesSweepTests.cs
@@ -61,7 +61,7 @@ public sealed class QrDecodingSamplesSweepTests {
                     BudgetMilliseconds = 12000,
                     AutoCrop = true,
                     AggressiveSampling = true,
-                    StylizedSampling = true,
+                    StylizedSampling = false,
                     EnableTileScan = true,
                     TileGrid = 6
                 };

--- a/CodeGlyphX.Tests/QrScreenshotDecodeTests.cs
+++ b/CodeGlyphX.Tests/QrScreenshotDecodeTests.cs
@@ -20,7 +20,7 @@ public sealed class QrScreenshotDecodeTests {
             BudgetMilliseconds = 12000,
             AutoCrop = true,
             AggressiveSampling = true,
-            StylizedSampling = true,
+            StylizedSampling = false,
             EnableTileScan = true,
             TileGrid = 6
         };

--- a/CodeGlyphX/Qr/QrFinderPatternDetector.cs
+++ b/CodeGlyphX/Qr/QrFinderPatternDetector.cs
@@ -59,7 +59,11 @@ internal static class QrFinderPatternDetector {
             using var full = new PooledList<FinderPattern>(8);
             FindCandidatesWithStep(image, invert, rowStep: 1, full, aggressive, shouldStop, maxCandidates, requireDiagonalCheck);
             for (var i = 0; i < full.Count; i++) {
-                AddOrMerge(pooled, full[i]);
+                var candidate = full[i];
+                var weight = candidate.Count <= 1 ? 1 : Math.Min(candidate.Count, 8);
+                for (var w = 0; w < weight; w++) {
+                    AddOrMerge(pooled, new FinderPattern(candidate.X, candidate.Y, candidate.ModuleSize, 1));
+                }
             }
         }
 

--- a/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
+++ b/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
@@ -191,7 +191,8 @@ internal static partial class QrPixelDecoder {
                 allowAdaptiveThreshold = true;
                 allowBlur = true;
                 if (collectMaxScale < maxScale) {
-                    collectMaxScale = maxScale;
+                    var boostedCollect = maxScale <= 3 ? maxScale : Math.Min(maxScale, collectMaxScale + 1);
+                    collectMaxScale = boostedCollect;
                 }
             }
             if (options.MaxMilliseconds > 0) {
@@ -1082,7 +1083,8 @@ internal static partial class QrPixelDecoder {
         if (w <= 0 || h <= 0) return;
 
         var minDim = Math.Min(w, h);
-        var tileSize = Math.Clamp(minDim / 3, 64, minDim);
+        var tileMin = minDim < 64 ? minDim : 64;
+        var tileSize = Math.Clamp(minDim / 3, tileMin, minDim);
         var step = Math.Max(16, tileSize / 2);
         var thresholds = image.ThresholdMap;
         var threshold = image.Threshold;

--- a/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
+++ b/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
@@ -214,7 +214,7 @@ internal static partial class QrPixelDecoder {
                     allowAdaptiveThreshold = false;
                     allowBlur = false;
                 }
-                if (options.MaxMilliseconds <= 800 && !options.AggressiveSampling) {
+                if (options.MaxMilliseconds <= 800 && !options.AggressiveSampling && !options.StylizedSampling) {
                     aggressiveSampling = false;
                 }
             }

--- a/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
+++ b/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
@@ -185,6 +185,14 @@ internal static partial class QrPixelDecoder {
             }
             if (options.StylizedSampling) {
                 stylizedSampling = true;
+                aggressiveSampling = true;
+                minContrast = Math.Max(2, minContrast - 6);
+                allowExtraThresholds = true;
+                allowAdaptiveThreshold = true;
+                allowBlur = true;
+                if (collectMaxScale < maxScale) {
+                    collectMaxScale = maxScale;
+                }
             }
             if (options.MaxMilliseconds > 0) {
                 if (options.MaxMilliseconds <= 400) {


### PR DESCRIPTION
This PR starts the hard-art reliability track after #23.\n\nWhat\'s inside:\n- tune stylized sampling overrides to force more aggressive settings\n- make aggressive finder scans more thorough (smaller row step + full-scan merge)\n- add per-sample decode options in the decode-samples example\n\nValidation:\n- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release