### PR TITLE
Add high-level QR art API with theme, intensity, and safety

### DIFF
--- a/CodeGlyphX.Examples/Program.cs
+++ b/CodeGlyphX.Examples/Program.cs
@@ -32,6 +32,7 @@ internal static class Program {
         runner.Run("QR (ascii console)", QrAsciiExample.Run);
         runner.Run("QR (payloads)", QrPayloadsExample.Run);
         runner.Run("QR (styling)", QrFancyExample.Run);
+        runner.Run("QR (art presets)", QrArtPresetsExample.Run);
         runner.Run("QR (connected)", QrConnectedExample.Run);
         runner.Run("QR (glow eyes)", QrGlowExample.Run);
         runner.Run("QR (style board)", QrStyleBoardExample.Run);

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -30,6 +30,9 @@ internal static class QrArtPresetsExample {
 
         Save(dir, payload, "art-paint-splash-safe.png", QrArtPresets.PaintSplashSafe());
         Save(dir, payload, "art-paint-splash-bold.png", QrArtPresets.PaintSplashBold());
+
+        Save(dir, payload, "art-paint-splash-pastel-safe.png", QrArtPresets.PaintSplashPastelSafe());
+        Save(dir, payload, "art-paint-splash-pastel-bold.png", QrArtPresets.PaintSplashPastelBold());
     }
 
     private static void Save(string dir, string payload, string fileName, QrEasyOptions options) {

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -10,6 +10,7 @@ internal static class QrArtPresetsExample {
         var dir = Path.Combine(outputDir, "qr-art-presets");
         Directory.CreateDirectory(dir);
 
+#pragma warning disable CS0618 // QrArtPresets is deprecated in favor of QrArt.Theme + QrEasyOptions.Art.
         Save(dir, payload, "art-neon-glow-safe.png", QrArtPresets.NeonGlowSafe());
         Save(dir, payload, "art-neon-glow-bold.png", QrArtPresets.NeonGlowBold());
 
@@ -33,6 +34,7 @@ internal static class QrArtPresetsExample {
 
         Save(dir, payload, "art-paint-splash-pastel-safe.png", QrArtPresets.PaintSplashPastelSafe());
         Save(dir, payload, "art-paint-splash-pastel-bold.png", QrArtPresets.PaintSplashPastelBold());
+#pragma warning restore CS0618
 
         Save(dir, payload, "art-api-neon-glow.png", new QrEasyOptions {
             Art = QrArt.Theme(QrArtTheme.NeonGlow, QrArtVariant.Safe, intensity: 60)

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -27,6 +27,9 @@ internal static class QrArtPresetsExample {
 
         Save(dir, payload, "art-stripe-eyes-safe.png", QrArtPresets.StripeEyesSafe());
         Save(dir, payload, "art-stripe-eyes-bold.png", QrArtPresets.StripeEyesBold());
+
+        Save(dir, payload, "art-paint-splash-safe.png", QrArtPresets.PaintSplashSafe());
+        Save(dir, payload, "art-paint-splash-bold.png", QrArtPresets.PaintSplashBold());
     }
 
     private static void Save(string dir, string payload, string fileName, QrEasyOptions options) {

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -10,11 +10,20 @@ internal static class QrArtPresetsExample {
         var dir = Path.Combine(outputDir, "qr-art-presets");
         Directory.CreateDirectory(dir);
 
-        Save(dir, payload, "art-neon-glow.png", QrArtPresets.NeonGlow());
-        Save(dir, payload, "art-liquid-glass.png", QrArtPresets.LiquidGlass());
-        Save(dir, payload, "art-connected-squircle-glow.png", QrArtPresets.ConnectedSquircleGlow());
-        Save(dir, payload, "art-cut-corner-tech.png", QrArtPresets.CutCornerTech());
-        Save(dir, payload, "art-inset-rings.png", QrArtPresets.InsetRings());
+        Save(dir, payload, "art-neon-glow-safe.png", QrArtPresets.NeonGlowSafe());
+        Save(dir, payload, "art-neon-glow-bold.png", QrArtPresets.NeonGlowBold());
+
+        Save(dir, payload, "art-liquid-glass-safe.png", QrArtPresets.LiquidGlassSafe());
+        Save(dir, payload, "art-liquid-glass-bold.png", QrArtPresets.LiquidGlassBold());
+
+        Save(dir, payload, "art-connected-squircle-glow-safe.png", QrArtPresets.ConnectedSquircleGlowSafe());
+        Save(dir, payload, "art-connected-squircle-glow-bold.png", QrArtPresets.ConnectedSquircleGlowBold());
+
+        Save(dir, payload, "art-cut-corner-tech-safe.png", QrArtPresets.CutCornerTechSafe());
+        Save(dir, payload, "art-cut-corner-tech-bold.png", QrArtPresets.CutCornerTechBold());
+
+        Save(dir, payload, "art-inset-rings-safe.png", QrArtPresets.InsetRingsSafe());
+        Save(dir, payload, "art-inset-rings-bold.png", QrArtPresets.InsetRingsBold());
     }
 
     private static void Save(string dir, string payload, string fileName, QrEasyOptions options) {

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -24,6 +24,9 @@ internal static class QrArtPresetsExample {
 
         Save(dir, payload, "art-inset-rings-safe.png", QrArtPresets.InsetRingsSafe());
         Save(dir, payload, "art-inset-rings-bold.png", QrArtPresets.InsetRingsBold());
+
+        Save(dir, payload, "art-stripe-eyes-safe.png", QrArtPresets.StripeEyesSafe());
+        Save(dir, payload, "art-stripe-eyes-bold.png", QrArtPresets.StripeEyesBold());
     }
 
     private static void Save(string dir, string payload, string fileName, QrEasyOptions options) {

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using CodeGlyphX;
+using CodeGlyphX.Payloads;
+
+namespace CodeGlyphX.Examples;
+
+internal static class QrArtPresetsExample {
+    public static void Run(string outputDir) {
+        var payload = QrPayload.Url("https://example.com/qr/art-presets");
+        var dir = Path.Combine(outputDir, "qr-art-presets");
+        Directory.CreateDirectory(dir);
+
+        Save(dir, payload, "art-neon-glow.png", QrArtPresets.NeonGlow());
+        Save(dir, payload, "art-liquid-glass.png", QrArtPresets.LiquidGlass());
+        Save(dir, payload, "art-connected-squircle-glow.png", QrArtPresets.ConnectedSquircleGlow());
+        Save(dir, payload, "art-cut-corner-tech.png", QrArtPresets.CutCornerTech());
+        Save(dir, payload, "art-inset-rings.png", QrArtPresets.InsetRings());
+    }
+
+    private static void Save(string dir, string payload, string fileName, QrEasyOptions options) {
+        QR.Save(payload, Path.Combine(dir, fileName), options);
+    }
+}

--- a/CodeGlyphX.Examples/QrArtPresetsExample.cs
+++ b/CodeGlyphX.Examples/QrArtPresetsExample.cs
@@ -33,6 +33,13 @@ internal static class QrArtPresetsExample {
 
         Save(dir, payload, "art-paint-splash-pastel-safe.png", QrArtPresets.PaintSplashPastelSafe());
         Save(dir, payload, "art-paint-splash-pastel-bold.png", QrArtPresets.PaintSplashPastelBold());
+
+        Save(dir, payload, "art-api-neon-glow.png", new QrEasyOptions {
+            Art = QrArt.Theme(QrArtTheme.NeonGlow, QrArtVariant.Safe, intensity: 60)
+        });
+        Save(dir, payload, "art-api-paint-splash-pastel.png", new QrEasyOptions {
+            Art = QrArt.Theme(QrArtTheme.PaintSplash, QrArtVariant.Pastel, intensity: 62)
+        });
     }
 
     private static void Save(string dir, string payload, string fileName, QrEasyOptions options) {

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -8,11 +8,11 @@ public sealed class QrArtSafetyPresetsTests {
     public void Art_Presets_Are_Scan_Safe_By_Default() {
         var payload = "https://example.com/scan-safe";
         var presets = new[] {
-            ("NeonGlow", QrArtPresets.NeonGlow()),
-            ("LiquidGlass", QrArtPresets.LiquidGlass()),
-            ("ConnectedSquircleGlow", QrArtPresets.ConnectedSquircleGlow()),
-            ("CutCornerTech", QrArtPresets.CutCornerTech()),
-            ("InsetRings", QrArtPresets.InsetRings()),
+            ("NeonGlowSafe", QrArtPresets.NeonGlowSafe()),
+            ("LiquidGlassSafe", QrArtPresets.LiquidGlassSafe()),
+            ("ConnectedSquircleGlowSafe", QrArtPresets.ConnectedSquircleGlowSafe()),
+            ("CutCornerTechSafe", QrArtPresets.CutCornerTechSafe()),
+            ("InsetRingsSafe", QrArtPresets.InsetRingsSafe()),
         };
 
         foreach (var (name, preset) in presets) {

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -7,6 +7,7 @@ public sealed class QrArtSafetyPresetsTests {
     [Fact]
     public void Art_Presets_Are_Scan_Safe_By_Default() {
         var payload = "https://example.com/scan-safe";
+#pragma warning disable CS0618 // QrArtPresets is deprecated in favor of QrArt.Theme + QrEasyOptions.Art.
         var presets = new[] {
             ("NeonGlowSafe", QrArtPresets.NeonGlowSafe()),
             ("LiquidGlassSafe", QrArtPresets.LiquidGlassSafe()),
@@ -17,6 +18,7 @@ public sealed class QrArtSafetyPresetsTests {
             ("PaintSplashSafe", QrArtPresets.PaintSplashSafe()),
             ("PaintSplashPastelSafe", QrArtPresets.PaintSplashPastelSafe()),
         };
+#pragma warning restore CS0618
 
         foreach (var (name, preset) in presets) {
             var report = QrEasy.EvaluateSafety(payload, preset);

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -14,6 +14,7 @@ public sealed class QrArtSafetyPresetsTests {
             ("CutCornerTechSafe", QrArtPresets.CutCornerTechSafe()),
             ("InsetRingsSafe", QrArtPresets.InsetRingsSafe()),
             ("StripeEyesSafe", QrArtPresets.StripeEyesSafe()),
+            ("PaintSplashSafe", QrArtPresets.PaintSplashSafe()),
         };
 
         foreach (var (name, preset) in presets) {

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -13,6 +13,7 @@ public sealed class QrArtSafetyPresetsTests {
             ("ConnectedSquircleGlowSafe", QrArtPresets.ConnectedSquircleGlowSafe()),
             ("CutCornerTechSafe", QrArtPresets.CutCornerTechSafe()),
             ("InsetRingsSafe", QrArtPresets.InsetRingsSafe()),
+            ("StripeEyesSafe", QrArtPresets.StripeEyesSafe()),
         };
 
         foreach (var (name, preset) in presets) {

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -15,6 +15,7 @@ public sealed class QrArtSafetyPresetsTests {
             ("InsetRingsSafe", QrArtPresets.InsetRingsSafe()),
             ("StripeEyesSafe", QrArtPresets.StripeEyesSafe()),
             ("PaintSplashSafe", QrArtPresets.PaintSplashSafe()),
+            ("PaintSplashPastelSafe", QrArtPresets.PaintSplashPastelSafe()),
         };
 
         foreach (var (name, preset) in presets) {

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -35,4 +35,22 @@ public sealed class QrArtSafetyPresetsTests {
             Assert.False(hasCriticalWarnings, $"{name} reported critical warnings: {warnings}.");
         }
     }
+
+    [Fact]
+    public void Art_Api_Safe_Mode_Is_Scan_Safe() {
+        var payload = "https://example.com/art-api";
+        var arts = new[] {
+            ("NeonGlow", QrArt.Theme(QrArtTheme.NeonGlow, QrArtVariant.Safe, intensity: 55)),
+            ("StripeEyes", QrArt.Theme(QrArtTheme.StripeEyes, QrArtVariant.Safe, intensity: 60)),
+            ("PaintSplashPastel", QrArt.Theme(QrArtTheme.PaintSplash, QrArtVariant.Pastel, intensity: 58)),
+        };
+
+        foreach (var (name, art) in arts) {
+            var opts = new QrEasyOptions { Art = art };
+            var report = QrEasy.EvaluateSafety(payload, opts);
+            var warnings = string.Join(", ", report.Warnings.Select(w => w.Kind));
+            Assert.True(report.IsSafe, $"{name} art should be scan safe (score={report.Score}, warnings={warnings}).");
+            Assert.True(report.Score >= 80, $"{name} art should score at least 80 (score={report.Score}, warnings={warnings}).");
+        }
+    }
 }

--- a/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
+++ b/CodeGlyphX.Tests/QrArtSafetyPresetsTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class QrArtSafetyPresetsTests {
+    [Fact]
+    public void Art_Presets_Are_Scan_Safe_By_Default() {
+        var payload = "https://example.com/scan-safe";
+        var presets = new[] {
+            ("NeonGlow", QrArtPresets.NeonGlow()),
+            ("LiquidGlass", QrArtPresets.LiquidGlass()),
+            ("ConnectedSquircleGlow", QrArtPresets.ConnectedSquircleGlow()),
+            ("CutCornerTech", QrArtPresets.CutCornerTech()),
+            ("InsetRings", QrArtPresets.InsetRings()),
+        };
+
+        foreach (var (name, preset) in presets) {
+            var report = QrEasy.EvaluateSafety(payload, preset);
+            var warnings = string.Join(", ", report.Warnings.Select(w => w.Kind));
+
+            Assert.True(report.IsSafe, $"{name} should be scan safe (score={report.Score}, warnings={warnings}).");
+            Assert.True(report.Score >= 80, $"{name} should score at least 80 (score={report.Score}, warnings={warnings}).");
+
+            var hasCriticalWarnings = report.Warnings.Any(w =>
+                w.Kind == QrArtWarningKind.LowContrast ||
+                w.Kind == QrArtWarningKind.LowContrastGradient ||
+                w.Kind == QrArtWarningKind.LowContrastPalette ||
+                w.Kind == QrArtWarningKind.ModuleScaleTooSmall ||
+                w.Kind == QrArtWarningKind.QuietZoneTooSmall);
+
+            Assert.False(hasCriticalWarnings, $"{name} reported critical warnings: {warnings}.");
+        }
+    }
+}

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -204,6 +204,51 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_With_ConnectedSquircle_Connects_Adjacent_Modules() {
+        var matrix = new BitMatrix(2, 2);
+        matrix[0, 0] = true;
+        matrix[1, 0] = true;
+
+        const int moduleSize = 12;
+        const int sampleY = moduleSize / 2;
+        const int sampleX = moduleSize - 1;
+
+        var squircle = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = 0,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            ModuleShape = QrPngModuleShape.Squircle,
+            ModuleScale = 0.6,
+        };
+
+        var connected = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = 0,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            ModuleShape = QrPngModuleShape.ConnectedSquircle,
+            ModuleScale = 0.6,
+        };
+
+        var squirclePng = QrPngRenderer.Render(matrix, squircle);
+        var (squircleRgba, _, _, squircleStride) = PngTestDecoder.DecodeRgba32(squirclePng);
+        var connectedPng = QrPngRenderer.Render(matrix, connected);
+        var (connectedRgba, _, _, connectedStride) = PngTestDecoder.DecodeRgba32(connectedPng);
+
+        var squircleIndex = sampleY * squircleStride + sampleX * 4;
+        var connectedIndex = sampleY * connectedStride + sampleX * 4;
+
+        Assert.Equal(255, squircleRgba[squircleIndex + 0]);
+        Assert.Equal(255, squircleRgba[squircleIndex + 1]);
+        Assert.Equal(255, squircleRgba[squircleIndex + 2]);
+
+        Assert.Equal(0, connectedRgba[connectedIndex + 0]);
+        Assert.Equal(0, connectedRgba[connectedIndex + 1]);
+        Assert.Equal(0, connectedRgba[connectedIndex + 2]);
+    }
+
+    [Fact]
     public void Render_With_Foreground_Palette_Checker_Alternates_Modules() {
         var matrix = new BitMatrix(2, 2);
         matrix[0, 0] = true;

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -81,6 +81,7 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_ArtPresets_Render_Png_Format() {
         var payload = "https://example.com/art";
+#pragma warning disable CS0618 // QrArtPresets is deprecated in favor of QrArt.Theme + QrEasyOptions.Art.
         var presets = new[] {
             QrArtPresets.NeonGlowSafe(),
             QrArtPresets.LiquidGlassSafe(),
@@ -91,6 +92,7 @@ public sealed class RendererFormatTests {
             QrArtPresets.PaintSplashSafe(),
             QrArtPresets.PaintSplashPastelSafe(),
         };
+#pragma warning restore CS0618
 
         foreach (var preset in presets) {
             var png = QrEasy.RenderPng(payload, preset);

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -88,6 +88,7 @@ public sealed class RendererFormatTests {
             QrArtPresets.CutCornerTechSafe(),
             QrArtPresets.InsetRingsSafe(),
             QrArtPresets.StripeEyesSafe(),
+            QrArtPresets.PaintSplashSafe(),
         };
 
         foreach (var preset in presets) {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -100,6 +100,22 @@ public sealed class RendererFormatTests {
     }
 
     [Fact]
+    public void Qr_ArtApi_Render_Png_Format() {
+        var payload = "https://example.com/art-api";
+        var arts = new[] {
+            QrArt.Theme(QrArtTheme.NeonGlow, QrArtVariant.Safe, intensity: 60),
+            QrArt.Theme(QrArtTheme.StripeEyes, QrArtVariant.Safe, intensity: 58),
+            QrArt.Theme(QrArtTheme.PaintSplash, QrArtVariant.Pastel, intensity: 62),
+        };
+
+        foreach (var art in arts) {
+            var png = QrEasy.RenderPng(payload, new QrEasyOptions { Art = art });
+            Assert.True(ImageReader.TryDetectFormat(png, out var format));
+            Assert.Equal(ImageFormat.Png, format);
+        }
+    }
+
+    [Fact]
     public void Qr_Ascii_UnicodeBlocks_Uses_Block_Glyphs() {
         var payload = "https://example.com";
         var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -82,11 +82,12 @@ public sealed class RendererFormatTests {
     public void Qr_ArtPresets_Render_Png_Format() {
         var payload = "https://example.com/art";
         var presets = new[] {
-            QrArtPresets.NeonGlow(),
-            QrArtPresets.LiquidGlass(),
-            QrArtPresets.ConnectedSquircleGlow(),
-            QrArtPresets.CutCornerTech(),
-            QrArtPresets.InsetRings(),
+            QrArtPresets.NeonGlowSafe(),
+            QrArtPresets.LiquidGlassSafe(),
+            QrArtPresets.ConnectedSquircleGlowSafe(),
+            QrArtPresets.CutCornerTechSafe(),
+            QrArtPresets.InsetRingsSafe(),
+            QrArtPresets.StripeEyesSafe(),
         };
 
         foreach (var preset in presets) {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -79,6 +79,24 @@ public sealed class RendererFormatTests {
     }
 
     [Fact]
+    public void Qr_ArtPresets_Render_Png_Format() {
+        var payload = "https://example.com/art";
+        var presets = new[] {
+            QrArtPresets.NeonGlow(),
+            QrArtPresets.LiquidGlass(),
+            QrArtPresets.ConnectedSquircleGlow(),
+            QrArtPresets.CutCornerTech(),
+            QrArtPresets.InsetRings(),
+        };
+
+        foreach (var preset in presets) {
+            var png = QrEasy.RenderPng(payload, preset);
+            Assert.True(ImageReader.TryDetectFormat(png, out var format));
+            Assert.Equal(ImageFormat.Png, format);
+        }
+    }
+
+    [Fact]
     public void Qr_Ascii_UnicodeBlocks_Uses_Block_Glyphs() {
         var payload = "https://example.com";
         var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -89,6 +89,7 @@ public sealed class RendererFormatTests {
             QrArtPresets.InsetRingsSafe(),
             QrArtPresets.StripeEyesSafe(),
             QrArtPresets.PaintSplashSafe(),
+            QrArtPresets.PaintSplashPastelSafe(),
         };
 
         foreach (var preset in presets) {

--- a/CodeGlyphX/QrArt.cs
+++ b/CodeGlyphX/QrArt.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// High-level QR art helpers.
+/// </summary>
+public static class QrArt {
+    /// <summary>
+    /// Creates a single art configuration using a theme, variant, and intensity.
+    /// </summary>
+    public static QrArtOptions Theme(
+        QrArtTheme theme,
+        QrArtVariant variant = QrArtVariant.Safe,
+        int intensity = 50,
+        QrArtSafetyMode safetyMode = QrArtSafetyMode.Safe) {
+        if (intensity < 0) intensity = 0;
+        if (intensity > 100) intensity = 100;
+
+        return new QrArtOptions {
+            Theme = theme,
+            Variant = variant,
+            Intensity = intensity,
+            SafetyMode = safetyMode,
+        };
+    }
+}
+

--- a/CodeGlyphX/QrArtOptions.cs
+++ b/CodeGlyphX/QrArtOptions.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// High-level QR art options that map to scan-friendly render settings.
+/// </summary>
+public sealed class QrArtOptions {
+    /// <summary>
+    /// Theme to apply.
+    /// </summary>
+    public QrArtTheme Theme { get; set; }
+
+    /// <summary>
+    /// Variant to apply within the theme.
+    /// </summary>
+    public QrArtVariant Variant { get; set; } = QrArtVariant.Safe;
+
+    /// <summary>
+    /// Art intensity (0..100). Higher values increase decorative effects.
+    /// </summary>
+    public int Intensity { get; set; } = 50;
+
+    /// <summary>
+    /// Safety guardrail strength applied after the theme.
+    /// </summary>
+    public QrArtSafetyMode SafetyMode { get; set; } = QrArtSafetyMode.Safe;
+
+    internal void Validate() {
+        if (Intensity is < 0 or > 100) throw new ArgumentOutOfRangeException(nameof(Intensity));
+    }
+}
+

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -297,6 +297,134 @@ public static class QrArtPresets {
         return opts;
     }
 
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="NeonGlow"/>.
+    /// </summary>
+    public static QrEasyOptions NeonGlowSafe() => NeonGlow();
+
+    /// <summary>
+    /// Bolder variant of <see cref="NeonGlow"/> with stronger effects.
+    /// </summary>
+    public static QrEasyOptions NeonGlowBold() {
+        var opts = NeonGlowSafe();
+        opts.ModuleScale = 0.93;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.90;
+            opts.ModuleScaleMap.RingSize = 1;
+        }
+        if (opts.ForegroundPalette is not null) {
+            opts.ForegroundPalette.RingSize = 1;
+            opts.ForegroundPalette.Colors = new[] {
+                new Rgba32(0, 92, 88),
+                new Rgba32(0, 78, 170),
+                new Rgba32(136, 46, 188),
+            };
+        }
+        if (opts.Eyes is not null) {
+            opts.Eyes.GlowRadiusPx = 28;
+            opts.Eyes.GlowAlpha = 120;
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="LiquidGlass"/>.
+    /// </summary>
+    public static QrEasyOptions LiquidGlassSafe() => LiquidGlass();
+
+    /// <summary>
+    /// Bolder variant of <see cref="LiquidGlass"/> with punchier gradients.
+    /// </summary>
+    public static QrEasyOptions LiquidGlassBold() {
+        var opts = LiquidGlassSafe();
+        opts.ModuleScale = 0.94;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.90;
+            opts.ModuleScaleMap.RingSize = 2;
+        }
+        opts.ForegroundGradient = new QrPngGradientOptions {
+            Type = QrPngGradientType.DiagonalDown,
+            StartColor = new Rgba32(28, 132, 196),
+            EndColor = new Rgba32(34, 62, 168),
+        };
+        if (opts.Eyes is not null) {
+            opts.Eyes.OuterGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.Radial,
+                StartColor = new Rgba32(64, 166, 214),
+                EndColor = new Rgba32(34, 82, 188),
+            };
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="ConnectedSquircleGlow"/>.
+    /// </summary>
+    public static QrEasyOptions ConnectedSquircleGlowSafe() => ConnectedSquircleGlow();
+
+    /// <summary>
+    /// Bolder variant of <see cref="ConnectedSquircleGlow"/> with denser rings.
+    /// </summary>
+    public static QrEasyOptions ConnectedSquircleGlowBold() {
+        var opts = ConnectedSquircleGlowSafe();
+        opts.ModuleScale = 0.94;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.90;
+            opts.ModuleScaleMap.RingSize = 1;
+        }
+        if (opts.ForegroundPalette is not null) {
+            opts.ForegroundPalette.RingSize = 1;
+            opts.ForegroundPalette.Colors = new[] {
+                new Rgba32(58, 70, 184),
+                new Rgba32(90, 60, 184),
+                new Rgba32(40, 128, 176),
+            };
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="CutCornerTech"/>.
+    /// </summary>
+    public static QrEasyOptions CutCornerTechSafe() => CutCornerTech();
+
+    /// <summary>
+    /// Bolder variant of <see cref="CutCornerTech"/> with tighter modules.
+    /// </summary>
+    public static QrEasyOptions CutCornerTechBold() {
+        var opts = CutCornerTechSafe();
+        opts.ModuleScale = 0.88;
+        opts.ModuleCornerRadiusPx = 5;
+        if (opts.ForegroundPalette is not null) {
+            opts.ForegroundPalette.RingSize = 1;
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="InsetRings"/>.
+    /// </summary>
+    public static QrEasyOptions InsetRingsSafe() => InsetRings();
+
+    /// <summary>
+    /// Bolder variant of <see cref="InsetRings"/> with stronger ring contrast.
+    /// </summary>
+    public static QrEasyOptions InsetRingsBold() {
+        var opts = InsetRingsSafe();
+        opts.ModuleScale = 0.93;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.90;
+        }
+        if (opts.ForegroundPalette is not null) {
+            opts.ForegroundPalette.Colors = new[] {
+                new Rgba32(26, 58, 156),
+                new Rgba32(54, 86, 184),
+                new Rgba32(18, 108, 152),
+            };
+        }
+        return opts;
+    }
+
     private static QrEasyOptions BaseArt() {
         return new QrEasyOptions {
             ErrorCorrectionLevel = QrErrorCorrectionLevel.H,

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -470,6 +470,76 @@ public static class QrArtPresets {
     }
 
     /// <summary>
+    /// Pastel paint-splash canvas with a softer palette.
+    /// </summary>
+    public static QrEasyOptions PaintSplashPastel() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(20, 40, 98);
+        opts.Background = new Rgba32(250, 252, 255);
+        opts.ModuleShape = QrPngModuleShape.ConnectedSquircle;
+        opts.ModuleScale = 0.96;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Radial,
+            MinScale = 0.94,
+            MaxScale = 1.0,
+            RingSize = 2,
+        };
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Cycle,
+            RingSize = 2,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(20, 40, 98),
+                new Rgba32(32, 72, 144),
+                new Rgba32(24, 108, 140),
+            },
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.Target,
+            OuterShape = QrPngModuleShape.Rounded,
+            InnerShape = QrPngModuleShape.Circle,
+            OuterCornerRadiusPx = 6,
+            InnerCornerRadiusPx = 4,
+            OuterColor = new Rgba32(28, 60, 136),
+            InnerColor = new Rgba32(60, 174, 186),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 30,
+            CornerRadiusPx = 30,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = new Rgba32(244, 248, 255),
+                EndColor = new Rgba32(226, 236, 255),
+            },
+            Splash = new QrPngCanvasSplashOptions {
+                Color = new Rgba32(96, 132, 210, 92),
+                Colors = new[] {
+                    new Rgba32(96, 132, 210, 92),
+                    new Rgba32(190, 110, 200, 92),
+                    new Rgba32(110, 186, 140, 92),
+                    new Rgba32(214, 152, 104, 92),
+                },
+                Count = 12,
+                MinRadiusPx = 16,
+                MaxRadiusPx = 48,
+                SpreadPx = 30,
+                Seed = 7331,
+                DripChance = 0.45,
+                DripLengthPx = 30,
+                DripWidthPx = 9,
+                ProtectQrArea = true,
+            },
+            BorderPx = 1,
+            BorderColor = new Rgba32(255, 255, 255, 214),
+            ShadowOffsetX = 6,
+            ShadowOffsetY = 8,
+            ShadowColor = new Rgba32(36, 66, 140, 52),
+        };
+        return opts;
+    }
+
+    /// <summary>
     /// Explicit scan-safe variant of <see cref="NeonGlow"/>.
     /// </summary>
     public static QrEasyOptions NeonGlowSafe() => NeonGlow();
@@ -652,6 +722,39 @@ public static class QrArtPresets {
             opts.Canvas.Splash.DripChance = 0.55;
             opts.Canvas.Splash.DripLengthPx = 36;
             opts.Canvas.Splash.MaxRadiusPx = Math.Max(opts.Canvas.Splash.MaxRadiusPx, 54);
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="PaintSplashPastel"/>.
+    /// </summary>
+    public static QrEasyOptions PaintSplashPastelSafe() => PaintSplashPastel();
+
+    /// <summary>
+    /// Bolder variant of <see cref="PaintSplashPastel"/> with denser splashes.
+    /// </summary>
+    public static QrEasyOptions PaintSplashPastelBold() {
+        var opts = PaintSplashPastelSafe();
+        opts.ModuleScale = 0.95;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.92;
+            opts.ModuleScaleMap.RingSize = 1;
+        }
+        if (opts.Canvas?.Splash is not null) {
+            opts.Canvas.Splash.Color = new Rgba32(96, 132, 210, 112);
+            if (opts.Canvas.Splash.Colors is not null) {
+                opts.Canvas.Splash.Colors = new[] {
+                    new Rgba32(96, 132, 210, 108),
+                    new Rgba32(190, 110, 200, 108),
+                    new Rgba32(110, 186, 140, 108),
+                    new Rgba32(214, 152, 104, 108),
+                };
+            }
+            opts.Canvas.Splash.Count = 18;
+            opts.Canvas.Splash.DripChance = 0.6;
+            opts.Canvas.Splash.DripLengthPx = 38;
+            opts.Canvas.Splash.MaxRadiusPx = Math.Max(opts.Canvas.Splash.MaxRadiusPx, 56);
         }
         return opts;
     }

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -444,6 +444,12 @@ public static class QrArtPresets {
             },
             Splash = new QrPngCanvasSplashOptions {
                 Color = new Rgba32(40, 150, 210, 96),
+                Colors = new[] {
+                    new Rgba32(40, 150, 210, 92),
+                    new Rgba32(214, 72, 150, 92),
+                    new Rgba32(110, 190, 70, 92),
+                    new Rgba32(230, 96, 54, 92),
+                },
                 Count = 11,
                 MinRadiusPx = 16,
                 MaxRadiusPx = 46,
@@ -633,6 +639,15 @@ public static class QrArtPresets {
             opts.ModuleScaleMap.RingSize = 1;
         }
         if (opts.Canvas?.Splash is not null) {
+            opts.Canvas.Splash.Color = new Rgba32(40, 150, 210, 120);
+            if (opts.Canvas.Splash.Colors is not null) {
+                opts.Canvas.Splash.Colors = new[] {
+                    new Rgba32(40, 150, 210, 112),
+                    new Rgba32(214, 72, 150, 112),
+                    new Rgba32(110, 190, 70, 112),
+                    new Rgba32(230, 96, 54, 112),
+                };
+            }
             opts.Canvas.Splash.Count = 16;
             opts.Canvas.Splash.DripChance = 0.55;
             opts.Canvas.Splash.DripLengthPx = 36;

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -1,0 +1,310 @@
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// Expressive QR art presets with scan-friendly defaults.
+/// </summary>
+public static class QrArtPresets {
+    /// <summary>
+    /// High-contrast neon glow on a dark canvas.
+    /// </summary>
+    public static QrEasyOptions NeonGlow() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(0, 255, 240);
+        opts.Background = new Rgba32(252, 254, 255);
+        opts.ModuleShape = QrPngModuleShape.Dot;
+        opts.ModuleScale = 0.92;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Radial,
+            MinScale = 0.86,
+            MaxScale = 1.0,
+            RingSize = 2,
+        };
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Cycle,
+            RingSize = 2,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(0, 255, 240),
+                new Rgba32(0, 168, 255),
+                new Rgba32(255, 92, 255),
+            },
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.Glow,
+            OuterShape = QrPngModuleShape.Rounded,
+            InnerShape = QrPngModuleShape.Circle,
+            OuterColor = new Rgba32(0, 255, 240),
+            InnerColor = new Rgba32(255, 92, 255),
+            OuterCornerRadiusPx = 6,
+            InnerCornerRadiusPx = 4,
+            GlowRadiusPx = 34,
+            GlowAlpha = 140,
+            GlowColor = new Rgba32(0, 210, 255, 220),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 28,
+            CornerRadiusPx = 30,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = new Rgba32(8, 10, 28),
+                EndColor = new Rgba32(30, 20, 76),
+            },
+            BorderPx = 2,
+            BorderColor = new Rgba32(255, 255, 255, 54),
+            ShadowOffsetX = 6,
+            ShadowOffsetY = 8,
+            ShadowColor = new Rgba32(0, 0, 0, 70),
+        };
+        return opts;
+    }
+
+    /// <summary>
+    /// Soft, glassy gradients with smooth squircles.
+    /// </summary>
+    public static QrEasyOptions LiquidGlass() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(32, 98, 255);
+        opts.Background = new Rgba32(248, 251, 255);
+        opts.ModuleShape = QrPngModuleShape.Squircle;
+        opts.ModuleScale = 0.94;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Rings,
+            MinScale = 0.9,
+            MaxScale = 1.0,
+            RingSize = 3,
+        };
+        opts.ForegroundGradient = new QrPngGradientOptions {
+            Type = QrPngGradientType.DiagonalDown,
+            StartColor = new Rgba32(38, 190, 255),
+            EndColor = new Rgba32(66, 84, 255),
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.InsetRing,
+            OuterShape = QrPngModuleShape.Squircle,
+            InnerShape = QrPngModuleShape.Circle,
+            OuterCornerRadiusPx = 7,
+            InnerCornerRadiusPx = 4,
+            OuterGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.Radial,
+                StartColor = new Rgba32(102, 224, 255),
+                EndColor = new Rgba32(48, 96, 255),
+            },
+            InnerColor = new Rgba32(255, 255, 255),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 26,
+            CornerRadiusPx = 28,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = new Rgba32(242, 248, 255),
+                EndColor = new Rgba32(222, 236, 255),
+            },
+            Pattern = new QrPngBackgroundPatternOptions {
+                Type = QrPngBackgroundPatternType.Dots,
+                Color = new Rgba32(80, 120, 255, 24),
+                SizePx = 12,
+                ThicknessPx = 2,
+            },
+            BorderPx = 1,
+            BorderColor = new Rgba32(255, 255, 255, 190),
+            ShadowOffsetX = 4,
+            ShadowOffsetY = 6,
+            ShadowColor = new Rgba32(60, 90, 160, 54),
+        };
+        return opts;
+    }
+
+    /// <summary>
+    /// Connected squircles with a bold, modern glow.
+    /// </summary>
+    public static QrEasyOptions ConnectedSquircleGlow() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(110, 120, 255);
+        opts.Background = new Rgba32(250, 252, 255);
+        opts.ModuleShape = QrPngModuleShape.ConnectedSquircle;
+        opts.ModuleScale = 0.94;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Radial,
+            MinScale = 0.9,
+            MaxScale = 1.0,
+            RingSize = 2,
+        };
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Cycle,
+            RingSize = 2,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(110, 120, 255),
+                new Rgba32(140, 96, 255),
+                new Rgba32(90, 210, 255),
+            },
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.Target,
+            OuterShape = QrPngModuleShape.Rounded,
+            InnerShape = QrPngModuleShape.Circle,
+            OuterCornerRadiusPx = 6,
+            InnerCornerRadiusPx = 4,
+            OuterColor = new Rgba32(120, 128, 255),
+            InnerColor = new Rgba32(90, 210, 255),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 28,
+            CornerRadiusPx = 30,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = new Rgba32(14, 18, 42),
+                EndColor = new Rgba32(34, 22, 88),
+            },
+            BorderPx = 2,
+            BorderColor = new Rgba32(255, 255, 255, 52),
+            ShadowOffsetX = 6,
+            ShadowOffsetY = 8,
+            ShadowColor = new Rgba32(0, 0, 0, 72),
+        };
+        return opts;
+    }
+
+    /// <summary>
+    /// Techy cut-corner eyes with structured palettes.
+    /// </summary>
+    public static QrEasyOptions CutCornerTech() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(20, 32, 62);
+        opts.Background = new Rgba32(244, 248, 255);
+        opts.ModuleShape = QrPngModuleShape.Rounded;
+        opts.ModuleScale = 0.9;
+        opts.ModuleCornerRadiusPx = 4;
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Rings,
+            RingSize = 2,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(34, 54, 110),
+                new Rgba32(72, 104, 214),
+                new Rgba32(26, 170, 220),
+            },
+        };
+        opts.ForegroundPaletteZones = new QrPngPaletteZoneOptions {
+            CornerSize = 9,
+            CornerPalette = new QrPngPaletteOptions {
+                Mode = QrPngPaletteMode.Checker,
+                ApplyToEyes = true,
+                Colors = new[] {
+                    new Rgba32(22, 36, 84),
+                    new Rgba32(80, 120, 255),
+                },
+            },
+            CenterSize = 11,
+            CenterPalette = new QrPngPaletteOptions {
+                Mode = QrPngPaletteMode.Cycle,
+                RingSize = 1,
+                ApplyToEyes = false,
+                Colors = new[] {
+                    new Rgba32(44, 210, 255),
+                    new Rgba32(110, 120, 255),
+                },
+            },
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.CutCorner,
+            OuterShape = QrPngModuleShape.Square,
+            InnerShape = QrPngModuleShape.Rounded,
+            OuterColor = new Rgba32(18, 28, 70),
+            InnerColor = new Rgba32(98, 128, 255),
+            OuterCornerRadiusPx = 0,
+            InnerCornerRadiusPx = 4,
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 26,
+            CornerRadiusPx = 28,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.Horizontal,
+                StartColor = new Rgba32(232, 240, 255),
+                EndColor = new Rgba32(210, 226, 255),
+            },
+            Pattern = new QrPngBackgroundPatternOptions {
+                Type = QrPngBackgroundPatternType.Grid,
+                Color = new Rgba32(60, 90, 180, 26),
+                SizePx = 16,
+                ThicknessPx = 1,
+            },
+            BorderPx = 1,
+            BorderColor = new Rgba32(255, 255, 255, 210),
+            ShadowOffsetX = 4,
+            ShadowOffsetY = 6,
+            ShadowColor = new Rgba32(30, 50, 110, 54),
+        };
+        return opts;
+    }
+
+    /// <summary>
+    /// Inset-ring eyes with orderly ring palettes.
+    /// </summary>
+    public static QrEasyOptions InsetRings() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(44, 80, 180);
+        opts.Background = new Rgba32(248, 250, 255);
+        opts.ModuleShape = QrPngModuleShape.Squircle;
+        opts.ModuleScale = 0.93;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Rings,
+            MinScale = 0.9,
+            MaxScale = 1.0,
+            RingSize = 1,
+        };
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Rings,
+            RingSize = 1,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(44, 80, 180),
+                new Rgba32(82, 112, 214),
+                new Rgba32(28, 170, 220),
+            },
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.InsetRing,
+            OuterShape = QrPngModuleShape.Rounded,
+            InnerShape = QrPngModuleShape.Circle,
+            OuterCornerRadiusPx = 7,
+            InnerCornerRadiusPx = 4,
+            OuterColor = new Rgba32(36, 64, 150),
+            InnerColor = new Rgba32(255, 255, 255),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 24,
+            CornerRadiusPx = 26,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.Vertical,
+                StartColor = new Rgba32(238, 244, 255),
+                EndColor = new Rgba32(220, 232, 255),
+            },
+            BorderPx = 1,
+            BorderColor = new Rgba32(255, 255, 255, 200),
+            ShadowOffsetX = 4,
+            ShadowOffsetY = 6,
+            ShadowColor = new Rgba32(40, 70, 150, 48),
+        };
+        return opts;
+    }
+
+    private static QrEasyOptions BaseArt() {
+        return new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.H,
+            ModuleSize = 10,
+            QuietZone = 4,
+            BackgroundSupersample = 2,
+            ProtectFunctionalPatterns = true,
+            ProtectQuietZone = true,
+        };
+    }
+}

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 
@@ -11,6 +12,8 @@ public static class QrArtPresets {
     /// <summary>
     /// High-contrast neon glow on a dark canvas.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions NeonGlow() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(0, 96, 92);
@@ -74,6 +77,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Soft, glassy gradients with smooth squircles.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions LiquidGlass() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(24, 68, 160);
@@ -139,6 +144,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Connected squircles with a bold, modern glow.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions ConnectedSquircleGlow() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(60, 72, 180);
@@ -199,6 +206,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Techy cut-corner eyes with structured palettes.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions CutCornerTech() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(20, 32, 62);
@@ -281,6 +290,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Inset-ring eyes with orderly ring palettes.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions InsetRings() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(28, 60, 150);
@@ -341,6 +352,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Stripe-textured eyes with calm module styling.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions StripeEyes() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(26, 46, 128);
@@ -402,6 +415,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Paint-splash canvas with crisp, scan-friendly modules.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions PaintSplash() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(18, 36, 92);
@@ -472,6 +487,8 @@ public static class QrArtPresets {
     /// <summary>
     /// Pastel paint-splash canvas with a softer palette.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions PaintSplashPastel() {
         var opts = BaseArt();
         opts.Foreground = new Rgba32(20, 40, 98);
@@ -542,11 +559,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="NeonGlow"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions NeonGlowSafe() => NeonGlow();
 
     /// <summary>
     /// Bolder variant of <see cref="NeonGlow"/> with stronger effects.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions NeonGlowBold() {
         var opts = NeonGlowSafe();
         opts.ModuleScale = 0.93;
@@ -572,11 +593,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="LiquidGlass"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions LiquidGlassSafe() => LiquidGlass();
 
     /// <summary>
     /// Bolder variant of <see cref="LiquidGlass"/> with punchier gradients.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions LiquidGlassBold() {
         var opts = LiquidGlassSafe();
         opts.ModuleScale = 0.94;
@@ -602,11 +627,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="ConnectedSquircleGlow"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions ConnectedSquircleGlowSafe() => ConnectedSquircleGlow();
 
     /// <summary>
     /// Bolder variant of <see cref="ConnectedSquircleGlow"/> with denser rings.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions ConnectedSquircleGlowBold() {
         var opts = ConnectedSquircleGlowSafe();
         opts.ModuleScale = 0.94;
@@ -628,11 +657,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="CutCornerTech"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions CutCornerTechSafe() => CutCornerTech();
 
     /// <summary>
     /// Bolder variant of <see cref="CutCornerTech"/> with tighter modules.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions CutCornerTechBold() {
         var opts = CutCornerTechSafe();
         opts.ModuleScale = 0.88;
@@ -646,11 +679,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="InsetRings"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions InsetRingsSafe() => InsetRings();
 
     /// <summary>
     /// Bolder variant of <see cref="InsetRings"/> with stronger ring contrast.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions InsetRingsBold() {
         var opts = InsetRingsSafe();
         opts.ModuleScale = 0.93;
@@ -670,11 +707,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="StripeEyes"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions StripeEyesSafe() => StripeEyes();
 
     /// <summary>
     /// Bolder variant of <see cref="StripeEyes"/> that also textures modules.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions StripeEyesBold() {
         var opts = StripeEyesSafe();
         opts.ModuleScale = 0.94;
@@ -696,11 +737,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="PaintSplash"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions PaintSplashSafe() => PaintSplash();
 
     /// <summary>
     /// Bolder variant of <see cref="PaintSplash"/> with denser splashes.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions PaintSplashBold() {
         var opts = PaintSplashSafe();
         opts.ModuleScale = 0.95;
@@ -729,11 +774,15 @@ public static class QrArtPresets {
     /// <summary>
     /// Explicit scan-safe variant of <see cref="PaintSplashPastel"/>.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions PaintSplashPastelSafe() => PaintSplashPastel();
 
     /// <summary>
     /// Bolder variant of <see cref="PaintSplashPastel"/> with denser splashes.
     /// </summary>
+    [Obsolete("Use QrArt.Theme(...) + QrEasyOptions.Art instead.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static QrEasyOptions PaintSplashPastelBold() {
         var opts = PaintSplashPastelSafe();
         opts.ModuleScale = 0.95;

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -1,3 +1,4 @@
+using System;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 
@@ -399,6 +400,70 @@ public static class QrArtPresets {
     }
 
     /// <summary>
+    /// Paint-splash canvas with crisp, scan-friendly modules.
+    /// </summary>
+    public static QrEasyOptions PaintSplash() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(18, 36, 92);
+        opts.Background = new Rgba32(250, 252, 255);
+        opts.ModuleShape = QrPngModuleShape.ConnectedSquircle;
+        opts.ModuleScale = 0.96;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Radial,
+            MinScale = 0.94,
+            MaxScale = 1.0,
+            RingSize = 2,
+        };
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Cycle,
+            RingSize = 2,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(18, 36, 92),
+                new Rgba32(26, 68, 148),
+                new Rgba32(14, 120, 150),
+            },
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = true,
+            FrameStyle = QrPngEyeFrameStyle.Target,
+            OuterShape = QrPngModuleShape.Rounded,
+            InnerShape = QrPngModuleShape.Circle,
+            OuterCornerRadiusPx = 6,
+            InnerCornerRadiusPx = 4,
+            OuterColor = new Rgba32(20, 44, 120),
+            InnerColor = new Rgba32(26, 164, 182),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 30,
+            CornerRadiusPx = 30,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = new Rgba32(238, 246, 255),
+                EndColor = new Rgba32(218, 232, 255),
+            },
+            Splash = new QrPngCanvasSplashOptions {
+                Color = new Rgba32(40, 150, 210, 96),
+                Count = 11,
+                MinRadiusPx = 16,
+                MaxRadiusPx = 46,
+                SpreadPx = 28,
+                Seed = 4242,
+                DripChance = 0.42,
+                DripLengthPx = 28,
+                DripWidthPx = 9,
+                ProtectQrArea = true,
+            },
+            BorderPx = 1,
+            BorderColor = new Rgba32(255, 255, 255, 210),
+            ShadowOffsetX = 6,
+            ShadowOffsetY = 8,
+            ShadowColor = new Rgba32(22, 50, 120, 56),
+        };
+        return opts;
+    }
+
+    /// <summary>
     /// Explicit scan-safe variant of <see cref="NeonGlow"/>.
     /// </summary>
     public static QrEasyOptions NeonGlowSafe() => NeonGlow();
@@ -548,6 +613,30 @@ public static class QrArtPresets {
         }
         if (opts.ForegroundPalette is not null) {
             opts.ForegroundPalette.RingSize = 1;
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="PaintSplash"/>.
+    /// </summary>
+    public static QrEasyOptions PaintSplashSafe() => PaintSplash();
+
+    /// <summary>
+    /// Bolder variant of <see cref="PaintSplash"/> with denser splashes.
+    /// </summary>
+    public static QrEasyOptions PaintSplashBold() {
+        var opts = PaintSplashSafe();
+        opts.ModuleScale = 0.95;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.92;
+            opts.ModuleScaleMap.RingSize = 1;
+        }
+        if (opts.Canvas?.Splash is not null) {
+            opts.Canvas.Splash.Count = 16;
+            opts.Canvas.Splash.DripChance = 0.55;
+            opts.Canvas.Splash.DripLengthPx = 36;
+            opts.Canvas.Splash.MaxRadiusPx = Math.Max(opts.Canvas.Splash.MaxRadiusPx, 54);
         }
         return opts;
     }

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -32,6 +32,14 @@ public static class QrArtPresets {
                 new Rgba32(120, 40, 160),
             },
         };
+        opts.ForegroundPattern = new QrPngForegroundPatternOptions {
+            Type = QrPngForegroundPatternType.StippleDots,
+            Color = new Rgba32(0, 48, 46, 120),
+            SizePx = 5,
+            ThicknessPx = 1,
+            ApplyToModules = true,
+            ApplyToEyes = false,
+        };
         opts.Eyes = new QrPngEyeOptions {
             UseFrame = true,
             FrameStyle = QrPngEyeFrameStyle.Glow,
@@ -81,6 +89,14 @@ public static class QrArtPresets {
             Type = QrPngGradientType.DiagonalDown,
             StartColor = new Rgba32(24, 120, 180),
             EndColor = new Rgba32(28, 52, 150),
+        };
+        opts.ForegroundPattern = new QrPngForegroundPatternOptions {
+            Type = QrPngForegroundPatternType.StippleDots,
+            Color = new Rgba32(18, 50, 120, 96),
+            SizePx = 6,
+            ThicknessPx = 1,
+            ApplyToModules = true,
+            ApplyToEyes = false,
         };
         opts.Eyes = new QrPngEyeOptions {
             UseFrame = true,
@@ -144,6 +160,14 @@ public static class QrArtPresets {
                 new Rgba32(36, 120, 164),
             },
         };
+        opts.ForegroundPattern = new QrPngForegroundPatternOptions {
+            Type = QrPngForegroundPatternType.StippleDots,
+            Color = new Rgba32(44, 54, 150, 96),
+            SizePx = 6,
+            ThicknessPx = 1,
+            ApplyToModules = true,
+            ApplyToEyes = false,
+        };
         opts.Eyes = new QrPngEyeOptions {
             UseFrame = true,
             FrameStyle = QrPngEyeFrameStyle.Target,
@@ -190,6 +214,14 @@ public static class QrArtPresets {
                 new Rgba32(40, 60, 140),
                 new Rgba32(18, 98, 140),
             },
+        };
+        opts.ForegroundPattern = new QrPngForegroundPatternOptions {
+            Type = QrPngForegroundPatternType.Crosshatch,
+            Color = new Rgba32(12, 24, 64, 92),
+            SizePx = 6,
+            ThicknessPx = 1,
+            ApplyToModules = true,
+            ApplyToEyes = false,
         };
         opts.ForegroundPaletteZones = new QrPngPaletteZoneOptions {
             CornerSize = 9,
@@ -270,6 +302,14 @@ public static class QrArtPresets {
                 new Rgba32(16, 98, 140),
             },
         };
+        opts.ForegroundPattern = new QrPngForegroundPatternOptions {
+            Type = QrPngForegroundPatternType.StippleDots,
+            Color = new Rgba32(18, 42, 120, 92),
+            SizePx = 6,
+            ThicknessPx = 1,
+            ApplyToModules = true,
+            ApplyToEyes = false,
+        };
         opts.Eyes = new QrPngEyeOptions {
             UseFrame = true,
             FrameStyle = QrPngEyeFrameStyle.InsetRing,
@@ -293,6 +333,67 @@ public static class QrArtPresets {
             ShadowOffsetX = 4,
             ShadowOffsetY = 6,
             ShadowColor = new Rgba32(40, 70, 150, 48),
+        };
+        return opts;
+    }
+
+    /// <summary>
+    /// Stripe-textured eyes with calm module styling.
+    /// </summary>
+    public static QrEasyOptions StripeEyes() {
+        var opts = BaseArt();
+        opts.Foreground = new Rgba32(26, 46, 128);
+        opts.Background = new Rgba32(248, 250, 255);
+        opts.ModuleShape = QrPngModuleShape.Squircle;
+        opts.ModuleScale = 0.96;
+        opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
+            Mode = QrPngModuleScaleMode.Rings,
+            MinScale = 0.94,
+            MaxScale = 1.0,
+            RingSize = 2,
+        };
+        opts.ForegroundPalette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Cycle,
+            RingSize = 2,
+            ApplyToEyes = false,
+            Colors = new[] {
+                new Rgba32(26, 46, 128),
+                new Rgba32(40, 70, 150),
+                new Rgba32(20, 110, 156),
+            },
+        };
+        opts.ForegroundPattern = new QrPngForegroundPatternOptions {
+            Type = QrPngForegroundPatternType.DiagonalStripes,
+            Color = new Rgba32(18, 34, 108, 148),
+            SizePx = 6,
+            ThicknessPx = 2,
+            SnapToModuleSize = true,
+            ModuleStep = 1,
+            ApplyToModules = false,
+            ApplyToEyes = true,
+        };
+        opts.Eyes = new QrPngEyeOptions {
+            UseFrame = false,
+            OuterShape = QrPngModuleShape.Rounded,
+            InnerShape = QrPngModuleShape.Squircle,
+            OuterCornerRadiusPx = 6,
+            InnerCornerRadiusPx = 4,
+            OuterColor = new Rgba32(24, 44, 132),
+            InnerColor = new Rgba32(46, 170, 188),
+        };
+        opts.Canvas = new QrPngCanvasOptions {
+            PaddingPx = 26,
+            CornerRadiusPx = 28,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.Vertical,
+                StartColor = new Rgba32(236, 244, 255),
+                EndColor = new Rgba32(220, 232, 255),
+            },
+            BorderPx = 1,
+            BorderColor = new Rgba32(255, 255, 255, 200),
+            ShadowOffsetX = 4,
+            ShadowOffsetY = 6,
+            ShadowColor = new Rgba32(32, 60, 130, 48),
         };
         return opts;
     }
@@ -421,6 +522,32 @@ public static class QrArtPresets {
                 new Rgba32(54, 86, 184),
                 new Rgba32(18, 108, 152),
             };
+        }
+        return opts;
+    }
+
+    /// <summary>
+    /// Explicit scan-safe variant of <see cref="StripeEyes"/>.
+    /// </summary>
+    public static QrEasyOptions StripeEyesSafe() => StripeEyes();
+
+    /// <summary>
+    /// Bolder variant of <see cref="StripeEyes"/> that also textures modules.
+    /// </summary>
+    public static QrEasyOptions StripeEyesBold() {
+        var opts = StripeEyesSafe();
+        opts.ModuleScale = 0.94;
+        if (opts.ModuleScaleMap is not null) {
+            opts.ModuleScaleMap.MinScale = 0.90;
+            opts.ModuleScaleMap.RingSize = 1;
+        }
+        if (opts.ForegroundPattern is not null) {
+            opts.ForegroundPattern.ApplyToModules = true;
+            opts.ForegroundPattern.SizePx = 6;
+            opts.ForegroundPattern.ThicknessPx = 2;
+        }
+        if (opts.ForegroundPalette is not null) {
+            opts.ForegroundPalette.RingSize = 1;
         }
         return opts;
     }

