### PR TITLE
Add QR decode scenario packs and pass-rate reporting

### DIFF
--- a/Assets/Templates/pages/benchmark.html
+++ b/Assets/Templates/pages/benchmark.html
@@ -124,6 +124,16 @@
         </div>
     </section>
 
+    <section class="benchmark-section benchmark-pack-runner">
+        <h2>QR Reliability (Pack Runner)</h2>
+        <p class="section-description">
+            Decode pass rates across realistic QR packs (screenshots, multi-code boards, and stress cases).
+        </p>
+        <div class="benchmark-pack-runner" data-benchmark-pack-runner>
+            <p class="loading-text">Loading QR reliability data...</p>
+        </div>
+    </section>
+
     <section class="benchmark-section benchmark-notes">
         <h2>Methodology Notes</h2>
         <div data-benchmark-notes>

--- a/Build/Generate-BenchmarkReport.ps1
+++ b/Build/Generate-BenchmarkReport.ps1
@@ -268,6 +268,165 @@ function Try-Parse-Mean([string]$value, [ref]$nanoseconds) {
     return $false
 }
 
+function Get-PackRunnerReportPath([string]$artifactsPath, [string]$runMode) {
+    if ([string]::IsNullOrWhiteSpace($artifactsPath) -or [string]::IsNullOrWhiteSpace($runMode)) { return $null }
+    $packDir = Join-Path $artifactsPath "pack-runner"
+    if (-not (Test-Path $packDir)) { return $null }
+
+    $preferred = Join-Path $packDir "qr-decode-packs-$runMode.json"
+    if (Test-Path $preferred) { return $preferred }
+
+    $candidates = Get-ChildItem -Path $packDir -Filter "qr-decode-packs-*-$runMode.json" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTimeUtc -Descending
+    if ($candidates -and $candidates.Count -gt 0) {
+        return $candidates[0].FullName
+    }
+    return $null
+}
+
+function Get-PackRunnerPayload([string]$artifactsPath, [string]$runMode) {
+    $reportPath = Get-PackRunnerReportPath -artifactsPath $artifactsPath -runMode $runMode
+    if (-not $reportPath) { return $null }
+
+    $raw = Get-Content -Path $reportPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    function Get-Field([object]$obj, [string[]]$names, $default = $null) {
+        if (-not $obj) { return $default }
+        foreach ($name in $names) {
+            if ($obj.PSObject.Properties.Name -contains $name) {
+                return $obj.$name
+            }
+        }
+        return $default
+    }
+
+    $packsRaw = Get-Field $raw @("Packs", "packs") @()
+    if (-not $packsRaw) { $packsRaw = @() }
+
+    $enginesAcc = @{}
+    $packSummaries = @()
+
+    foreach ($pack in $packsRaw) {
+        $packName = [string](Get-Field $pack @("Name", "name") "unknown")
+        $scenarioCount = [int](Get-Field $pack @("ScenarioCount", "scenarioCount") 0)
+        $enginesRaw = Get-Field $pack @("Engines", "engines") @()
+        if (-not $enginesRaw) { $enginesRaw = @() }
+
+        $engineSummaries = @()
+        foreach ($engine in $enginesRaw) {
+            $engineName = [string](Get-Field $engine @("Name", "name") "unknown")
+            $isExternal = [bool](Get-Field $engine @("IsExternal", "isExternal") $false)
+            $runs = [double](Get-Field $engine @("Runs", "runs") 0)
+            $decodeRate = [double](Get-Field $engine @("DecodeRate", "decodeRate") 0)
+            $expectedRate = [double](Get-Field $engine @("ExpectedRate", "expectedRate") 0)
+            $medianMs = [double](Get-Field $engine @("MedianMs", "medianMs") 0)
+            $p95Ms = [double](Get-Field $engine @("P95Ms", "p95Ms") 0)
+
+            $scenariosRaw = Get-Field $engine @("Scenarios", "scenarios") @()
+            if (-not $scenariosRaw) { $scenariosRaw = @() }
+            $failingScenarios = New-Object System.Collections.Generic.List[string]
+            foreach ($scenario in $scenariosRaw) {
+                $scenarioExpected = [double](Get-Field $scenario @("ExpectedRate", "expectedRate") 1)
+                if ($scenarioExpected -ge 0.9999) { continue }
+                $scenarioName = [string](Get-Field $scenario @("Name", "name") $null)
+                if (-not [string]::IsNullOrWhiteSpace($scenarioName)) {
+                    $failingScenarios.Add($scenarioName)
+                }
+            }
+
+            $engineSummaries += [pscustomobject]@{
+                name = $engineName
+                isExternal = $isExternal
+                runs = $runs
+                decodeRate = $decodeRate
+                expectedRate = $expectedRate
+                medianMs = $medianMs
+                p95Ms = $p95Ms
+                failingScenarios = $failingScenarios.ToArray()
+            }
+
+            if (-not $enginesAcc.ContainsKey($engineName)) {
+                $enginesAcc[$engineName] = @{
+                    name = $engineName
+                    isExternal = $isExternal
+                    runs = 0.0
+                    decodeWeighted = 0.0
+                    expectedWeighted = 0.0
+                    failingScenarios = (New-Object "System.Collections.Generic.HashSet[string]")
+                    failingPacks = (New-Object "System.Collections.Generic.HashSet[string]")
+                }
+            }
+
+            $acc = $enginesAcc[$engineName]
+            $acc.runs += $runs
+            $acc.decodeWeighted += $decodeRate * $runs
+            $acc.expectedWeighted += $expectedRate * $runs
+            if ($failingScenarios.Count -gt 0) {
+                foreach ($fs in $failingScenarios) { [void]$acc.failingScenarios.Add($fs) }
+                [void]$acc.failingPacks.Add($packName)
+            }
+        }
+
+        $packSummaries += [pscustomobject]@{
+            name = $packName
+            scenarioCount = $scenarioCount
+            engines = $engineSummaries
+        }
+    }
+
+    $engineSummariesAcc = @()
+    foreach ($entry in $enginesAcc.GetEnumerator()) {
+        $acc = $entry.Value
+        $runs = [double]$acc.runs
+        $decodeRate = $null
+        $expectedRate = $null
+        if ($runs -gt 0) {
+            $decodeRate = $acc.decodeWeighted / $runs
+            $expectedRate = $acc.expectedWeighted / $runs
+        }
+        $engineSummariesAcc += [pscustomobject]@{
+            name = $acc.name
+            isExternal = $acc.isExternal
+            runs = $runs
+            decodeRate = $decodeRate
+            expectedRate = $expectedRate
+            failingScenarios = ($acc.failingScenarios.ToArray() | Sort-Object)
+            failingPacks = ($acc.failingPacks.ToArray() | Sort-Object)
+        }
+    }
+
+    $engineSummariesOrdered = $engineSummariesAcc | Sort-Object @{ Expression = { $_.isExternal } }, @{ Expression = { $_.name } }
+
+    function Format-Pct([double]$value) {
+        if ($null -eq $value) { return "n/a" }
+        return ("{0:P0}" -f $value)
+    }
+
+    $noteBits = @()
+    foreach ($engine in $engineSummariesOrdered) {
+        $bit = "$($engine.name) expected=$(Format-Pct $engine.expectedRate)"
+        $fails = @($engine.failingScenarios | Select-Object -First 4)
+        if ($fails.Count -gt 0) {
+            $bit += " (misses: $($fails -join ', '))"
+        }
+        $noteBits += $bit
+    }
+
+    $note = $null
+    if ($noteBits.Count -gt 0) {
+        $note = "QR pack runner ($runMode): " + ($noteBits -join "; ")
+    }
+
+    return [pscustomobject]@{
+        reportPath = $reportPath
+        generatedUtc = (Get-Field $raw @("DateUtc", "dateUtc") $null)
+        mode = $runMode
+        packs = $packSummaries
+        engines = $engineSummariesOrdered
+        note = $note
+    }
+}
+
 function Format-MeanAllocCell([object]$entry, [string]$deltaText = $null) {
     if (-not $entry) { return "" }
     $mean = Normalize-MeanText $entry["mean"]
@@ -428,6 +587,7 @@ if (-not [string]::IsNullOrWhiteSpace($runModeWarning)) {
 }
 
 $runModeLabel = Format-RunModeLabel $runModeNormalized $runModeSource $requestedRunMode
+$packRunnerPayload = Get-PackRunnerPayload -artifactsPath $ArtifactsPath -runMode $runModeNormalized
 
 $publishFlag = if ($Publish) {
     $true
@@ -478,6 +638,9 @@ $lines.Add("- Benchmarks run under controlled, ideal conditions on a single mach
 $lines.Add("")
 $lines.Add("### Notes")
 $lines.Add("- $runModeLabel")
+if ($packRunnerPayload -and -not [string]::IsNullOrWhiteSpace($packRunnerPayload.note)) {
+    $lines.Add("- $($packRunnerPayload.note)")
+}
 $lines.Add("- Quick runs include the same scenario set as Full runs; run time is driven by iteration counts.")
 $lines.Add("- Comparisons target PNG output and include encode+render (not encode-only).")
 $lines.Add("- Module size and quiet zone are matched to CodeGlyphX defaults where possible; image size is derived from CodeGlyphX modules.")
@@ -836,6 +999,20 @@ foreach ($file in $baselineFiles | Sort-Object Name) {
     })
 }
 
+$notesList = @(
+    $runModeLabel,
+    "Comparisons target PNG output and include encode+render (not encode-only).",
+    "Module size and quiet zone are matched to CodeGlyphX defaults where possible; image size is derived from CodeGlyphX modules.",
+    "ZXing.Net uses ZXing.Net.Bindings.ImageSharp.V3 (ImageSharp 3.x renderer).",
+    "Barcoder uses Barcoder.Renderer.Image (ImageSharp renderer).",
+    "QRCoder uses PngByteQRCode (managed PNG output, no external renderer).",
+    "QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).",
+    "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy)."
+)
+if ($packRunnerPayload -and -not [string]::IsNullOrWhiteSpace($packRunnerPayload.note)) {
+    $notesList += $packRunnerPayload.note
+}
+
 $jsonDoc = @{
     generatedUtc = (Get-Date).ToUniversalTime().ToString("o")
     schemaVersion = 1
@@ -859,19 +1036,11 @@ $jsonDoc = @{
         "Δ lines in comparison tables show vendor ratios vs CodeGlyphX (time / alloc).",
         "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
     )
-    notes = @(
-        $runModeLabel,
-        "Comparisons target PNG output and include encode+render (not encode-only).",
-        "Module size and quiet zone are matched to CodeGlyphX defaults where possible; image size is derived from CodeGlyphX modules.",
-        "ZXing.Net uses ZXing.Net.Bindings.ImageSharp.V3 (ImageSharp 3.x renderer).",
-        "Barcoder uses Barcoder.Renderer.Image (ImageSharp renderer).",
-        "QRCoder uses PngByteQRCode (managed PNG output, no external renderer).",
-        "QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).",
-        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy)."
-    )
+    notes = $notesList
     summary = $summaryItems
     baseline = $jsonBaseline
     comparisons = $jsonSections
+    packRunner = $packRunnerPayload
 }
 
 $jsonSkeleton = @{
@@ -881,7 +1050,7 @@ $jsonSkeleton = @{
 }
 
 if (-not (Test-Path $jsonOutput)) {
-    Write-TextUtf8NoBom $jsonOutput ($jsonSkeleton | ConvertTo-Json -Depth 8)
+    Write-TextUtf8NoBom $jsonOutput ($jsonSkeleton | ConvertTo-Json -Depth 12)
 }
 
 $jsonText = Get-Content -Path $jsonOutput -Raw -Encoding UTF8
@@ -903,12 +1072,12 @@ foreach ($os in @("windows", "linux", "macos")) {
 }
 
 $jsonAll.$osName.$runModeNormalized = $jsonDoc
-$jsonOut = $jsonAll | ConvertTo-Json -Depth 8
+$jsonOut = $jsonAll | ConvertTo-Json -Depth 12
 Write-TextUtf8NoBom $jsonOutput $jsonOut
 
 $summaryOutput = Join-Path $PSScriptRoot "..\Assets\Data\benchmark-summary.json"
 if (-not (Test-Path $summaryOutput)) {
-    Write-TextUtf8NoBom $summaryOutput ($jsonSkeleton | ConvertTo-Json -Depth 8)
+    Write-TextUtf8NoBom $summaryOutput ($jsonSkeleton | ConvertTo-Json -Depth 12)
 }
 $summaryText = Get-Content -Path $summaryOutput -Raw -Encoding UTF8
 $summaryAll = $summaryText | ConvertFrom-Json
@@ -943,8 +1112,9 @@ $summaryAll.$osName.$runModeNormalized = [pscustomobject]@{
     howToRead = $jsonDoc.howToRead
     notes = $jsonDoc.notes
     summary = $jsonDoc.summary
+    packRunner = $jsonDoc.packRunner
 }
-$summaryOut = $summaryAll | ConvertTo-Json -Depth 8
+$summaryOut = $summaryAll | ConvertTo-Json -Depth 12
 Write-TextUtf8NoBom $summaryOutput $summaryOut
 
 # Summary output is already stored under Assets/Data for website ingestion.

--- a/Build/Run-Benchmarks-Compare.ps1
+++ b/Build/Run-Benchmarks-Compare.ps1
@@ -39,10 +39,9 @@ New-Item -ItemType Directory -Force -Path $artifactsPath | Out-Null
 $benchQuick = -not $Full
 $runMode = if ($benchQuick) { "quick" } else { "full" }
 $quickProps = @()
-$quickEnv = @{}
+$quickEnv = @{ BENCH_QUICK = if ($benchQuick) { "true" } else { "false" } }
 if ($benchQuick) {
     $quickProps += "/p:BenchQuick=true"
-    $quickEnv["BENCH_QUICK"] = "true"
 }
 
 $expectedCompare = @(
@@ -163,10 +162,64 @@ function Invoke-Preflight {
     }
 }
 
+function Invoke-PackRunner {
+    param(
+        [string[]]$MsBuildProps,
+        [hashtable]$EnvVars,
+        [string]$Label
+    )
+
+    Write-Host ""
+    Write-Host "== $Label =="
+
+    $reportsDir = Join-Path $artifactsPath "pack-runner"
+    New-Item -ItemType Directory -Force -Path $reportsDir | Out-Null
+
+    $packEnv = @{}
+    if ($EnvVars) {
+        foreach ($key in $EnvVars.Keys) {
+            $packEnv[$key] = $EnvVars[$key]
+        }
+    }
+    $packEnv["CODEGLYPHX_PACK_REPORTS_DIR"] = $reportsDir
+    $packEnv["BENCH_QUICK"] = if ($benchQuick) { "true" } else { "false" }
+
+    $previous = @{}
+    foreach ($key in $packEnv.Keys) {
+        $previous[$key] = [System.Environment]::GetEnvironmentVariable($key)
+        [System.Environment]::SetEnvironmentVariable($key, $packEnv[$key])
+    }
+
+    try {
+        $args = @(
+            "run",
+            "-c", $Configuration,
+            "--framework", $Framework,
+            "--project", $projectPath
+        )
+        if ($MsBuildProps) {
+            $args += $MsBuildProps
+        }
+        $args += @("--", "--pack-runner", "--mode", $runMode, "--format", "json", "--reports-dir", $reportsDir)
+        & dotnet @args
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet run failed: $Label"
+        }
+    } finally {
+        foreach ($key in $packEnv.Keys) {
+            [System.Environment]::SetEnvironmentVariable($key, $previous[$key])
+        }
+    }
+}
+
 Push-Location $repoRoot
 try {
+    $packProps = @()
+    $packEnvVars = @{}
     if (-not $NoBase) {
         Invoke-Benchmark -MsBuildProps $quickProps -Filter $BaseFilter -Label "Baseline (CodeGlyphX only)" -EnvVars $quickEnv
+        $packProps = @($quickProps)
+        foreach ($key in $quickEnv.Keys) { $packEnvVars[$key] = $quickEnv[$key] }
     }
 
     if (-not $NoCompare) {
@@ -194,6 +247,9 @@ try {
         }
 
         Invoke-Benchmark -MsBuildProps $props -Filter $CompareFilter -Label "External comparisons" -EnvVars $envVars
+        $packProps = @($props)
+        $packEnvVars = @{}
+        foreach ($key in $envVars.Keys) { $packEnvVars[$key] = $envVars[$key] }
 
         $resultsPath = Join-Path $artifactsPath "results"
         $shouldEnforceCompare = -not $AllowPartial -and $CompareFilter -eq "*Compare*"
@@ -211,6 +267,7 @@ try {
             }
         }
     }
