### PR TITLE
Document net472 parity and fallbacks

### DIFF
--- a/Assets/Templates/pages/docs.html
+++ b/Assets/Templates/pages/docs.html
@@ -111,7 +111,7 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
             <h2>Getting Help</h2>
             <p>
                 If you encounter issues or have questions, please visit the
-                <a href="https://github.com/EvotecIT/CodeGlyphX/issues" target="_blank">GitHub Issues</a> page.
+                <a href="https://github.com/EvotecIT/CodeGlyphX/issues" target="_blank" rel="noopener">GitHub Issues</a> page.
             </p>
         </section>
 

--- a/Assets/Templates/pages/docs.html
+++ b/Assets/Templates/pages/docs.html
@@ -186,6 +186,17 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
             </table>
             <p class="text-muted">QR pixel decode APIs are net8+ only (e.g., <code>QrImageDecoder.TryDecodeImage(...)</code> and <code>QrDecoder.TryDecode(...)</code> from pixels).</p>
             <p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code> and <code>SupportsQrPixelDebug</code>).</p>
+            <h3>net472 parity and guidance</h3>
+            <p class="text-muted">On <code>net472</code> and <code>netstandard2.0</code>, all encoders, payload helpers, renderers, and module-grid decoders behave the same as net8+. The main intentional gaps are QR pixel decode, QR pixel debug rendering, and Span-based overloads.</p>
+            <pre class="code-block">if (CodeGlyphXFeatures.SupportsQrPixelDecode &&
+    QrImageDecoder.TryDecodeImage(bytes, QrPixelDecodeOptions.Screen(), out var decoded))
+{
+    Console.WriteLine(decoded.Text);
+}
+else
+{
+    // net472 fallback: decode from module grids or use a net8+ worker.
+}</pre>
             <p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps that only need encoding, rendering, and module-grid decode.</p>
         </section>
 

--- a/CodeGlyphX.Website/wwwroot/docs/index.html
+++ b/CodeGlyphX.Website/wwwroot/docs/index.html
@@ -270,6 +270,17 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
             </table>
             <p class="text-muted">QR pixel decode APIs are net8+ only (e.g., <code>QrImageDecoder.TryDecodeImage(...)</code> and <code>QrDecoder.TryDecode(...)</code> from pixels).</p>
             <p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code> and <code>SupportsQrPixelDebug</code>).</p>
+            <h3>net472 parity and guidance</h3>
+            <p class="text-muted">On <code>net472</code> and <code>netstandard2.0</code>, all encoders, payload helpers, renderers, and module-grid decoders behave the same as net8+. The main intentional gaps are QR pixel decode, QR pixel debug rendering, and Span-based overloads.</p>
+            <pre class="code-block">if (CodeGlyphXFeatures.SupportsQrPixelDecode &&
+    QrImageDecoder.TryDecodeImage(bytes, QrPixelDecodeOptions.Screen(), out var decoded))
+{
+    Console.WriteLine(decoded.Text);
+}
+else
+{
+    // net472 fallback: decode from module grids or use a net8+ worker.
+}</pre>
             <p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps that only need encoding, rendering, and module-grid decode.</p>
         </section>
 

--- a/CodeGlyphX.Website/wwwroot/docs/index.html
+++ b/CodeGlyphX.Website/wwwroot/docs/index.html
@@ -195,7 +195,7 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
             <h2>Getting Help</h2>
             <p>
                 If you encounter issues or have questions, please visit the
-                <a href="https://github.com/EvotecIT/CodeGlyphX/issues" target="_blank">GitHub Issues</a> page.
+                <a href="https://github.com/EvotecIT/CodeGlyphX/issues" target="_blank" rel="noopener">GitHub Issues</a> page.
             </p>
         </section>
 
@@ -1329,4 +1329,3 @@ if (docsOverlay && docsSidebar) {
   </script>
 </body>
 </html>
-

--- a/README.md
+++ b/README.md
@@ -71,6 +71,32 @@ Notes:
 - `QrImageDecoder.TryDecodeImage(...)` and `QrDecoder.TryDecode(...)` from pixels are net8+ only.
 - Runtime checks are available via `CodeGlyphXFeatures` (e.g., `SupportsQrPixelDecode`, `SupportsQrPixelDebug`).
 
+### net472 parity and guidance
+
+What works the same as net8+/net10+ on `net472`:
+- All encoders, payload helpers, renderers, and file codecs.
+- Module-grid decode (BitMatrix) across supported symbologies.
+- Pixel decode for 1D barcodes and 2D matrix codes other than QR.
+
+What is intentionally limited on `net472`:
+- QR pixel decode from raw pixels/images (`QrImageDecoder` / pixel-based `QrDecoder`) returns `false`.
+- QR pixel debug rendering throws `PlatformNotSupportedException`.
+- Span-based overloads are not available (use the `byte[]` overloads).
+
+Recommended pattern for shared code:
+
+```csharp
+if (CodeGlyphXFeatures.SupportsQrPixelDecode &&
+    QrImageDecoder.TryDecodeImage(bytes, QrPixelDecodeOptions.Screen(), out var decoded))
+{
+    Console.WriteLine(decoded.Text);
+}
+else
+{
+    // net472 fallback: decode from module grids or run QR pixel decode on a net8+ worker.
+}
+```
+
 Choosing a target:
 - Pick `net8.0`/`net10.0` when you need QR pixel decode from images/screenshots, pixel debug rendering, Span APIs, or maximum throughput.
 - Pick `net472`/`netstandard2.0` for legacy apps that only need encoding, rendering, and module-grid decode (QR pixel decode from images is unavailable).


### PR DESCRIPTION
This updates the docs to clearly describe what works the same on net472/netstandard2.0 vs net8+/net10+, and how to write safe fallbacks for QR pixel decode.

Changes:
- Add a net472 parity + fallback section to `README.md`
- Mirror the guidance on the docs page template
- Regenerate `CodeGlyphX.Website/wwwroot/docs/index.html`

Notes:
- No runtime behavior changes; documentation-only update.