--- a/CodeGlyphX/QrArtPresets.cs
+++ b/CodeGlyphX/QrArtPresets.cs
@@ -12,13 +12,13 @@ public static class QrArtPresets {
     /// </summary>
     public static QrEasyOptions NeonGlow() {
         var opts = BaseArt();
-        opts.Foreground = new Rgba32(0, 255, 240);
-        opts.Background = new Rgba32(252, 254, 255);
+        opts.Foreground = new Rgba32(0, 96, 92);
+        opts.Background = new Rgba32(250, 252, 255);
         opts.ModuleShape = QrPngModuleShape.Dot;
-        opts.ModuleScale = 0.92;
+        opts.ModuleScale = 0.96;
         opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
             Mode = QrPngModuleScaleMode.Radial,
-            MinScale = 0.86,
+            MinScale = 0.92,
             MaxScale = 1.0,
             RingSize = 2,
         };
@@ -27,9 +27,9 @@ public static class QrArtPresets {
             RingSize = 2,
             ApplyToEyes = false,
             Colors = new[] {
-                new Rgba32(0, 255, 240),
-                new Rgba32(0, 168, 255),
-                new Rgba32(255, 92, 255),
+                new Rgba32(0, 96, 92),
+                new Rgba32(0, 72, 156),
+                new Rgba32(120, 40, 160),
             },
         };
         opts.Eyes = new QrPngEyeOptions {
@@ -37,13 +37,13 @@ public static class QrArtPresets {
             FrameStyle = QrPngEyeFrameStyle.Glow,
             OuterShape = QrPngModuleShape.Rounded,
             InnerShape = QrPngModuleShape.Circle,
-            OuterColor = new Rgba32(0, 255, 240),
-            InnerColor = new Rgba32(255, 92, 255),
+            OuterColor = new Rgba32(0, 90, 140),
+            InnerColor = new Rgba32(120, 40, 160),
             OuterCornerRadiusPx = 6,
             InnerCornerRadiusPx = 4,
-            GlowRadiusPx = 34,
-            GlowAlpha = 140,
-            GlowColor = new Rgba32(0, 210, 255, 220),
+            GlowRadiusPx = 22,
+            GlowAlpha = 96,
+            GlowColor = new Rgba32(0, 170, 220, 160),
         };
         opts.Canvas = new QrPngCanvasOptions {
             PaddingPx = 28,
@@ -67,20 +67,20 @@ public static class QrArtPresets {
     /// </summary>
     public static QrEasyOptions LiquidGlass() {
         var opts = BaseArt();
-        opts.Foreground = new Rgba32(32, 98, 255);
-        opts.Background = new Rgba32(248, 251, 255);
+        opts.Foreground = new Rgba32(24, 68, 160);
+        opts.Background = new Rgba32(246, 250, 255);
         opts.ModuleShape = QrPngModuleShape.Squircle;
-        opts.ModuleScale = 0.94;
+        opts.ModuleScale = 0.96;
         opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
             Mode = QrPngModuleScaleMode.Rings,
-            MinScale = 0.9,
+            MinScale = 0.94,
             MaxScale = 1.0,
             RingSize = 3,
         };
         opts.ForegroundGradient = new QrPngGradientOptions {
             Type = QrPngGradientType.DiagonalDown,
-            StartColor = new Rgba32(38, 190, 255),
-            EndColor = new Rgba32(66, 84, 255),
+            StartColor = new Rgba32(24, 120, 180),
+            EndColor = new Rgba32(28, 52, 150),
         };
         opts.Eyes = new QrPngEyeOptions {
             UseFrame = true,
@@ -91,8 +91,8 @@ public static class QrArtPresets {
             InnerCornerRadiusPx = 4,
             OuterGradient = new QrPngGradientOptions {
                 Type = QrPngGradientType.Radial,
-                StartColor = new Rgba32(102, 224, 255),
-                EndColor = new Rgba32(48, 96, 255),
+                StartColor = new Rgba32(56, 150, 200),
+                EndColor = new Rgba32(28, 72, 176),
             },
             InnerColor = new Rgba32(255, 255, 255),
         };
@@ -124,13 +124,13 @@ public static class QrArtPresets {
     /// </summary>
     public static QrEasyOptions ConnectedSquircleGlow() {
         var opts = BaseArt();
-        opts.Foreground = new Rgba32(110, 120, 255);
+        opts.Foreground = new Rgba32(60, 72, 180);
         opts.Background = new Rgba32(250, 252, 255);
         opts.ModuleShape = QrPngModuleShape.ConnectedSquircle;
-        opts.ModuleScale = 0.94;
+        opts.ModuleScale = 0.96;
         opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
             Mode = QrPngModuleScaleMode.Radial,
-            MinScale = 0.9,
+            MinScale = 0.94,
             MaxScale = 1.0,
             RingSize = 2,
         };
@@ -139,9 +139,9 @@ public static class QrArtPresets {
             RingSize = 2,
             ApplyToEyes = false,
             Colors = new[] {
-                new Rgba32(110, 120, 255),
-                new Rgba32(140, 96, 255),
-                new Rgba32(90, 210, 255),
+                new Rgba32(60, 72, 180),
+                new Rgba32(80, 56, 180),
+                new Rgba32(36, 120, 164),
             },
         };
         opts.Eyes = new QrPngEyeOptions {
@@ -151,8 +151,8 @@ public static class QrArtPresets {
             InnerShape = QrPngModuleShape.Circle,
             OuterCornerRadiusPx = 6,
             InnerCornerRadiusPx = 4,
-            OuterColor = new Rgba32(120, 128, 255),
-            InnerColor = new Rgba32(90, 210, 255),
+            OuterColor = new Rgba32(72, 82, 190),
+            InnerColor = new Rgba32(40, 130, 170),
         };
         opts.Canvas = new QrPngCanvasOptions {
             PaddingPx = 28,
@@ -186,9 +186,9 @@ public static class QrArtPresets {
             RingSize = 2,
             ApplyToEyes = false,
             Colors = new[] {
-                new Rgba32(34, 54, 110),
-                new Rgba32(72, 104, 214),
-                new Rgba32(26, 170, 220),
+                new Rgba32(24, 38, 86),
+                new Rgba32(40, 60, 140),
+                new Rgba32(18, 98, 140),
             },
         };
         opts.ForegroundPaletteZones = new QrPngPaletteZoneOptions {
@@ -198,7 +198,7 @@ public static class QrArtPresets {
                 ApplyToEyes = true,
                 Colors = new[] {
                     new Rgba32(22, 36, 84),
-                    new Rgba32(80, 120, 255),
+                    new Rgba32(40, 60, 140),
                 },
             },
             CenterSize = 11,
@@ -207,8 +207,8 @@ public static class QrArtPresets {
                 RingSize = 1,
                 ApplyToEyes = false,
                 Colors = new[] {
-                    new Rgba32(44, 210, 255),
-                    new Rgba32(110, 120, 255),
+                    new Rgba32(20, 92, 140),
+                    new Rgba32(44, 60, 140),
                 },
             },
         };
@@ -250,13 +250,13 @@ public static class QrArtPresets {
     /// </summary>
     public static QrEasyOptions InsetRings() {
         var opts = BaseArt();
-        opts.Foreground = new Rgba32(44, 80, 180);
+        opts.Foreground = new Rgba32(28, 60, 150);
         opts.Background = new Rgba32(248, 250, 255);
         opts.ModuleShape = QrPngModuleShape.Squircle;
-        opts.ModuleScale = 0.93;
+        opts.ModuleScale = 0.95;
         opts.ModuleScaleMap = new QrPngModuleScaleMapOptions {
             Mode = QrPngModuleScaleMode.Rings,
-            MinScale = 0.9,
+            MinScale = 0.94,
             MaxScale = 1.0,
             RingSize = 1,
         };
@@ -265,9 +265,9 @@ public static class QrArtPresets {
             RingSize = 1,
             ApplyToEyes = false,
             Colors = new[] {
-                new Rgba32(44, 80, 180),
-                new Rgba32(82, 112, 214),
-                new Rgba32(28, 170, 220),
+                new Rgba32(28, 60, 150),
+                new Rgba32(48, 80, 170),
+                new Rgba32(16, 98, 140),
             },
         };
         opts.Eyes = new QrPngEyeOptions {
@@ -277,7 +277,7 @@ public static class QrArtPresets {
             InnerShape = QrPngModuleShape.Circle,
             OuterCornerRadiusPx = 7,
             InnerCornerRadiusPx = 4,
-            OuterColor = new Rgba32(36, 64, 150),
+            OuterColor = new Rgba32(24, 52, 140),
             InnerColor = new Rgba32(255, 255, 255),
         };
         opts.Canvas = new QrPngCanvasOptions {

--- a/CodeGlyphX/QrArtSafety.cs
+++ b/CodeGlyphX/QrArtSafety.cs
@@ -141,6 +141,7 @@ public static class QrArtSafety {
             || options.ModuleScaleMap is not null
             || options.ForegroundGradient is not null
             || options.ForegroundPalette is not null
+            || options.ForegroundPattern is not null
             || options.ForegroundPaletteZones is not null
             || options.Eyes is not null;
 
@@ -155,20 +156,32 @@ public static class QrArtSafety {
         var bg = options.BackgroundGradient is null
             ? new[] { options.Background }
             : new[] { options.BackgroundGradient.StartColor, options.BackgroundGradient.EndColor };
+        var pattern = options.ForegroundPattern;
+        var patternActive = pattern is not null && pattern.Color.A != 0 && pattern.ThicknessPx > 0;
 
         if (options.ForegroundPalette is not null || options.ForegroundPaletteZones is not null) {
             var palettes = CollectPalettes(options.ForegroundPalette, options.ForegroundPaletteZones);
-            var min = MinContrast(palettes, bg);
+            var colors = patternActive
+                ? AddPatternVariants(palettes, pattern!)
+                : palettes;
+            var min = MinContrast(colors, bg);
             if (min < 4.5) {
                 Add(QrArtWarningKind.LowContrastPalette, "Palette includes low-contrast colors against the background.", 30);
             }
         } else if (options.ForegroundGradient is null) {
-            var contrast = MinContrast(new[] { options.Foreground }, bg);
+            var colors = patternActive
+                ? new[] { options.Foreground, ComposeOver(pattern!.Color, options.Foreground) }
+                : new[] { options.Foreground };
+            var contrast = MinContrast(colors, bg);
             if (contrast < 4.5) {
                 Add(QrArtWarningKind.LowContrast, $"Foreground/background contrast {contrast:0.00} is low.", 30);
             }
         } else {
-            var min = MinContrast(new[] { options.ForegroundGradient.StartColor, options.ForegroundGradient.EndColor }, bg);
+            var gradientColors = new[] { options.ForegroundGradient.StartColor, options.ForegroundGradient.EndColor };
+            var colors = patternActive
+                ? AddPatternVariants(gradientColors, pattern!)
+                : gradientColors;
+            var min = MinContrast(colors, bg);
             if (min < 4.5) {
                 Add(QrArtWarningKind.LowContrastGradient, "Gradient includes low-contrast colors against the background.", 30);
             }
@@ -219,6 +232,37 @@ public static class QrArtSafety {
             }
         }
         return min;
+    }
+
+    private static Rgba32[] AddPatternVariants(Rgba32[] colors, QrPngForegroundPatternOptions pattern) {
+        var list = new List<Rgba32>(colors.Length * 2);
+        for (var i = 0; i < colors.Length; i++) {
+            var color = colors[i];
+            list.Add(color);
+            list.Add(ComposeOver(pattern.Color, color));
+        }
+        return list.ToArray();
+    }
+
+    private static Rgba32 ComposeOver(Rgba32 top, Rgba32 bottom) {
+        var ta = top.A;
+        if (ta == 0) return bottom;
+        if (ta == 255 && bottom.A == 255) return top;
+
+        var ba = bottom.A;
+        var inv = 255 - ta;
+        var outA = ta + (ba * inv + 127) / 255;
+        if (outA <= 0) return new Rgba32(0, 0, 0, 0);
+
+        var outRPre = top.R * ta + (int)((bottom.R * ba * (long)inv + 127) / 255);
+        var outGPre = top.G * ta + (int)((bottom.G * ba * (long)inv + 127) / 255);
+        var outBPre = top.B * ta + (int)((bottom.B * ba * (long)inv + 127) / 255);
+
+        var outR = (outRPre + outA / 2) / outA;
+        var outG = (outGPre + outA / 2) / outA;
+        var outB = (outBPre + outA / 2) / outA;
+
+        return new Rgba32((byte)outR, (byte)outG, (byte)outB, (byte)outA);
     }
 
     private static Rgba32[] CollectPalettes(QrPngPaletteOptions? basePalette, QrPngPaletteZoneOptions? zones) {

--- a/CodeGlyphX/QrArtSafetyMode.cs
+++ b/CodeGlyphX/QrArtSafetyMode.cs
@@ -1,0 +1,19 @@
+namespace CodeGlyphX;
+
+/// <summary>
+/// Safety guardrail strength for QR art styling.
+/// </summary>
+public enum QrArtSafetyMode {
+    /// <summary>
+    /// Strong guardrails for maximum scan reliability.
+    /// </summary>
+    Safe,
+    /// <summary>
+    /// Balanced guardrails with moderate artistic freedom.
+    /// </summary>
+    Balanced,
+    /// <summary>
+    /// Light guardrails that allow bolder styling.
+    /// </summary>
+    Bold,
+}

--- a/CodeGlyphX/QrArtTheme.cs
+++ b/CodeGlyphX/QrArtTheme.cs
@@ -1,0 +1,35 @@
+namespace CodeGlyphX;
+
+/// <summary>
+/// High-level QR art themes.
+/// </summary>
+public enum QrArtTheme {
+    /// <summary>
+    /// Neon glow with dotted texture and a dark canvas.
+    /// </summary>
+    NeonGlow,
+    /// <summary>
+    /// Glassy gradients and smooth squircles.
+    /// </summary>
+    LiquidGlass,
+    /// <summary>
+    /// Connected squircles with a modern glow.
+    /// </summary>
+    ConnectedSquircleGlow,
+    /// <summary>
+    /// Tech-inspired cut-corner eyes and structured palettes.
+    /// </summary>
+    CutCornerTech,
+    /// <summary>
+    /// Orderly rings with inset-ring eyes.
+    /// </summary>
+    InsetRings,
+    /// <summary>
+    /// Stripe-textured eyes with calmer modules.
+    /// </summary>
+    StripeEyes,
+    /// <summary>
+    /// Paint splash/drip canvas effects.
+    /// </summary>
+    PaintSplash,
+}

--- a/CodeGlyphX/QrArtVariant.cs
+++ b/CodeGlyphX/QrArtVariant.cs
@@ -1,0 +1,19 @@
+namespace CodeGlyphX;
+
+/// <summary>
+/// Theme variants for QR art.
+/// </summary>
+public enum QrArtVariant {
+    /// <summary>
+    /// Scan-friendly default variant.
+    /// </summary>
+    Safe,
+    /// <summary>
+    /// More decorative variant with stronger effects.
+    /// </summary>
+    Bold,
+    /// <summary>
+    /// Pastel palette variant (when supported by the theme).
+    /// </summary>
+    Pastel,
+}

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -76,6 +76,7 @@ public static partial class QrEasy {
         if (opts.ModuleCornerRadiusPx.HasValue) render.ModuleCornerRadiusPx = opts.ModuleCornerRadiusPx.Value;
         if (opts.ForegroundGradient is not null) render.ForegroundGradient = opts.ForegroundGradient;
         if (opts.ForegroundPalette is not null) render.ForegroundPalette = opts.ForegroundPalette;
+        if (opts.ForegroundPattern is not null) render.ForegroundPattern = opts.ForegroundPattern;
         if (opts.ForegroundPaletteZones is not null) render.ForegroundPaletteZones = opts.ForegroundPaletteZones;
         if (opts.ModuleScaleMap is not null) render.ModuleScaleMap = opts.ModuleScaleMap;
         if (opts.Canvas is not null) render.Canvas = opts.Canvas;
@@ -227,6 +228,7 @@ public static partial class QrEasy {
             ModuleCornerRadiusPx = opts.ModuleCornerRadiusPx,
             ForegroundGradient = opts.ForegroundGradient,
             ForegroundPalette = opts.ForegroundPalette,
+            ForegroundPattern = opts.ForegroundPattern,
             ForegroundPaletteZones = opts.ForegroundPaletteZones,
             Eyes = opts.Eyes,
             Canvas = opts.Canvas,

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -298,6 +298,7 @@ public static partial class QrEasy {
     }
 
     private static QrEasyOptions SelectArtPreset(QrArtOptions art) {
+#pragma warning disable CS0618 // QrArtPresets is deprecated in favor of the high-level art API.
         return art.Theme switch {
             QrArtTheme.NeonGlow => art.Variant == QrArtVariant.Bold ? QrArtPresets.NeonGlowBold() : QrArtPresets.NeonGlowSafe(),
             QrArtTheme.LiquidGlass => art.Variant == QrArtVariant.Bold ? QrArtPresets.LiquidGlassBold() : QrArtPresets.LiquidGlassSafe(),
@@ -312,6 +313,7 @@ public static partial class QrEasy {
             },
             _ => QrArtPresets.PaintSplashSafe(),
         };
+#pragma warning restore CS0618
     }
 
     private static void ApplyArtDefaults(QrPngRenderOptions render, QrEasyOptions preset) {

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -93,6 +93,11 @@ public sealed class QrEasyOptions {
     public QrRenderStyle Style { get; set; } = QrRenderStyle.Default;
 
     /// <summary>
+    /// High-level QR art options (theme + variant + intensity).
+    /// </summary>
+    public QrArtOptions? Art { get; set; }
+
+    /// <summary>
     /// Overrides the module shape (when set).
     /// </summary>
     public QrPngModuleShape? ModuleShape { get; set; }

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -133,6 +133,11 @@ public sealed class QrEasyOptions {
     public QrPngPaletteOptions? ForegroundPalette { get; set; }
 
     /// <summary>
+    /// Overrides the foreground pattern overlay.
+    /// </summary>
+    public QrPngForegroundPatternOptions? ForegroundPattern { get; set; }
+
+    /// <summary>
     /// Overrides palette zones.
     /// </summary>
     public QrPngPaletteZoneOptions? ForegroundPaletteZones { get; set; }

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
@@ -32,6 +32,11 @@ public sealed class QrPngCanvasOptions {
     public QrPngBackgroundPatternOptions? Pattern { get; set; }
 
     /// <summary>
+    /// Optional paint splash/drip overlay (kept outside the QR area).
+    /// </summary>
+    public QrPngCanvasSplashOptions? Splash { get; set; }
+
+    /// <summary>
     /// Border thickness in pixels (0 = no border).
     /// </summary>
     public int BorderPx { get; set; }
@@ -62,5 +67,6 @@ public sealed class QrPngCanvasOptions {
         if (BorderPx < 0) throw new ArgumentOutOfRangeException(nameof(BorderPx));
         BackgroundGradient?.Validate();
         Pattern?.Validate();
+        Splash?.Validate();
     }
 }

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasSplashOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasSplashOptions.cs
@@ -12,6 +12,11 @@ public sealed class QrPngCanvasSplashOptions {
     public Rgba32 Color { get; set; } = new(48, 96, 220, 92);
 
     /// <summary>
+    /// Optional multi-color splash palette. When set, a random entry is used per splash.
+    /// </summary>
+    public Rgba32[]? Colors { get; set; }
+
+    /// <summary>
     /// Number of splash blobs to draw.
     /// </summary>
     public int Count { get; set; } = 10;
@@ -64,6 +69,6 @@ public sealed class QrPngCanvasSplashOptions {
         if (DripChance is < 0 or > 1) throw new ArgumentOutOfRangeException(nameof(DripChance));
         if (DripLengthPx < 0) throw new ArgumentOutOfRangeException(nameof(DripLengthPx));
         if (DripWidthPx < 0) throw new ArgumentOutOfRangeException(nameof(DripWidthPx));
+        if (Colors is { Length: 0 }) throw new ArgumentOutOfRangeException(nameof(Colors));
     }
 }
-

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasSplashOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasSplashOptions.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Paint splash/drip options for the canvas background.
+/// </summary>
+public sealed class QrPngCanvasSplashOptions {
+    /// <summary>
+    /// Splash color (alpha recommended).
+    /// </summary>
+    public Rgba32 Color { get; set; } = new(48, 96, 220, 92);
+
+    /// <summary>
+    /// Number of splash blobs to draw.
+    /// </summary>
+    public int Count { get; set; } = 10;
+
+    /// <summary>
+    /// Minimum splash radius in pixels.
+    /// </summary>
+    public int MinRadiusPx { get; set; } = 14;
+
+    /// <summary>
+    /// Maximum splash radius in pixels.
+    /// </summary>
+    public int MaxRadiusPx { get; set; } = 40;
+
+    /// <summary>
+    /// How far splashes can extend beyond the QR bounds.
+    /// </summary>
+    public int SpreadPx { get; set; } = 22;
+
+    /// <summary>
+    /// Random seed used to place splashes.
+    /// </summary>
+    public int Seed { get; set; } = 12345;
+
+    /// <summary>
+    /// Chance (0..1) that a splash will include a downward drip.
+    /// </summary>
+    public double DripChance { get; set; } = 0.35;
+
+    /// <summary>
+    /// Maximum drip length in pixels.
+    /// </summary>
+    public int DripLengthPx { get; set; } = 26;
+
+    /// <summary>
+    /// Drip width in pixels.
+    /// </summary>
+    public int DripWidthPx { get; set; } = 8;
+
+    /// <summary>
+    /// When true, never draws inside the QR area.
+    /// </summary>
+    public bool ProtectQrArea { get; set; } = true;
+
+    internal void Validate() {
+        if (Count < 0) throw new ArgumentOutOfRangeException(nameof(Count));
+        if (MinRadiusPx < 1) throw new ArgumentOutOfRangeException(nameof(MinRadiusPx));
+        if (MaxRadiusPx < MinRadiusPx) throw new ArgumentOutOfRangeException(nameof(MaxRadiusPx));
+        if (SpreadPx < 0) throw new ArgumentOutOfRangeException(nameof(SpreadPx));
+        if (DripChance is < 0 or > 1) throw new ArgumentOutOfRangeException(nameof(DripChance));
+        if (DripLengthPx < 0) throw new ArgumentOutOfRangeException(nameof(DripLengthPx));
+        if (DripWidthPx < 0) throw new ArgumentOutOfRangeException(nameof(DripWidthPx));
+    }
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngForegroundPatternOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngForegroundPatternOptions.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Foreground pattern options for styling dark modules.
+/// </summary>
+public sealed class QrPngForegroundPatternOptions {
+    /// <summary>
+    /// Gets or sets the pattern type.
+    /// </summary>
+    public QrPngForegroundPatternType Type { get; set; } = QrPngForegroundPatternType.StippleDots;
+
+    /// <summary>
+    /// Gets or sets the pattern color (alpha recommended).
+    /// </summary>
+    public Rgba32 Color { get; set; } = new(0, 0, 0, 48);
+
+    /// <summary>
+    /// Gets or sets the pattern cell size in pixels.
+    /// </summary>
+    public int SizePx { get; set; } = 6;
+
+    /// <summary>
+    /// Gets or sets the pattern thickness (dot radius or stripe thickness).
+    /// </summary>
+    public int ThicknessPx { get; set; } = 1;
+
+    /// <summary>
+    /// When true, pattern cell size snaps to a multiple of the QR module size.
+    /// </summary>
+    public bool SnapToModuleSize { get; set; }
+
+    /// <summary>
+    /// Module size multiplier when <see cref="SnapToModuleSize"/> is enabled.
+    /// </summary>
+    public int ModuleStep { get; set; } = 1;
+
+    /// <summary>
+    /// When true, applies the pattern to non-eye modules.
+    /// </summary>
+    public bool ApplyToModules { get; set; } = true;
+
+    /// <summary>
+    /// When true, applies the pattern to eye (finder) modules.
+    /// </summary>
+    public bool ApplyToEyes { get; set; }
+
+    internal void Validate() {
+        if (SizePx <= 0) throw new ArgumentOutOfRangeException(nameof(SizePx));
+        if (ThicknessPx < 0) throw new ArgumentOutOfRangeException(nameof(ThicknessPx));
+        if (ModuleStep <= 0) throw new ArgumentOutOfRangeException(nameof(ModuleStep));
+    }
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngForegroundPatternType.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngForegroundPatternType.cs
@@ -1,0 +1,20 @@
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Foreground pattern types applied inside dark modules.
+/// </summary>
+public enum QrPngForegroundPatternType {
+    /// <summary>
+    /// Small stipple dots.
+    /// </summary>
+    StippleDots,
+    /// <summary>
+    /// Diagonal stripes.
+    /// </summary>
+    DiagonalStripes,
+    /// <summary>
+    /// Two diagonal stripe sets forming a crosshatch.
+    /// </summary>
+    Crosshatch,
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngModuleShape.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngModuleShape.cs
@@ -21,6 +21,10 @@ public enum QrPngModuleShape {
     /// </summary>
     ConnectedRounded,
     /// <summary>
+    /// Squircle modules that connect to adjacent dark modules.
+    /// </summary>
+    ConnectedSquircle,
+    /// <summary>
     /// Diamond-shaped modules.
     /// </summary>
     Diamond,

--- a/CodeGlyphX/Rendering/Png/QrPngRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderOptions.cs
@@ -62,6 +62,11 @@ public sealed partial class QrPngRenderOptions {
     public QrPngPaletteOptions? ForegroundPalette { get; set; }
 
     /// <summary>
+    /// Optional pattern overlay for foreground modules.
+    /// </summary>
+    public QrPngForegroundPatternOptions? ForegroundPattern { get; set; }
+
+    /// <summary>
     /// Optional palette overrides for specific zones.
     /// </summary>
     public QrPngPaletteZoneOptions? ForegroundPaletteZones { get; set; }

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
@@ -593,6 +593,8 @@ public static partial class QrPngRenderer {
         var maxR = Math.Max(minR, splash.MaxRadiusPx);
         var spread = Math.Max(0, splash.SpreadPx);
         var rand = new Random(splash.Seed);
+        var palette = splash.Colors;
+        var paletteLen = palette?.Length ?? 0;
 
         var bandX0 = qrX0 - spread;
         var bandX1 = qrX1 + spread;
@@ -600,6 +602,7 @@ public static partial class QrPngRenderer {
         var bandY1 = qrY1 + spread;
 
         for (var i = 0; i < splash.Count; i++) {
+            var blobColor = paletteLen > 0 ? palette![rand.Next(paletteLen)] : splash.Color;
             var blobR = NextBetween(rand, minR, maxR);
             var side = rand.Next(4);
 
@@ -633,7 +636,7 @@ public static partial class QrPngRenderer {
                 cx,
                 cy,
                 blobR,
-                splash.Color,
+                blobColor,
                 canvasX,
                 canvasY,
                 canvasX1,
@@ -661,7 +664,7 @@ public static partial class QrPngRenderer {
                     dripCy,
                     rx,
                     ry,
-                    splash.Color,
+                    blobColor,
                     canvasX,
                     canvasY,
                     canvasX1,

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -383,6 +383,7 @@ public static partial class QrPngRenderer {
                 FillMaskShape(scanlines, widthPx, heightPx, stride, x, y, w, h, color, shape, radius);
                 return;
             case QrPngModuleShape.Squircle:
+            case QrPngModuleShape.ConnectedSquircle:
                 FillSquircle(scanlines, widthPx, heightPx, stride, x, y, w, h, color);
                 return;
             case QrPngModuleShape.Dot:
@@ -427,6 +428,7 @@ public static partial class QrPngRenderer {
                 FillMaskShapeGradient(scanlines, widthPx, heightPx, stride, x, y, w, h, gradient, shape, radius);
                 return;
             case QrPngModuleShape.Squircle:
+            case QrPngModuleShape.ConnectedSquircle:
                 FillSquircleGradient(scanlines, widthPx, heightPx, stride, x, y, w, h, gradient);
                 return;
             case QrPngModuleShape.Dot:

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1317,11 +1317,28 @@ public static partial class QrPngRenderer {
             Background = canvas.Background,
             BackgroundGradient = canvas.BackgroundGradient,
             Pattern = ScalePattern(canvas.Pattern, scale),
+            Splash = ScaleSplash(canvas.Splash, scale),
             BorderPx = canvas.BorderPx * scale,
             BorderColor = canvas.BorderColor,
             ShadowOffsetX = canvas.ShadowOffsetX * scale,
             ShadowOffsetY = canvas.ShadowOffsetY * scale,
             ShadowColor = canvas.ShadowColor
+        };
+    }
+
+    private static QrPngCanvasSplashOptions? ScaleSplash(QrPngCanvasSplashOptions? splash, int scale) {
+        if (splash is null) return null;
+        return new QrPngCanvasSplashOptions {
+            Color = splash.Color,
+            Count = splash.Count,
+            MinRadiusPx = Math.Max(1, splash.MinRadiusPx * scale),
+            MaxRadiusPx = Math.Max(1, splash.MaxRadiusPx * scale),
+            SpreadPx = Math.Max(0, splash.SpreadPx * scale),
+            Seed = splash.Seed,
+            DripChance = splash.DripChance,
+            DripLengthPx = Math.Max(0, splash.DripLengthPx * scale),
+            DripWidthPx = Math.Max(0, splash.DripWidthPx * scale),
+            ProtectQrArea = splash.ProtectQrArea,
         };
     }
 

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1330,6 +1330,7 @@ public static partial class QrPngRenderer {
         if (splash is null) return null;
         return new QrPngCanvasSplashOptions {
             Color = splash.Color,
+            Colors = splash.Colors,
             Count = splash.Count,
             MinRadiusPx = Math.Max(1, splash.MinRadiusPx * scale),
             MaxRadiusPx = Math.Max(1, splash.MaxRadiusPx * scale),

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Binary1.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Binary1.cs
@@ -200,6 +200,7 @@ public static partial class QrPngRenderer {
         if (opts.BackgroundSupersample > 1) return false;
         if (opts.ForegroundGradient is not null) return false;
         if (opts.ForegroundPalette is not null) return false;
+        if (opts.ForegroundPattern is not null) return false;
         if (opts.ForegroundPaletteZones is not null) return false;
         if (opts.ModuleScaleMap is not null) return false;
         if (opts.Eyes is not null) return false;

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
@@ -15,6 +15,7 @@ public static partial class QrPngRenderer {
             && opts.BackgroundSupersample == 1
             && opts.ForegroundGradient is null
             && opts.ForegroundPalette is null
+            && opts.ForegroundPattern is null
             && opts.ForegroundPaletteZones is null
             && opts.ModuleScaleMap is null
             && opts.Eyes is null

--- a/CodeGlyphX/Rendering/Png/RenderOptions.Fluent.cs
+++ b/CodeGlyphX/Rendering/Png/RenderOptions.Fluent.cs
@@ -74,6 +74,14 @@ public sealed partial class QrPngRenderOptions {
     }
 
     /// <summary>
+    /// Sets the foreground pattern overlay.
+    /// </summary>
+    public QrPngRenderOptions WithForegroundPattern(QrPngForegroundPatternOptions? pattern) {
+        ForegroundPattern = pattern;
+        return this;
+    }
+
+    /// <summary>
     /// Sets palette overrides for specific zones.
     /// </summary>
     public QrPngRenderOptions WithForegroundPaletteZones(QrPngPaletteZoneOptions? zones) {

--- a/CodeGlyphX/Rendering/Svg/SvgQrRenderer.cs
+++ b/CodeGlyphX/Rendering/Svg/SvgQrRenderer.cs
@@ -254,6 +254,7 @@ public static class SvgQrRenderer {
         if (scale > 1.0) scale = 1.0;
 
         if (shape == QrPngModuleShape.ConnectedRounded) shape = QrPngModuleShape.Rounded;
+        if (shape == QrPngModuleShape.ConnectedSquircle) shape = QrPngModuleShape.Squircle;
         if (shape == QrPngModuleShape.Dot) scale *= QrPngShapeDefaults.DotScale;
         if (shape == QrPngModuleShape.DotGrid) {
             AppendDotGrid(sb, cellX, cellY, cellSize, scale, fill);


### PR DESCRIPTION
## Summary
- add a new high-level art API: `QrArt.Theme(...)` + `QrArtOptions`
- wire `QrEasyOptions.Art` into PNG rendering with guardrails
- map themes to existing art presets while allowing intensity and safety tuning
- deprecate/hide `QrArtPresets.*` to reduce API overload while keeping compatibility
- add focused tests and example outputs using the new API

## API
```csharp
var opts = new QrEasyOptions {
    Art = QrArt.Theme(QrArtTheme.NeonGlow, QrArtVariant.Safe, intensity: 60)
};
var png = QrEasy.RenderPng("https://example.com", opts);
```

## Tests
- dotnet build -c Release
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release --filter "FullyQualifiedName~QrArtSafetyPresetsTests|FullyQualifiedName~RendererFormatTests|FullyQualifiedName~QrPngRendererTests"