+    Invoke-PackRunner -MsBuildProps $packProps -EnvVars $packEnvVars -Label "QR decode pack runner"
 } finally {
     Pop-Location
 }

--- a/CodeGlyphX.Benchmarks/Compare/DecodeSampleHelper.cs
+++ b/CodeGlyphX.Benchmarks/Compare/DecodeSampleHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX.Benchmarks;
@@ -8,31 +7,10 @@ internal static class DecodeSampleHelper
 {
     public static void LoadRgba(string relativePath, out byte[] rgba, out int width, out int height)
     {
-        var bytes = ReadRepoFile(relativePath);
+        var bytes = RepoFiles.ReadRepoFile(relativePath);
         if (!ImageReader.TryDecodeRgba32(bytes, out rgba, out width, out height))
         {
             throw new InvalidOperationException($"Failed to decode image '{relativePath}'.");
         }
-    }
-
-    private static byte[] ReadRepoFile(string relativePath)
-    {
-        if (string.IsNullOrWhiteSpace(relativePath))
-        {
-            throw new ArgumentException("Path is required.", nameof(relativePath));
-        }
-
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && dir is not null; i++)
-        {
-            var candidate = Path.Combine(dir.FullName, relativePath);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllBytes(candidate);
-            }
-            dir = dir.Parent;
-        }
-
-        throw new FileNotFoundException($"Could not locate sample file '{relativePath}'.");
     }
 }

--- a/CodeGlyphX.Benchmarks/Program.cs
+++ b/CodeGlyphX.Benchmarks/Program.cs
@@ -17,8 +17,14 @@ public class Program
             Environment.Exit(exitCode);
         }
 
+        if (QrDecodePackRunner.TryParseArgs(filteredArgs, out var packOptions, out var remainingArgs))
+        {
+            var exitCode = QrDecodePackRunner.Run(packOptions);
+            Environment.Exit(exitCode);
+        }
+
         // Run all benchmarks
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(filteredArgs);
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(remainingArgs);
 
         // Or run specific benchmark:
         // BenchmarkRunner.Run<QrCodeBenchmarks>();

--- a/CodeGlyphX.Benchmarks/QrDecodeEngines.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeEngines.cs
@@ -14,6 +14,7 @@ internal readonly record struct DecodeEngineResult(bool Success, int Count, stri
 internal interface IQrDecodeEngine {
     string Name { get; }
     bool IsExternal { get; }
+    IReadOnlyList<string> Aliases { get; }
     DecodeEngineResult Decode(QrDecodeScenarioData data, QrPixelDecodeOptions options);
 }
 
@@ -31,6 +32,7 @@ internal static class QrDecodeEngines {
     private sealed class CodeGlyphXEngine : IQrDecodeEngine {
         public string Name => "CodeGlyphX";
         public bool IsExternal => false;
+        public IReadOnlyList<string> Aliases { get; } = new[] { "codeglyphx", "cgx", "self", "ours" };
 
         public DecodeEngineResult Decode(QrDecodeScenarioData data, QrPixelDecodeOptions options) {
             QrDecoded[] decoded;
@@ -72,6 +74,7 @@ internal static class QrDecodeEngines {
 
         public string Name => "ZXing.Net";
         public bool IsExternal => true;
+        public IReadOnlyList<string> Aliases { get; } = new[] { "zxing", "zxingnet", "zxing.net", "zx" };
 
         public DecodeEngineResult Decode(QrDecodeScenarioData data, QrPixelDecodeOptions options) {
             var result = _reader.Decode(data.Rgba, data.Width, data.Height, RGBLuminanceSource.BitmapFormat.RGBA32);
@@ -84,4 +87,3 @@ internal static class QrDecodeEngines {
     }
 #endif
 }
-

--- a/CodeGlyphX.Benchmarks/QrDecodeEngines.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeEngines.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CodeGlyphX.Rendering;
+#if COMPARE_ZXING
+using ZXing;
+using ZXing.Common;
+#endif
+
+namespace CodeGlyphX.Benchmarks;
+
+internal readonly record struct DecodeEngineResult(bool Success, int Count, string[] Texts);
+
+internal interface IQrDecodeEngine {
+    string Name { get; }
+    bool IsExternal { get; }
+    DecodeEngineResult Decode(QrDecodeScenarioData data, QrPixelDecodeOptions options);
+}
+
+internal static class QrDecodeEngines {
+    public static IReadOnlyList<IQrDecodeEngine> Create() {
+        var engines = new List<IQrDecodeEngine>(4) {
+            new CodeGlyphXEngine()
+        };
+#if COMPARE_ZXING
+        engines.Add(new ZXingEngine());
+#endif
+        return engines;
+    }
+
+    private sealed class CodeGlyphXEngine : IQrDecodeEngine {
+        public string Name => "CodeGlyphX";
+        public bool IsExternal => false;
+
+        public DecodeEngineResult Decode(QrDecodeScenarioData data, QrPixelDecodeOptions options) {
+            QrDecoded[] decoded;
+            var okAll = QrDecoder.TryDecodeAll(
+                data.Rgba,
+                data.Width,
+                data.Height,
+                data.Stride,
+                PixelFormat.Rgba32,
+                out decoded,
+                out _,
+                options);
+            if (!okAll || decoded.Length == 0) {
+                if (QrDecoder.TryDecode(data.Rgba, data.Width, data.Height, data.Stride, PixelFormat.Rgba32, out var single, out _, options)) {
+                    decoded = new[] { single };
+                } else {
+                    decoded = Array.Empty<QrDecoded>();
+                }
+            }
+
+            if (decoded.Length == 0) {
+                return new DecodeEngineResult(false, 0, Array.Empty<string>());
+            }
+
+            var texts = decoded
+                .Select(d => d.Text)
+                .Where(t => !string.IsNullOrWhiteSpace(t))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            return new DecodeEngineResult(texts.Length > 0, decoded.Length, texts);
+        }
+    }
+
+#if COMPARE_ZXING
+    private sealed class ZXingEngine : IQrDecodeEngine {
+        private readonly BarcodeReaderGeneric _reader = new() {
+            Options = new DecodingOptions { PossibleFormats = new[] { BarcodeFormat.QR_CODE } }
+        };
+
+        public string Name => "ZXing.Net";
+        public bool IsExternal => true;
+
+        public DecodeEngineResult Decode(QrDecodeScenarioData data, QrPixelDecodeOptions options) {
+            var result = _reader.Decode(data.Rgba, data.Width, data.Height, RGBLuminanceSource.BitmapFormat.RGBA32);
+            if (result is null || string.IsNullOrWhiteSpace(result.Text)) {
+                return new DecodeEngineResult(false, 0, Array.Empty<string>());
+            }
+
+            return new DecodeEngineResult(true, 1, new[] { result.Text });
+        }
+    }
+#endif
+}
+

--- a/CodeGlyphX.Benchmarks/QrDecodeImageOps.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeImageOps.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CodeGlyphX.Benchmarks;
+
+internal static class QrDecodeImageOps {
+    public static byte[] ResampleBilinear(byte[] src, int srcWidth, int srcHeight, int dstWidth, int dstHeight) {
+        if (srcWidth <= 0 || srcHeight <= 0 || dstWidth <= 0 || dstHeight <= 0) {
+            throw new ArgumentOutOfRangeException("Invalid resample dimensions.");
+        }
+
+        var dst = new byte[checked(dstWidth * dstHeight * 4)];
+        var scaleX = srcWidth / (double)dstWidth;
+        var scaleY = srcHeight / (double)dstHeight;
+
+        for (var y = 0; y < dstHeight; y++) {
+            var sy = (y + 0.5) * scaleY - 0.5;
+            if (sy < 0) sy = 0;
+            var y0 = (int)sy;
+            var y1 = Math.Min(y0 + 1, srcHeight - 1);
+            var wy = sy - y0;
+            var row0 = y0 * srcWidth * 4;
+            var row1 = y1 * srcWidth * 4;
+
+            for (var x = 0; x < dstWidth; x++) {
+                var sx = (x + 0.5) * scaleX - 0.5;
+                if (sx < 0) sx = 0;
+                var x0 = (int)sx;
+                var x1 = Math.Min(x0 + 1, srcWidth - 1);
+                var wx = sx - x0;
+
+                var idx00 = row0 + x0 * 4;
+                var idx10 = row0 + x1 * 4;
+                var idx01 = row1 + x0 * 4;
+                var idx11 = row1 + x1 * 4;
+                var dstIndex = (y * dstWidth + x) * 4;
+
+                for (var c = 0; c < 4; c++) {
+                    var v00 = src[idx00 + c];
+                    var v10 = src[idx10 + c];
+                    var v01 = src[idx01 + c];
+                    var v11 = src[idx11 + c];
+
+                    var v0 = v00 + (v10 - v00) * wx;
+                    var v1 = v01 + (v11 - v01) * wx;
+                    var value = v0 + (v1 - v0) * wy;
+                    if (value < 0) value = 0;
+                    else if (value > 255) value = 255;
+                    dst[dstIndex + c] = (byte)value;
+                }
+            }
+        }
+
+        return dst;
+    }
+
+    public static void FillSolid(byte[] pixels, int width, int height, int stride, byte r, byte g, byte b, byte a) {
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var i = row + x * 4;
+                pixels[i] = b;
+                pixels[i + 1] = g;
+                pixels[i + 2] = r;
+                pixels[i + 3] = a;
+            }
+        }
+    }
+
+    public static void Blit(byte[] src, int srcW, int srcH, int srcStride, byte[] dest, int destW, int destH, int destStride, int offsetX, int offsetY) {
+        for (var y = 0; y < srcH; y++) {
+            var dy = offsetY + y;
+            if ((uint)dy >= (uint)destH) break;
+            Buffer.BlockCopy(src, y * srcStride, dest, dy * destStride + offsetX * 4, srcW * 4);
+        }
+    }
+
+    public static byte[] BuildCompositeGrid(string[] payloads, QrEasyOptions renderOptions, int grid, int pad, out int widthPx, out int heightPx, out int stridePx) {
+        var tiles = new List<(byte[] pixels, int width, int height, int stride)>(payloads.Length);
+
+        for (var i = 0; i < payloads.Length; i++) {
+            var pixels = QrEasy.RenderPixels(payloads[i], out var tileW, out var tileH, out var tileStride, renderOptions);
+            tiles.Add((pixels, tileW, tileH, tileStride));
+        }
+
+        var tileWidth = tiles.Max(tile => tile.width);
+        var tileHeight = tiles.Max(tile => tile.height);
+        var cellWidth = tileWidth + pad * 2;
+        var cellHeight = tileHeight + pad * 2;
+        widthPx = grid * cellWidth;
+        heightPx = grid * cellHeight;
+        stridePx = widthPx * 4;
+        var canvas = new byte[heightPx * stridePx];
+
+        FillSolid(canvas, widthPx, heightPx, stridePx, 255, 255, 255, 255);
+
+        for (var i = 0; i < tiles.Count; i++) {
+            var row = i / grid;
+            var col = i % grid;
+            var x0 = col * cellWidth + pad;
+            var y0 = row * cellHeight + pad;
+            var tile = tiles[i];
+            Blit(tile.pixels, tile.width, tile.height, tile.stride, canvas, widthPx, heightPx, stridePx, x0, y0);
+        }
+
+        return canvas;
+    }
+
+    public static void ApplyBoxBlur(byte[] pixels, int width, int height, int stride, int radius) {
+        if (radius <= 0) return;
+        var copy = new byte[pixels.Length];
+        Buffer.BlockCopy(pixels, 0, copy, 0, pixels.Length);
+
+        for (var y = 0; y < height; y++) {
+            var y0 = Math.Max(0, y - radius);
+            var y1 = Math.Min(height - 1, y + radius);
+            for (var x = 0; x < width; x++) {
+                var x0 = Math.Max(0, x - radius);
+                var x1 = Math.Min(width - 1, x + radius);
+                var sumB = 0;
+                var sumG = 0;
+                var sumR = 0;
+                var sumA = 0;
+                var count = 0;
+                for (var yy = y0; yy <= y1; yy++) {
+                    var row = yy * stride;
+                    for (var xx = x0; xx <= x1; xx++) {
+                        var i = row + xx * 4;
+                        sumB += copy[i];
+                        sumG += copy[i + 1];
+                        sumR += copy[i + 2];
+                        sumA += copy[i + 3];
+                        count++;
+                    }
+                }
+
+                var di = y * stride + x * 4;
+                pixels[di] = (byte)(sumB / count);
+                pixels[di + 1] = (byte)(sumG / count);
+                pixels[di + 2] = (byte)(sumR / count);
+                pixels[di + 3] = (byte)(sumA / count);
+            }
+        }
+    }
+
+    public static void ApplyDeterministicNoise(byte[] pixels, int width, int height, int stride, int amplitude, int seed) {
+        if (amplitude <= 0) return;
+        var rng = new Random(seed);
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var i = row + x * 4;
+                var delta = rng.Next(-amplitude, amplitude + 1);
+                pixels[i] = ClampToByte(pixels[i] + delta);
+                pixels[i + 1] = ClampToByte(pixels[i + 1] + delta);
+                pixels[i + 2] = ClampToByte(pixels[i + 2] + delta);
+            }
+        }
+    }
+
+    private static byte ClampToByte(int value) {
+        if (value < 0) return 0;
+        if (value > 255) return 255;
+        return (byte)value;
+    }
+}
+

--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -133,7 +133,7 @@ internal static class QrDecodePackRunner {
         remainingArgs = remaining.ToArray();
         if (!runRequested) return false;
 
-        var resolvedMode = mode ?? QrPackMode.Quick;
+        var resolvedMode = mode ?? ResolveModeFromBenchQuickEnv() ?? QrPackMode.Quick;
         var resolvedIterations = iterations ?? (resolvedMode == QrPackMode.Quick ? 3 : 5);
         var resolvedMinIterMs = minIterMs ?? (resolvedMode == QrPackMode.Quick ? 400 : 800);
         var resolvedOpsCap = opsCap ?? 12;
@@ -588,6 +588,20 @@ internal static class QrDecodePackRunner {
     private static QrPackMode ParseMode(string? value) {
         if (string.Equals(value, "full", StringComparison.OrdinalIgnoreCase)) return QrPackMode.Full;
         return QrPackMode.Quick;
+    }
+
+    private static QrPackMode? ResolveModeFromBenchQuickEnv() {
+        var benchQuick = Environment.GetEnvironmentVariable("BENCH_QUICK");
+        if (string.IsNullOrWhiteSpace(benchQuick)) return null;
+        if (string.Equals(benchQuick, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(benchQuick, "1", StringComparison.OrdinalIgnoreCase)) {
+            return QrPackMode.Quick;
+        }
+        if (string.Equals(benchQuick, "false", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(benchQuick, "0", StringComparison.OrdinalIgnoreCase)) {
+            return QrPackMode.Full;
+        }
+        return null;
     }
 
     private sealed class ReportModel {

--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -246,7 +246,7 @@ internal static class QrDecodePackRunner {
         var targetRuns = Math.Max(1, options.Iterations * opsPerIteration);
         if (calibration.ElapsedMilliseconds >= 7000) {
             targetRuns = 1;
-        } else if (calibration.ElapsedMilliseconds >= options.MinIterationMilliseconds * 4) {
+        } else if (calibration.ElapsedMilliseconds >= (long)options.MinIterationMilliseconds * 4L) {
             targetRuns = Math.Min(targetRuns, options.Iterations);
         }
         if (options.Mode == QrPackMode.Full && string.Equals(scenario.Pack, QrDecodeScenarioPacks.Art, StringComparison.OrdinalIgnoreCase)) {
@@ -584,8 +584,8 @@ internal static class QrDecodePackRunner {
 
         var valid = new HashSet<string>(QrDecodeScenarioPacks.AllPacks, StringComparer.OrdinalIgnoreCase);
         var packs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var pack in requestedPacks) {
-            if (valid.Contains(pack)) packs.Add(pack);
+        foreach (var pack in requestedPacks.Where(valid.Contains)) {
+            packs.Add(pack);
         }
 
         if (packs.Count == 0) {

--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -6,14 +6,23 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime;
 using System.Text;
+using System.Text.Json;
 using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX.Benchmarks;
+
+[Flags]
+internal enum QrReportFormats {
+    Text = 1,
+    Json = 2,
+    Csv = 4
+}
 
 internal sealed class QrDecodePackRunnerOptions {
     public required QrPackMode Mode { get; init; }
     public required HashSet<string> Packs { get; init; }
     public required IReadOnlyList<IQrDecodeEngine> Engines { get; init; }
+    public required QrReportFormats ReportFormats { get; init; }
     public required int Iterations { get; init; }
     public required int MinIterationMilliseconds { get; init; }
     public required int OpsCap { get; init; }
@@ -32,12 +41,14 @@ internal static class QrDecodePackRunner {
         options = null!;
         var remaining = new List<string>(args.Length);
         var packList = new List<string>(8);
+        var engineList = new List<string>(4);
         var runRequested = false;
 
         QrPackMode? mode = null;
         int? iterations = null;
         int? minIterMs = null;
         int? opsCap = null;
+        QrReportFormats? formats = null;
 
         for (var i = 0; i < args.Length; i++) {
             var arg = args[i];
@@ -53,6 +64,13 @@ internal static class QrDecodePackRunner {
             if (string.Equals(arg, "--pack", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
                 runRequested = true;
                 AddPacks(packList, args[++i]);
+                continue;
+            }
+
+            if ((string.Equals(arg, "--engine", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(arg, "--engines", StringComparison.OrdinalIgnoreCase)) && i + 1 < args.Length) {
+                runRequested = true;
+                AddEngines(engineList, args[++i]);
                 continue;
             }
 
@@ -80,6 +98,24 @@ internal static class QrDecodePackRunner {
                 continue;
             }
 
+            if (string.Equals(arg, "--format", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                runRequested = true;
+                formats = ParseFormats(args[++i], formats);
+                continue;
+            }
+
+            if (string.Equals(arg, "--json", StringComparison.OrdinalIgnoreCase)) {
+                runRequested = true;
+                formats = (formats ?? QrReportFormats.Text) | QrReportFormats.Json;
+                continue;
+            }
+
+            if (string.Equals(arg, "--csv", StringComparison.OrdinalIgnoreCase)) {
+                runRequested = true;
+                formats = (formats ?? QrReportFormats.Text) | QrReportFormats.Csv;
+                continue;
+            }
+
             remaining.Add(arg);
         }
 
@@ -102,13 +138,16 @@ internal static class QrDecodePackRunner {
         var resolvedMinIterMs = minIterMs ?? (resolvedMode == QrPackMode.Quick ? 400 : 800);
         var resolvedOpsCap = opsCap ?? 12;
         var externalRunsCap = resolvedMode == QrPackMode.Quick ? 2 : 3;
+        var resolvedFormats = (formats ?? QrReportFormats.Text) | QrReportFormats.Text;
 
         var packs = ResolvePacks(packList, resolvedMode);
-        var engines = QrDecodeEngines.Create();
+        var availableEngines = QrDecodeEngines.Create();
+        var engines = ResolveEngines(availableEngines, engineList);
         options = new QrDecodePackRunnerOptions {
             Mode = resolvedMode,
             Packs = packs,
             Engines = engines,
+            ReportFormats = resolvedFormats,
             Iterations = resolvedIterations,
             MinIterationMilliseconds = resolvedMinIterMs,
             OpsCap = resolvedOpsCap,
@@ -128,6 +167,7 @@ internal static class QrDecodePackRunner {
             return 1;
         }
 
+        var nowUtc = DateTime.UtcNow;
         var results = new List<QrDecodeScenarioResult>(scenarios.Length * options.Engines.Count);
         foreach (var engine in options.Engines) {
             foreach (var scenario in scenarios) {
@@ -136,15 +176,31 @@ internal static class QrDecodePackRunner {
             }
         }
 
-        var report = BuildReport(options, results);
+        var report = BuildReport(options, results, nowUtc);
         Console.WriteLine(report);
 
         var reportsDir = RepoFiles.EnsureReportDirectory();
-        var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
-        var reportPath = Path.Combine(reportsDir, $"qr-decode-packs-{stamp}-{options.Mode.ToString().ToLowerInvariant()}.txt");
+        var stamp = nowUtc.ToString("yyyyMMdd-HHmmss");
+        var baseName = $"qr-decode-packs-{stamp}-{options.Mode.ToString().ToLowerInvariant()}";
+        var reportPath = Path.Combine(reportsDir, baseName + ".txt");
         File.WriteAllText(reportPath, report, Encoding.UTF8);
+
+        var written = new List<string>(3) { reportPath };
+        if (options.ReportFormats.HasFlag(QrReportFormats.Json)) {
+            var jsonPath = Path.Combine(reportsDir, baseName + ".json");
+            var json = BuildJsonReport(options, results, nowUtc);
+            File.WriteAllText(jsonPath, json, Encoding.UTF8);
+            written.Add(jsonPath);
+        }
+        if (options.ReportFormats.HasFlag(QrReportFormats.Csv)) {
+            var csvPath = Path.Combine(reportsDir, baseName + ".csv");
+            var csv = BuildCsvReport(options, results, nowUtc);
+            File.WriteAllText(csvPath, csv, Encoding.UTF8);
+            written.Add(csvPath);
+        }
+
         Console.WriteLine();
-        Console.WriteLine($"Report written: {reportPath}");
+        Console.WriteLine($"Reports written: {string.Join(", ", written)}");
 
         return 0;
     }
@@ -224,12 +280,12 @@ internal static class QrDecodePackRunner {
         return true;
     }
 
-    private static string BuildReport(QrDecodePackRunnerOptions options, List<QrDecodeScenarioResult> results) {
+    private static string BuildReport(QrDecodePackRunnerOptions options, List<QrDecodeScenarioResult> results, DateTime nowUtc) {
         var sb = new StringBuilder(4096);
         var packs = options.Packs.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray();
 
         sb.AppendLine("QR Decode Scenario Packs");
-        sb.AppendLine($"Date (UTC): {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Date (UTC): {nowUtc:yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine($"Mode: {options.Mode}");
         sb.AppendLine($"Packs: {string.Join(", ", packs)}");
         sb.AppendLine($"Iterations: {options.Iterations} (min iteration ms: {options.MinIterationMilliseconds}, ops cap: {options.OpsCap})");
@@ -295,6 +351,212 @@ internal static class QrDecodePackRunner {
         return joined.Length <= 80 ? joined : joined[..77] + "...";
     }
 
+    private static string BuildJsonReport(QrDecodePackRunnerOptions options, List<QrDecodeScenarioResult> results, DateTime nowUtc) {
+        var model = BuildReportModel(options, results, nowUtc);
+        var jsonOptions = new JsonSerializerOptions {
+            WriteIndented = true
+        };
+        return JsonSerializer.Serialize(model, jsonOptions);
+    }
+
+    private static string BuildCsvReport(QrDecodePackRunnerOptions options, List<QrDecodeScenarioResult> results, DateTime nowUtc) {
+        var model = BuildReportModel(options, results, nowUtc);
+        var sb = new StringBuilder(8192);
+        sb.AppendLine("dateUtc,mode,pack,engine,isExternal,scenario,width,height,runs,opsPerIteration,decodeRate,expectedRate,medianMs,p95Ms,avgDecodedCount,expected");
+
+        var date = nowUtc.ToString("O");
+        foreach (var pack in model.Packs) {
+            foreach (var engine in pack.Engines) {
+                foreach (var scenario in engine.Scenarios) {
+                    sb.Append(date).Append(',');
+                    sb.Append(model.Mode).Append(',');
+                    sb.Append(pack.Name).Append(',');
+                    sb.Append(engine.Name).Append(',');
+                    sb.Append(engine.IsExternal ? "true" : "false").Append(',');
+                    sb.Append(scenario.Name).Append(',');
+                    sb.Append(scenario.Width).Append(',');
+                    sb.Append(scenario.Height).Append(',');
+                    sb.Append(scenario.Runs).Append(',');
+                    sb.Append(scenario.OpsPerIteration).Append(',');
+                    sb.Append(scenario.DecodeRate.ToString("F4")).Append(',');
+                    sb.Append(scenario.ExpectedRate.ToString("F4")).Append(',');
+                    sb.Append(scenario.MedianMs.ToString("F2")).Append(',');
+                    sb.Append(scenario.P95Ms.ToString("F2")).Append(',');
+                    sb.Append(scenario.AvgDecodedCount.ToString("F2")).Append(',');
+                    sb.Append(EscapeCsv(scenario.Expected));
+                    sb.AppendLine();
+                }
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static ReportModel BuildReportModel(QrDecodePackRunnerOptions options, List<QrDecodeScenarioResult> results, DateTime nowUtc) {
+        var packs = results
+            .GroupBy(r => r.Scenario.Pack)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(packGroup => {
+                var scenarioCount = packGroup.Select(r => r.Scenario.Name).Distinct(StringComparer.Ordinal).Count();
+                var engines = packGroup
+                    .GroupBy(r => r.EngineName)
+                    .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+                    .Select(engineGroup => {
+                        var packSummary = Summarize(engineGroup.ToList());
+                        var scenarios = engineGroup
+                            .OrderBy(r => r.Scenario.Name, StringComparer.OrdinalIgnoreCase)
+                            .Select(result => {
+                                var median = Percentile(result.Times, 0.50);
+                                var p95 = Percentile(result.Times, 0.95);
+                                var decodeRate = result.DecodeSuccess / (double)result.Runs;
+                                var expectedRate = result.ExpectedMatch / (double)result.Runs;
+                                var expectedLabel = result.Scenario.ExpectedTexts is null ? "any" : TruncateExpected(result.Scenario.ExpectedTexts);
+                                return new ScenarioModel {
+                                    Name = result.Scenario.Name,
+                                    Width = result.Width,
+                                    Height = result.Height,
+                                    Runs = result.Runs,
+                                    OpsPerIteration = result.OpsPerIteration,
+                                    DecodeRate = decodeRate,
+                                    ExpectedRate = expectedRate,
+                                    MedianMs = median,
+                                    P95Ms = p95,
+                                    AvgDecodedCount = result.AvgDecodedCount,
+                                    Expected = expectedLabel
+                                };
+                            })
+                            .ToArray();
+
+                        return new EngineModel {
+                            Name = engineGroup.Key,
+                            IsExternal = engineGroup.First().EngineIsExternal,
+                            Runs = packSummary.Runs,
+                            DecodeRate = packSummary.DecodeRate,
+                            ExpectedRate = packSummary.ExpectedRate,
+                            MedianMs = packSummary.MedianMs,
+                            P95Ms = packSummary.P95Ms,
+                            Scenarios = scenarios
+                        };
+                    })
+                    .ToArray();
+
+                return new PackModel {
+                    Name = packGroup.Key,
+                    ScenarioCount = scenarioCount,
+                    Engines = engines
+                };
+            })
+            .ToArray();
+
+        return new ReportModel {
+            DateUtc = nowUtc,
+            Mode = options.Mode.ToString(),
+            PacksRequested = options.Packs.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray(),
+            Iterations = options.Iterations,
+            MinIterationMilliseconds = options.MinIterationMilliseconds,
+            OpsCap = options.OpsCap,
+            ExternalRunsCap = options.ExternalRunsCap,
+            Engines = options.Engines
+                .Select(e => new EngineMeta { Name = e.Name, IsExternal = e.IsExternal })
+                .ToArray(),
+            Runtime = RuntimeInformation.FrameworkDescription,
+            Os = RuntimeInformation.OSDescription,
+            Architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+            CpuLogicalCores = Environment.ProcessorCount,
+            GcMode = GCSettings.IsServerGC ? "Server" : "Workstation",
+            Packs = packs
+        };
+    }
+
+    private static IReadOnlyList<IQrDecodeEngine> ResolveEngines(IReadOnlyList<IQrDecodeEngine> available, List<string> requested) {
+        if (requested.Count == 0) return available;
+
+        var requestedTokens = requested
+            .Select(NormalizeToken)
+            .Where(t => t.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (requestedTokens.Length == 0) return available;
+
+        var unmatched = new HashSet<string>(requestedTokens, StringComparer.Ordinal);
+        var matched = new List<IQrDecodeEngine>(available.Count);
+        foreach (var engine in available) {
+            var aliasSet = new HashSet<string>(
+                engine.Aliases.Append(engine.Name).Select(NormalizeToken).Where(t => t.Length > 0),
+                StringComparer.Ordinal);
+            var isMatch = requestedTokens.Any(aliasSet.Contains);
+            if (!isMatch) continue;
+            matched.Add(engine);
+            foreach (var token in requestedTokens) {
+                if (aliasSet.Contains(token)) unmatched.Remove(token);
+            }
+        }
+
+        if (matched.Count == 0) {
+            Console.Error.WriteLine($"No engines matched '{string.Join(",", requested)}'; using all available engines.");
+            return available;
+        }
+
+        if (unmatched.Count > 0) {
+            Console.Error.WriteLine($"Some engines were not available: {string.Join(", ", unmatched)}");
+        }
+
+        return matched;
+    }
+
+    private static void AddEngines(List<string> engineList, string engineArg) {
+        if (string.IsNullOrWhiteSpace(engineArg)) return;
+        var parts = engineArg.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i < parts.Length; i++) {
+            var engine = parts[i].Trim();
+            if (engine.Length > 0) engineList.Add(engine);
+        }
+    }
+
+    private static string NormalizeToken(string value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var buffer = new char[value.Length];
+        var count = 0;
+        for (var i = 0; i < value.Length; i++) {
+            var c = value[i];
+            if (!char.IsLetterOrDigit(c)) continue;
+            buffer[count++] = char.ToLowerInvariant(c);
+        }
+        return count == 0 ? string.Empty : new string(buffer, 0, count);
+    }
+
+    private static QrReportFormats ParseFormats(string formatArg, QrReportFormats? current) {
+        var formats = current ?? QrReportFormats.Text;
+        if (string.IsNullOrWhiteSpace(formatArg)) return formats;
+        var parts = formatArg.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i < parts.Length; i++) {
+            var token = NormalizeToken(parts[i]);
+            if (token is "all") {
+                formats |= QrReportFormats.Json | QrReportFormats.Csv | QrReportFormats.Text;
+                continue;
+            }
+            if (token is "json") {
+                formats |= QrReportFormats.Json;
+                continue;
+            }
+            if (token is "csv") {
+                formats |= QrReportFormats.Csv;
+                continue;
+            }
+            if (token is "text" or "txt") {
+                formats |= QrReportFormats.Text;
+            }
+        }
+        return formats;
+    }
+
+    private static string EscapeCsv(string? value) {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var needsQuotes = value.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0;
+        if (!needsQuotes) return value;
+        return "\"" + value.Replace("\"", "\"\"") + "\"";
+    }
+
     private static HashSet<string> ResolvePacks(List<string> requestedPacks, QrPackMode mode) {
         var defaults = mode == QrPackMode.Quick ? QuickDefaultPacks : QrDecodeScenarioPacks.AllPacks;
         if (requestedPacks.Count == 0) {
@@ -326,6 +588,59 @@ internal static class QrDecodePackRunner {
     private static QrPackMode ParseMode(string? value) {
         if (string.Equals(value, "full", StringComparison.OrdinalIgnoreCase)) return QrPackMode.Full;
         return QrPackMode.Quick;
+    }
+
+    private sealed class ReportModel {
+        public required DateTime DateUtc { get; init; }
+        public required string Mode { get; init; }
+        public required string[] PacksRequested { get; init; }
+        public required int Iterations { get; init; }
+        public required int MinIterationMilliseconds { get; init; }
+        public required int OpsCap { get; init; }
+        public required int ExternalRunsCap { get; init; }
+        public required EngineMeta[] Engines { get; init; }
+        public required string Runtime { get; init; }
+        public required string Os { get; init; }
+        public required string Architecture { get; init; }
+        public required int CpuLogicalCores { get; init; }
+        public required string GcMode { get; init; }
+        public required PackModel[] Packs { get; init; }
+    }
+
+    private sealed class EngineMeta {
+        public required string Name { get; init; }
+        public required bool IsExternal { get; init; }
+    }
+
+    private sealed class PackModel {
+        public required string Name { get; init; }
+        public required int ScenarioCount { get; init; }
+        public required EngineModel[] Engines { get; init; }
+    }
+
+    private sealed class EngineModel {
+        public required string Name { get; init; }
+        public required bool IsExternal { get; init; }
+        public required int Runs { get; init; }
+        public required double DecodeRate { get; init; }
+        public required double ExpectedRate { get; init; }
+        public required double MedianMs { get; init; }
+        public required double P95Ms { get; init; }
+        public required ScenarioModel[] Scenarios { get; init; }
+    }
+
+    private sealed class ScenarioModel {
+        public required string Name { get; init; }
+        public required int Width { get; init; }
+        public required int Height { get; init; }
+        public required int Runs { get; init; }
+        public required int OpsPerIteration { get; init; }
+        public required double DecodeRate { get; init; }
+        public required double ExpectedRate { get; init; }
+        public required double MedianMs { get; init; }
+        public required double P95Ms { get; init; }
+        public required double AvgDecodedCount { get; init; }
+        public required string Expected { get; init; }
     }
 
     private readonly record struct DecodeRunResult(bool Decoded, bool ExpectedMatched, int DecodedCount, double ElapsedMilliseconds);

--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime;
+using System.Text;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX.Benchmarks;
+
+internal sealed class QrDecodePackRunnerOptions {
+    public required QrPackMode Mode { get; init; }
+    public required HashSet<string> Packs { get; init; }
+    public required int Iterations { get; init; }
+    public required int MinIterationMilliseconds { get; init; }
+    public required int OpsCap { get; init; }
+}
+
+internal static class QrDecodePackRunner {
+    private static readonly string[] QuickDefaultPacks = {
+        QrDecodeScenarioPacks.Ideal,
+        QrDecodeScenarioPacks.Stress,
+        QrDecodeScenarioPacks.Screenshot,
+        QrDecodeScenarioPacks.Multi
+    };
+
+    public static bool TryParseArgs(string[] args, out QrDecodePackRunnerOptions options, out string[] remainingArgs) {
+        options = null!;
+        var remaining = new List<string>(args.Length);
+        var packList = new List<string>(8);
+        var runRequested = false;
+
+        QrPackMode? mode = null;
+        int? iterations = null;
+        int? minIterMs = null;
+        int? opsCap = null;
+
+        for (var i = 0; i < args.Length; i++) {
+            var arg = args[i];
+            if (string.Equals(arg, "--pack-runner", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "--packs", StringComparison.OrdinalIgnoreCase)) {
+                runRequested = true;
+                if (string.Equals(arg, "--packs", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                    AddPacks(packList, args[++i]);
+                }
+                continue;
+            }
+
+            if (string.Equals(arg, "--pack", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                runRequested = true;
+                AddPacks(packList, args[++i]);
+                continue;
+            }
+
+            if (string.Equals(arg, "--mode", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                runRequested = true;
+                mode = ParseMode(args[++i]);
+                continue;
+            }
+
+            if (string.Equals(arg, "--iterations", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                runRequested = true;
+                if (int.TryParse(args[++i], out var parsed) && parsed > 0) iterations = parsed;
+                continue;
+            }
+
+            if (string.Equals(arg, "--min-iter-ms", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                runRequested = true;
+                if (int.TryParse(args[++i], out var parsed) && parsed > 0) minIterMs = parsed;
+                continue;
+            }
+
+            if (string.Equals(arg, "--ops-cap", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length) {
+                runRequested = true;
+                if (int.TryParse(args[++i], out var parsed) && parsed > 0) opsCap = parsed;
+                continue;
+            }
+
+            remaining.Add(arg);
+        }
+
+        // Env fallbacks also trigger the runner.
+        if (!runRequested) {
+            var envMode = Environment.GetEnvironmentVariable("CODEGLYPHX_BENCH_MODE");
+            var envPacks = Environment.GetEnvironmentVariable("CODEGLYPHX_BENCH_PACKS");
+            if (!string.IsNullOrWhiteSpace(envMode) || !string.IsNullOrWhiteSpace(envPacks)) {
+                runRequested = true;
+                mode ??= ParseMode(envMode);
+                if (!string.IsNullOrWhiteSpace(envPacks)) AddPacks(packList, envPacks);
+            }
+        }
+
+        remainingArgs = remaining.ToArray();
+        if (!runRequested) return false;
+
+        var resolvedMode = mode ?? QrPackMode.Quick;
+        var resolvedIterations = iterations ?? (resolvedMode == QrPackMode.Quick ? 3 : 5);
+        var resolvedMinIterMs = minIterMs ?? (resolvedMode == QrPackMode.Quick ? 400 : 800);
+        var resolvedOpsCap = opsCap ?? 12;
+
+        var packs = ResolvePacks(packList, resolvedMode);
+        options = new QrDecodePackRunnerOptions {
+            Mode = resolvedMode,
+            Packs = packs,
+            Iterations = resolvedIterations,
+            MinIterationMilliseconds = resolvedMinIterMs,
+            OpsCap = resolvedOpsCap
+        };
+
+        return true;
+    }
+
+    public static int Run(QrDecodePackRunnerOptions options) {
+        var scenarios = QrDecodeScenarioPacks.GetScenarios(options.Mode)
+            .Where(s => options.Packs.Contains(s.Pack))
+            .ToArray();
+
+        if (scenarios.Length == 0) {
+            Console.Error.WriteLine("No scenarios matched the selected packs.");
+            return 1;
+        }
+
+        var results = new List<QrDecodeScenarioResult>(scenarios.Length);
+        foreach (var scenario in scenarios) {
+            results.Add(RunScenario(scenario, options));
+        }
+
+        var report = BuildReport(options, results);
+        Console.WriteLine(report);
+
+        var reportsDir = RepoFiles.EnsureReportDirectory();
+        var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var reportPath = Path.Combine(reportsDir, $"qr-decode-packs-{stamp}-{options.Mode.ToString().ToLowerInvariant()}.txt");
+        File.WriteAllText(reportPath, report, Encoding.UTF8);
+        Console.WriteLine();
+        Console.WriteLine($"Report written: {reportPath}");
+
+        return 0;
+    }
+
+    private static QrDecodeScenarioResult RunScenario(QrDecodeScenario scenario, QrDecodePackRunnerOptions options) {
+        var data = scenario.CreateData();
+        var times = new List<double>(options.Iterations * 4);
+        var decodeSuccess = 0;
+        var expectedMatch = 0;
+        var decodedCountSum = 0;
+
+        // Calibration run to determine ops-per-iteration.
+        var calibration = DecodeOnce(data, scenario.Options, scenario.ExpectedTexts);
+        times.Add(calibration.ElapsedMilliseconds);
+        if (calibration.Decoded) decodeSuccess++;
+        if (calibration.ExpectedMatched) expectedMatch++;
+        decodedCountSum += calibration.DecodedCount;
+
+        var opsPerIteration = calibration.ElapsedMilliseconds <= 0
+            ? 1
+            : (int)Math.Ceiling(options.MinIterationMilliseconds / calibration.ElapsedMilliseconds);
+        if (opsPerIteration < 1) opsPerIteration = 1;
+        if (opsPerIteration > options.OpsCap) opsPerIteration = options.OpsCap;
+
+        var targetRuns = Math.Max(1, options.Iterations * opsPerIteration);
+        if (calibration.ElapsedMilliseconds >= 7000) {
+            targetRuns = 1;
+        } else if (calibration.ElapsedMilliseconds >= options.MinIterationMilliseconds * 4) {
+            targetRuns = Math.Min(targetRuns, options.Iterations);
+        }
+        if (options.Mode == QrPackMode.Full && string.Equals(scenario.Pack, QrDecodeScenarioPacks.Art, StringComparison.OrdinalIgnoreCase)) {
+            targetRuns = Math.Min(targetRuns, 2);
+        }
+        for (var run = 1; run < targetRuns; run++) {
+            var res = DecodeOnce(data, scenario.Options, scenario.ExpectedTexts);
+            times.Add(res.ElapsedMilliseconds);
+            if (res.Decoded) decodeSuccess++;
+            if (res.ExpectedMatched) expectedMatch++;
+            decodedCountSum += res.DecodedCount;
+        }
+
+        return new QrDecodeScenarioResult(
+            scenario,
+            targetRuns,
+            opsPerIteration,
+            decodeSuccess,
+            expectedMatch,
+            decodedCountSum / (double)targetRuns,
+            times,
+            data.Width,
+            data.Height);
+    }
+
+    private static DecodeRunResult DecodeOnce(QrDecodeScenarioData data, QrPixelDecodeOptions options, string[]? expectedTexts) {
+        var sw = Stopwatch.StartNew();
+        QrDecoded[] decoded;
+        var okAll = QrDecoder.TryDecodeAll(
+            data.Rgba,
+            data.Width,
+            data.Height,
+            data.Stride,
+            PixelFormat.Rgba32,
+            out decoded,
+            out _,
+            options);
+        if (!okAll || decoded.Length == 0) {
+            if (QrDecoder.TryDecode(data.Rgba, data.Width, data.Height, data.Stride, PixelFormat.Rgba32, out var single, out _, options)) {
+                decoded = new[] { single };
+            } else {
+                decoded = Array.Empty<QrDecoded>();
+            }
+        }
+        sw.Stop();
+
+        var decodedCount = decoded.Length;
+        var decodedSuccess = decodedCount > 0;
+        var expectedMatched = decodedSuccess && ExpectedMatched(decoded, expectedTexts);
+        return new DecodeRunResult(decodedSuccess, expectedMatched, decodedCount, sw.Elapsed.TotalMilliseconds);
+    }
+
+    private static bool ExpectedMatched(QrDecoded[] decoded, string[]? expectedTexts) {
+        if (expectedTexts is null || expectedTexts.Length == 0) return decoded.Length > 0;
+        var texts = decoded
+            .Select(d => d.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToHashSet(StringComparer.Ordinal);
+        for (var i = 0; i < expectedTexts.Length; i++) {
+            if (!texts.Contains(expectedTexts[i])) return false;
+        }
+        return true;
+    }
+
+    private static string BuildReport(QrDecodePackRunnerOptions options, List<QrDecodeScenarioResult> results) {
+        var sb = new StringBuilder(4096);
+        var packs = options.Packs.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray();
+
+        sb.AppendLine("QR Decode Scenario Packs");
+        sb.AppendLine($"Date (UTC): {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Mode: {options.Mode}");
+        sb.AppendLine($"Packs: {string.Join(", ", packs)}");
+        sb.AppendLine($"Iterations: {options.Iterations} (min iteration ms: {options.MinIterationMilliseconds}, ops cap: {options.OpsCap})");
+        sb.AppendLine($"Runtime: {RuntimeInformation.FrameworkDescription} | OS: {RuntimeInformation.OSDescription} | Arch: {RuntimeInformation.ProcessArchitecture}");
+        sb.AppendLine($"CPU: {Environment.ProcessorCount} logical cores | GC: {(GCSettings.IsServerGC ? "Server" : "Workstation")}");
+        sb.AppendLine();
+        sb.AppendLine("Interpretation:");
+        sb.AppendLine("- decode% = any QR decoded");
+        sb.AppendLine("- expected% = expected payload(s) decoded");
+        sb.AppendLine("- ideal packs should be ~100%; stress/art packs track reliability progress");
+        sb.AppendLine();
+
+        foreach (var group in results.GroupBy(r => r.Scenario.Pack).OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)) {
+            var packSummary = Summarize(group.ToList());
+            sb.AppendLine($"Pack: {group.Key}  scenarios={group.Count()}  runs={packSummary.Runs}  decode%={packSummary.DecodeRate:P0}  expected%={packSummary.ExpectedRate:P0}  medianMs={packSummary.MedianMs:F1}  p95Ms={packSummary.P95Ms:F1}");
+            foreach (var result in group.OrderBy(r => r.Scenario.Name, StringComparer.OrdinalIgnoreCase)) {
+                var median = Percentile(result.Times, 0.50);
+                var p95 = Percentile(result.Times, 0.95);
+                var decodeRate = result.DecodeSuccess / (double)result.Runs;
+                var expectedRate = result.ExpectedMatch / (double)result.Runs;
+                var expectedLabel = result.Scenario.ExpectedTexts is null ? "any" : TruncateExpected(result.Scenario.ExpectedTexts);
+                sb.AppendLine(
+                    $"  - {result.Scenario.Name,-28} size={result.Width}x{result.Height} ops={result.OpsPerIteration,2} decode%={decodeRate,6:P0} expected%={expectedRate,6:P0} medianMs={median,7:F1} p95Ms={p95,7:F1} decoded~={result.AvgDecodedCount,4:F1} expected={expectedLabel}");
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static PackSummary Summarize(List<QrDecodeScenarioResult> results) {
+        var runs = results.Sum(r => r.Runs);
+        var decode = results.Sum(r => r.DecodeSuccess);
+        var expected = results.Sum(r => r.ExpectedMatch);
+        var allTimes = results.SelectMany(r => r.Times).ToArray();
+        return new PackSummary(
+            runs,
+            decode / (double)Math.Max(1, runs),
+            expected / (double)Math.Max(1, runs),
+            Percentile(allTimes, 0.50),
+            Percentile(allTimes, 0.95));
+    }
+
+    private static double Percentile(IReadOnlyList<double> values, double percentile) {
+        if (values.Count == 0) return 0;
+        var ordered = values.OrderBy(v => v).ToArray();
+        var idx = (int)Math.Ceiling(percentile * (ordered.Length - 1));
+        if (idx < 0) idx = 0;
+        if (idx >= ordered.Length) idx = ordered.Length - 1;
+        return ordered[idx];
+    }
+
+    private static string TruncateExpected(string[] expectedTexts) {
+        var joined = string.Join("|", expectedTexts);
+        return joined.Length <= 80 ? joined : joined[..77] + "...";
+    }
+
+    private static HashSet<string> ResolvePacks(List<string> requestedPacks, QrPackMode mode) {
+        var defaults = mode == QrPackMode.Quick ? QuickDefaultPacks : QrDecodeScenarioPacks.AllPacks;
+        if (requestedPacks.Count == 0) {
+            return new HashSet<string>(defaults, StringComparer.OrdinalIgnoreCase);
+        }
+
+        var valid = new HashSet<string>(QrDecodeScenarioPacks.AllPacks, StringComparer.OrdinalIgnoreCase);
+        var packs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pack in requestedPacks) {
+            if (valid.Contains(pack)) packs.Add(pack);
+        }
+
+        if (packs.Count == 0) {
+            return new HashSet<string>(defaults, StringComparer.OrdinalIgnoreCase);
+        }
+
+        return packs;
+    }
+
+    private static void AddPacks(List<string> packList, string packArg) {
+        if (string.IsNullOrWhiteSpace(packArg)) return;
+        var parts = packArg.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i < parts.Length; i++) {
+            var pack = parts[i].Trim();
+            if (pack.Length > 0) packList.Add(pack);
+        }
+    }
+
+    private static QrPackMode ParseMode(string? value) {
+        if (string.Equals(value, "full", StringComparison.OrdinalIgnoreCase)) return QrPackMode.Full;
+        return QrPackMode.Quick;
+    }
+
+    private readonly record struct DecodeRunResult(bool Decoded, bool ExpectedMatched, int DecodedCount, double ElapsedMilliseconds);
+
+    private sealed class QrDecodeScenarioResult {
+        public QrDecodeScenarioResult(
+            QrDecodeScenario scenario,
+            int runs,
+            int opsPerIteration,
+            int decodeSuccess,
+            int expectedMatch,
+            double avgDecodedCount,
+            List<double> times,
+            int width,
+            int height) {
+            Scenario = scenario;
+            Runs = runs;
+            OpsPerIteration = opsPerIteration;
+            DecodeSuccess = decodeSuccess;
+            ExpectedMatch = expectedMatch;
+            AvgDecodedCount = avgDecodedCount;
+            Times = times;
+            Width = width;
+            Height = height;
+        }
+
+        public QrDecodeScenario Scenario { get; }
+        public int Runs { get; }
+        public int OpsPerIteration { get; }
+        public int DecodeSuccess { get; }
+        public int ExpectedMatch { get; }
+        public double AvgDecodedCount { get; }
+        public List<double> Times { get; }
+        public int Width { get; }
+        public int Height { get; }
+    }
+
+    private readonly record struct PackSummary(int Runs, double DecodeRate, double ExpectedRate, double MedianMs, double P95Ms);
+}

--- a/CodeGlyphX.Benchmarks/QrDecodeScenarioPacks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeScenarioPacks.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX.Benchmarks;
+
+internal enum QrPackMode {
+    Quick,
+    Full
+}
+
+internal sealed class QrDecodeScenario {
+    public QrDecodeScenario(
+        string name,
+        string pack,
+        Func<QrDecodeScenarioData> createData,
+        QrPixelDecodeOptions options,
+        string[]? expectedTexts = null) {
+        Name = name;
+        Pack = pack;
+        CreateData = createData;
+        Options = options;
+        ExpectedTexts = expectedTexts;
+    }
+
+    public string Name { get; }
+    public string Pack { get; }
+    public Func<QrDecodeScenarioData> CreateData { get; }
+    public QrPixelDecodeOptions Options { get; }
+    public string[]? ExpectedTexts { get; }
+}
+
+internal sealed class QrDecodeScenarioData {
+    public QrDecodeScenarioData(byte[] rgba, int width, int height) {
+        Rgba = rgba ?? throw new ArgumentNullException(nameof(rgba));
+        Width = width;
+        Height = height;
+        Stride = checked(width * 4);
+    }
+
+    public byte[] Rgba { get; }
+    public int Width { get; }
+    public int Height { get; }
+    public int Stride { get; }
+}
+
+internal static class QrDecodeScenarioPacks {
+    public const string Ideal = "ideal";
+    public const string Stress = "stress";
+    public const string Art = "art";
+    public const string Screenshot = "screenshot";
+    public const string Multi = "multi";
+
+    public static readonly string[] AllPacks = { Ideal, Stress, Art, Screenshot, Multi };
+
+    public static List<QrDecodeScenario> GetScenarios(QrPackMode mode) {
+        var scenarios = new List<QrDecodeScenario>(32);
+
+        // Ideal pack: common "should always work" cases.
+        scenarios.Add(Sample(Ideal, "clean-small", "Assets/DecodingSamples/qr-clean-small.png", IdealOptions(mode), ExpectedCleanSmall));
+        scenarios.Add(Sample(Ideal, "clean-large", "Assets/DecodingSamples/qr-clean-large.png", IdealOptions(mode), ExpectedCleanLarge));
+        scenarios.Add(Sample(Ideal, "generator-ui", "Assets/DecodingSamples/qr-generator-ui.png", IdealOptions(mode), "https://qrstud.io/qrmnky"));
+        scenarios.Add(Sample(Ideal, "dot-aa", "Assets/DecodingSamples/qr-dot-aa.png", IdealOptions(mode), "DOT-AA"));
+
+        // Stress pack: resampling, noise, quiet-zone removal, longer payloads.
+        scenarios.Add(Sample(Stress, "noisy-ui", "Assets/DecodingSamples/qr-noisy-ui.png", StressOptions(mode), ExpectedNoisyUi));
+        scenarios.Add(Generated(Stress, "resampled-generated", BuildResampledGenerated, StressOptions(mode), GeneratedPayload));
+        scenarios.Add(Generated(Stress, "no-quiet-generated", BuildNoQuietGenerated, StressOptions(mode), GeneratedPayload));
+        scenarios.Add(Generated(Stress, "long-payload-generated", BuildLongPayloadGenerated, StressOptions(mode), LongPayload));
+
+        // Screenshot pack: UI captures with multiple elements.
+        scenarios.Add(Sample(Screenshot, "screenshot-1", "Assets/DecodingSamples/qr-screenshot-1.png", ScreenshotOptions(mode), ExpectedCleanSmall));
+        scenarios.Add(Sample(Screenshot, "screenshot-2", "Assets/DecodingSamples/qr-screenshot-2.png", ScreenshotOptions(mode), "What did I just tell you? Now we're both disappointed!"));
+        scenarios.Add(Sample(Screenshot, "screenshot-3", "Assets/DecodingSamples/qr-screenshot-3.png", ScreenshotOptions(mode), ExpectedCleanSmall));
+
+        // Multi pack: many codes in one image + screenshot-like degradation.
+        scenarios.Add(Generated(Multi, "multi-8-screenshot-like", BuildMultiQrScreenshotLike, MultiOptions(mode), MultiPayloads));
+
+        // Art pack: stylized QR art, including the known hard set.
+        scenarios.Add(Sample(Art, "art-dots-variants", "Assets/DecodingSamples/qr-art-dots-variants.png", ArtOptions(mode), ExpectedJess3));
+        scenarios.Add(Sample(Art, "art-jess3-grid", "Assets/DecodingSamples/qr-art-jess3-characters-grid.png", ArtOptions(mode), ExpectedJess3));
+        scenarios.Add(Sample(Art, "art-jess3-splash", "Assets/DecodingSamples/qr-art-jess3-characters-splash.png", ArtOptions(mode), ExpectedJess3));
+        scenarios.Add(Sample(Art, "art-jess3-splash-variant", "Assets/DecodingSamples/qr-art-jess3-characters-splash-variant.png", ArtOptions(mode), ExpectedJess3));
+
+        if (mode == QrPackMode.Full) {
+            scenarios.Add(Sample(Art, "art-facebook-splash-grid", "Assets/DecodingSamples/qr-art-facebook-splash-grid.png", ArtOptions(mode), ExpectedJess3));
+            scenarios.Add(Sample(Art, "art-montage-grid", "Assets/DecodingSamples/qr-art-montage-grid.png", ArtOptions(mode), ExpectedJess3));
+            scenarios.Add(Sample(Art, "art-stripe-eye-grid", "Assets/DecodingSamples/qr-art-stripe-eye-grid.png", ArtOptions(mode), ExpectedJess3));
+            scenarios.Add(Sample(Art, "art-drip-variants", "Assets/DecodingSamples/qr-art-drip-variants.png", ArtOptions(mode), ExpectedJess3));
+            scenarios.Add(Sample(Art, "art-solid-bg-grid", "Assets/DecodingSamples/qr-art-solid-bg-grid.png", ArtOptions(mode), ExpectedJess3));
+            scenarios.Add(Sample(Art, "art-gear-illustration-grid", "Assets/DecodingSamples/qr-art-gear-illustration-grid.png", ArtOptions(mode), ExpectedJess3));
+        }
+
+        return scenarios;
+    }
+
+    private const string GeneratedPayload = "https://github.com/EvotecIT/CodeGlyphX";
+    private const string ExpectedJess3 = "http://jess3.com";
+    private const string ExpectedCleanLarge = "This is a quick test! 123#?";
+    private const string ExpectedCleanSmall = "otpauth://totp/Evotec+Services+sp.+z+o.o.%3aprzemyslaw.klys%40evotec.pl?secret=jnll6mrqknd57pmn&issuer=Microsoft";
+    private const string ExpectedNoisyUi = "otpauth://totp/Evotec+Services+sp.+z+o.o.%3aprzemyslaw.klys%40evotec.pl?secret=pqhjwcgzncvzykhd&issuer=Microsoft";
+    private static readonly string LongPayload = BuildLongPayload();
+    private static readonly string[] MultiPayloads = Enumerable.Range(1, 8).Select(i => $"SHOT-{i}").ToArray();
+
+    private static QrDecodeScenario Sample(string pack, string name, string relativePath, QrPixelDecodeOptions options, string expectedText) {
+        return new QrDecodeScenario(
+            name,
+            pack,
+            () => LoadSample(relativePath),
+            options,
+            new[] { expectedText });
+    }
+
+    private static QrDecodeScenario Generated(string pack, string name, Func<QrDecodeScenarioData> build, QrPixelDecodeOptions options, string expectedText) {
+        return new QrDecodeScenario(
+            name,
+            pack,
+            build,
+            options,
+            new[] { expectedText });
+    }
+
+    private static QrDecodeScenario Generated(string pack, string name, Func<QrDecodeScenarioData> build, QrPixelDecodeOptions options, string[] expectedTexts) {
+        return new QrDecodeScenario(
+            name,
+            pack,
+            build,
+            options,
+            expectedTexts);
+    }
+
+    private static QrDecodeScenarioData LoadSample(string relativePath) {
+        var bytes = RepoFiles.ReadRepoFile(relativePath);
+        if (!ImageReader.TryDecodeRgba32(bytes, out var rgba, out var width, out var height)) {
+            throw new InvalidOperationException($"Failed to decode sample '{relativePath}'.");
+        }
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    private static QrPixelDecodeOptions IdealOptions(QrPackMode mode) {
+        var quick = mode == QrPackMode.Quick;
+        return new QrPixelDecodeOptions {
+            Profile = QrDecodeProfile.Robust,
+            MaxDimension = quick ? 1600 : 1800,
+            BudgetMilliseconds = quick ? 1200 : 3000,
+            AggressiveSampling = true,
+            StylizedSampling = false,
+            EnableTileScan = true
+        };
+    }
+
+    private static QrPixelDecodeOptions StressOptions(QrPackMode mode) {
+        var quick = mode == QrPackMode.Quick;
+        return new QrPixelDecodeOptions {
+            Profile = QrDecodeProfile.Robust,
+            MaxDimension = 2200,
+            BudgetMilliseconds = quick ? 2200 : 5000,
+            AutoCrop = true,
+            AggressiveSampling = true,
+            StylizedSampling = false,
+            EnableTileScan = true,
+            TileGrid = 4
+        };
+    }
+
+    private static QrPixelDecodeOptions ScreenshotOptions(QrPackMode mode) {
+        var quick = mode == QrPackMode.Quick;
+        return new QrPixelDecodeOptions {
+            Profile = QrDecodeProfile.Robust,
+            MaxDimension = 3200,
+            BudgetMilliseconds = quick ? 4000 : 12000,
+            AutoCrop = true,
+            AggressiveSampling = true,
+            StylizedSampling = false,
+            EnableTileScan = true,
+            TileGrid = 6
+        };
+    }
+
+    private static QrPixelDecodeOptions MultiOptions(QrPackMode mode) {
+        var quick = mode == QrPackMode.Quick;
+        return new QrPixelDecodeOptions {
+            Profile = QrDecodeProfile.Robust,
+            MaxDimension = 3600,
+            BudgetMilliseconds = quick ? 5000 : 15000,
+            AutoCrop = true,
+            AggressiveSampling = true,
+            StylizedSampling = false,
+            EnableTileScan = true,
+            TileGrid = 4
+        };
+    }
+
+    private static QrPixelDecodeOptions ArtOptions(QrPackMode mode) {
+        var quick = mode == QrPackMode.Quick;
+        return new QrPixelDecodeOptions {
+            Profile = QrDecodeProfile.Robust,
+            MaxDimension = 3200,
+            BudgetMilliseconds = quick ? 4500 : 9000,
+            AutoCrop = true,
+            AggressiveSampling = true,
+            StylizedSampling = true,
+            EnableTileScan = true,
+            TileGrid = 4
+        };
+    }
+
+    private static QrDecodeScenarioData BuildResampledGenerated() {
+        var options = new QrEasyOptions { ModuleSize = 8 };
+        var png = QrEasy.RenderPng(GeneratedPayload, options);
+        if (!ImageReader.TryDecodeRgba32(png, out var baseRgba, out var baseWidth, out var baseHeight)) {
+            throw new InvalidOperationException("Failed to decode generated resample PNG.");
+        }
+
+        var downW = Math.Max(1, (int)Math.Round(baseWidth * 0.62, MidpointRounding.AwayFromZero));
+        var downH = Math.Max(1, (int)Math.Round(baseHeight * 0.62, MidpointRounding.AwayFromZero));
+        var down = QrDecodeImageOps.ResampleBilinear(baseRgba, baseWidth, baseHeight, downW, downH);
+
+        var upW = Math.Max(1, (int)Math.Round(baseWidth * 1.12, MidpointRounding.AwayFromZero));
+        var upH = Math.Max(1, (int)Math.Round(baseHeight * 1.12, MidpointRounding.AwayFromZero));
+        var up = QrDecodeImageOps.ResampleBilinear(down, downW, downH, upW, upH);
+
+        return new QrDecodeScenarioData(up, upW, upH);
+    }
+
+    private static QrDecodeScenarioData BuildNoQuietGenerated() {
+        var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
+        var png = QrEasy.RenderPng(GeneratedPayload, options);
+        if (!ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height)) {
+            throw new InvalidOperationException("Failed to decode generated no-quiet PNG.");
+        }
+
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    private static QrDecodeScenarioData BuildLongPayloadGenerated() {
+        var options = new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.M,
+            TargetSizePx = 1400,
+            TargetSizeIncludesQuietZone = true,
+            QuietZone = 4
+        };
+        var png = QrEasy.RenderPng(LongPayload, options);
+        if (!ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height)) {
+            throw new InvalidOperationException("Failed to decode generated long-payload PNG.");
+        }
+
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    private static QrDecodeScenarioData BuildMultiQrScreenshotLike() {
+        var renderOptions = new QrEasyOptions {
+            ModuleSize = 14,
+            QuietZone = 4,
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.H
+        };
+
+        var grid = 4;
+        var pad = 28;
+        var canvas = QrDecodeImageOps.BuildCompositeGrid(MultiPayloads, renderOptions, grid, pad, out var widthPx, out var heightPx, out var stridePx);
+
+        // Simulate UI capture/resampling + light blur/noise.
+        var downW = Math.Max(1, (int)Math.Round(widthPx * 0.68, MidpointRounding.AwayFromZero));
+        var downH = Math.Max(1, (int)Math.Round(heightPx * 0.68, MidpointRounding.AwayFromZero));
+        var down = QrDecodeImageOps.ResampleBilinear(canvas, widthPx, heightPx, downW, downH);
+
+        var upW = downW + 180;
+        var upH = downH + 120;
+        var up = QrDecodeImageOps.ResampleBilinear(down, downW, downH, upW, upH);
+
+        QrDecodeImageOps.ApplyBoxBlur(up, upW, upH, upW * 4, radius: 1);
+        QrDecodeImageOps.ApplyDeterministicNoise(up, upW, upH, upW * 4, amplitude: 8, seed: 4242);
+
+        return new QrDecodeScenarioData(up, upW, upH);
+    }
+
+    private static string BuildLongPayload() {
+        var baseText = "CodeGlyphX benchmark long payload ";
+        return string.Concat(Enumerable.Repeat(baseText, 24)).Trim();
+    }
+}

--- a/CodeGlyphX.Benchmarks/RepoFiles.cs
+++ b/CodeGlyphX.Benchmarks/RepoFiles.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+
+namespace CodeGlyphX.Benchmarks;
+
+internal static class RepoFiles {
+    public static byte[] ReadRepoFile(string relativePath) {
+        if (string.IsNullOrWhiteSpace(relativePath)) {
+            throw new ArgumentException("Path is required.", nameof(relativePath));
+        }
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && dir is not null; i++) {
+            var candidate = Path.Combine(dir.FullName, relativePath);
+            if (File.Exists(candidate)) {
+                return File.ReadAllBytes(candidate);
+            }
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate sample file '{relativePath}'.");
+    }
+
+    public static string ResolveRepoRoot() {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && dir is not null; i++) {
+            var roadmap = Path.Combine(dir.FullName, "ROADMAP.md");
+            var git = Path.Combine(dir.FullName, ".git");
+            if (File.Exists(roadmap) || Directory.Exists(git)) {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+
+    public static string EnsureReportDirectory() {
+        var root = ResolveRepoRoot();
+        var reports = Path.Combine(root, "BenchmarkReports");
+        Directory.CreateDirectory(reports);
+        return reports;
+    }
+}
+

--- a/CodeGlyphX.Website/wwwroot/benchmarks/index.html
+++ b/CodeGlyphX.Website/wwwroot/benchmarks/index.html
@@ -232,6 +232,16 @@
         </div>
     </section>
 
+    <section class="benchmark-section benchmark-pack-runner">
+        <h2>QR Reliability (Pack Runner)</h2>
+        <p class="section-description">
+            Decode pass rates across realistic QR packs (screenshots, multi-code boards, and stress cases).
+        </p>
+        <div class="benchmark-pack-runner" data-benchmark-pack-runner>
+            <p class="loading-text">Loading QR reliability data...</p>
+        </div>
+    </section>
+
     <section class="benchmark-section benchmark-notes">
         <h2>Methodology Notes</h2>
         <div data-benchmark-notes>
@@ -878,6 +888,90 @@ if (navToggle) {
     container.innerHTML = html;
   }
 
+  function formatPercent(value) {
+    if (value === null || value === undefined || Number.isNaN(value)) return 'n/a';
+    const pct = Math.round(value * 100);
+    return pct + '%';
+  }
+
+  function renderPackRunner(entry) {
+    const container = document.querySelector('[data-benchmark-pack-runner]');
+    if (!container) return;
+
+    const pack = entry && entry.packRunner;
+    if (!pack || !pack.packs || !pack.packs.length) {
+      container.innerHTML = '<p class="benchmark-no-data">No QR reliability data available for this mode.</p>';
+      return;
+    }
+
+    const engines = pack.engines || [];
+    const packs = pack.packs || [];
+    let html = '';
+
+    if (engines.length) {
+      html += '<div class="pack-runner-engines">';
+      engines.forEach(function(engine) {
+        const expected = formatPercent(engine.expectedRate);
+        const fails = (engine.failingScenarios || []).slice(0, 4);
+        html += '<div class="pack-engine-card' + (engine.isExternal ? ' pack-engine-external' : '') + '">';
+        html += '<div class="pack-engine-name">' + escapeHtml(engine.name || 'unknown') + '</div>';
+        html += '<div class="pack-engine-rate">expected ' + escapeHtml(expected) + '</div>';
+        if (fails.length) {
+          html += '<div class="pack-engine-fails">misses: ' + escapeHtml(fails.join(', ')) + '</div>';
+        }
+        html += '</div>';
+      });
+      html += '</div>';
+    }
+
+    const engineNames = [];
+    packs.forEach(function(p) {
+      (p.engines || []).forEach(function(e) {
+        if (engineNames.indexOf(e.name) === -1) engineNames.push(e.name);
+      });
+    });
+    engineNames.sort();
+
+    html += '<div class="pack-runner-table-wrap">';
+    html += '<table class="bench-table pack-runner-table">';
+    html += '<thead><tr><th>Pack</th><th>Scenarios</th>';
+    engineNames.forEach(function(name) {
+      html += '<th>' + escapeHtml(name) + '</th>';
+    });
+    html += '</tr></thead><tbody>';
+
+    packs.forEach(function(p) {
+      const byEngine = {};
+      (p.engines || []).forEach(function(e) { byEngine[e.name] = e; });
+
+      html += '<tr>';
+      html += '<td>' + escapeHtml(p.name || '') + '</td>';
+      html += '<td>' + escapeHtml(String(p.scenarioCount || 0)) + '</td>';
+
+      engineNames.forEach(function(name) {
+        const e = byEngine[name];
+        if (!e) {
+          html += '<td class="bench-na">-</td>';
+          return;
+        }
+        const expected = formatPercent(e.expectedRate);
+        const failClass = (e.expectedRate || 0) < 0.9999 ? 'pack-rate-bad' : 'pack-rate-good';
+        html += '<td class="' + failClass + '">';
+        html += '<div>' + escapeHtml(expected) + '</div>';
+        if (e.failingScenarios && e.failingScenarios.length) {
+          const sampleFails = e.failingScenarios.slice(0, 3).join(', ');
+          html += '<div class="bench-dim">misses: ' + escapeHtml(sampleFails) + '</div>';
+        }
+        html += '</td>';
+      });
+
+      html += '</tr>';
+    });
+
+    html += '</tbody></table></div>';
+    container.innerHTML = html;
+  }
+
   function renderNotes(entry) {
     const container = document.querySelector('[data-benchmark-notes]');
     if (!container || !entry || !entry.notes || !entry.notes.length) return;
@@ -1006,6 +1100,7 @@ if (navToggle) {
     renderDetails(detailEntry);
     renderBaseline(detailEntry);
     renderEnvironment(entry);
+    renderPackRunner(entry);
     renderNotes(entry);
   }
 
@@ -1037,4 +1132,3 @@ if (navToggle) {
   </script>
 </body>
 </html>
-

--- a/CodeGlyphX.Website/wwwroot/css/app.css
+++ b/CodeGlyphX.Website/wwwroot/css/app.css
@@ -3883,6 +3883,52 @@ body.using-keyboard .faq-hero h1:focus-visible {
     word-break: break-word;
 }
 
+/* Pack runner reliability */
+.pack-runner-engines {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.pack-engine-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem 0.9rem;
+}
+
+.pack-engine-name {
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.25rem;
+}
+
+.pack-engine-rate {
+    color: var(--text);
+    font-size: 0.9rem;
+}
+
+.pack-engine-fails {
+    margin-top: 0.35rem;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1.4;
+}
+
+.pack-runner-table-wrap {
+    overflow-x: auto;
+}
+
+.pack-runner-table td.pack-rate-good {
+    color: var(--text);
+}
+
+.pack-runner-table td.pack-rate-bad {
+    color: var(--warning, #f59e0b);
+    font-weight: 600;
+}
+
 /* Notes section */
 .benchmark-notes ul {
     margin: 0;

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Runs wherever .NET runs (Windows, Linux, macOS). WPF controls are Windows-only.
 Latest benchmark tables are generated into `BENCHMARK.md` (and `Assets/Data/benchmark*.json`).
 Benchmarks below were run on 2026-01-19 (Linux Ubuntu 24.04, Ryzen 9 9950X, .NET 8.0.22). Your results will vary.
 Benchmarks run on identical hardware with default settings.
-Quick runs use fewer iterations but include the same scenario list as full runs.
+Quick runs use fewer iterations but include the same scenario list as full runs (for BenchmarkDotNet tables). The QR pack runner uses a smaller quick pack set and adds art/stylized packs in full mode.
 
 ### QR (Encode)
 


### PR DESCRIPTION
This adds a scenario-pack runner alongside BenchmarkDotNet so we can measure decode reliability and performance with clearer pack labels.\n\nKey additions:\n- scenario packs (ideal, stress, screenshot, multi, art)\n- per-sample decode options tuned by pack and mode (quick vs full)\n- pass-rate summaries (decode% and expected%) plus median/p95 timings\n- environment and runtime metadata in the report\n- shared repo file + image ops helpers to reduce duplication\n\nHow to run (quick):\n- dotnet run --project CodeGlyphX.Benchmarks/CodeGlyphX.Benchmarks.csproj -c Release --framework net8.0 -- --pack-runner --mode quick\n\nReports are written under BenchmarkReports/.\n\nValidation:\n- dotnet build CodeGlyphX.Benchmarks/CodeGlyphX.Benchmarks.csproj -c Release