### PR TITLE
Include art pack in quick pack-runner defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
         if: runner.os == 'Windows'
         run: dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release -f net472 --no-restore
 
+      - name: Build Tests (net472)
+        if: runner.os == 'Windows'
+        run: dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net472 --no-restore
+
+      - name: Test (net472 smoke)
+        if: runner.os == 'Windows'
+        run: dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net472 --no-restore --no-build
+
   website-build:
     name: Website Build (PR)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Restore Core
         run: dotnet restore CodeGlyphX/CodeGlyphX.csproj
 
-      - name: Restore Tests
-        run: dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
+      - name: Restore Tests (net8.0)
+        run: dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0
+
+      - name: Restore Tests (net472)
+        if: runner.os == 'Windows'
+        run: dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net472
 
       - name: Restore Examples
         run: dotnet restore CodeGlyphX.Examples/CodeGlyphX.Examples.csproj

--- a/Assets/Data/benchmark-index.json
+++ b/Assets/Data/benchmark-index.json
@@ -2,26 +2,6 @@
   "schemaVersion": 1,
   "entries": [
     {
-      "os": "linux",
-      "runMode": "quick",
-      "generatedUtc": "2026-01-22T23:04:32.829577+01:00",
-      "publish": false,
-      "framework": "net8.0",
-      "configuration": "Release",
-      "artifacts": "/mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352",
-      "meta": {
-        "commit": null,
-        "branch": null,
-        "dotnetSdk": null,
-        "runtime": null,
-        "osDescription": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
-        "osArchitecture": "x86_64",
-        "processArchitecture": "x86_64",
-        "machineName": "EVOMONSTER",
-        "processorCount": 32
-      }
-    },
-    {
       "os": "windows",
       "runMode": "Full",
       "generatedUtc": "2026-01-24T10:49:40.7910358Z",
@@ -45,7 +25,7 @@
     {
       "os": "windows",
       "runMode": "quick",
-      "generatedUtc": "2026-01-24T11:41:47.0013230Z",
+      "generatedUtc": "2026-01-24T11:41:47.001323Z",
       "publish": false,
       "framework": "net8.0",
       "configuration": "Release",
@@ -56,6 +36,27 @@
         "dotnetSdk": "10.0.102",
         "runtime": ".NET 9.0.10",
         "osDescription": "Microsoft Windows 10.0.26200",
+        "osArchitecture": "X64",
+        "processArchitecture": "X64",
+        "machineName": "EVOMONSTER",
+        "processorCount": 32
+      },
+      "runModeSource": "explicit"
+    },
+    {
+      "os": "linux",
+      "runMode": "quick",
+      "generatedUtc": "2026-01-27T14:16:09.1385475Z",
+      "publish": false,
+      "framework": "net8.0",
+      "configuration": "Release",
+      "artifacts": "/tmp/cgx-psquick-smoke/linux-20260127-151049",
+      "meta": {
+        "commit": null,
+        "branch": null,
+        "dotnetSdk": "10.0.100",
+        "runtime": ".NET 9.0.10",
+        "osDescription": "Ubuntu 24.04.3 LTS",
         "osArchitecture": "X64",
         "processArchitecture": "X64",
         "machineName": "EVOMONSTER",

--- a/Assets/Data/benchmark-summary.json
+++ b/Assets/Data/benchmark-summary.json
@@ -1,7 +1,7 @@
 {
   "windows": {
     "quick": {
-      "generatedUtc": "2026-01-24T11:41:47.0013230Z",
+      "generatedUtc": "2026-01-24T11:41:47.001323Z",
       "schemaVersion": 1,
       "os": "windows",
       "framework": "net8.0",
@@ -943,54 +943,36 @@
   },
   "linux": {
     "quick": {
-      "generatedUtc": "2026-01-22T23:04:32.829577+01:00",
+      "generatedUtc": "2026-01-27T14:16:09.1385475Z",
       "schemaVersion": 1,
       "os": "linux",
       "framework": "net8.0",
       "configuration": "Release",
       "runMode": "quick",
       "runModeDetails": "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
+      "runModeSource": "explicit",
       "publish": false,
-      "artifacts": "/mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352",
+      "artifacts": "/tmp/cgx-psquick-smoke/linux-20260127-151049",
       "meta": {
         "commit": null,
         "branch": null,
-        "dotnetSdk": null,
-        "runtime": null,
-        "osDescription": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
-        "osArchitecture": "x86_64",
-        "processArchitecture": "x86_64",
+        "dotnetSdk": "10.0.100",
+        "runtime": ".NET 9.0.10",
+        "osDescription": "Ubuntu 24.04.3 LTS",
+        "osArchitecture": "X64",
+        "processArchitecture": "X64",
         "machineName": "EVOMONSTER",
         "processorCount": 32
       },
-      "missingComparisons": [
-        "Aztec (Encode)",
-        "Code 128 (Encode)",
-        "Code 39 (Encode)",
-        "Code 93 (Encode)",
-        "Data Matrix (Encode)",
-        "EAN-13 (Encode)",
-        "PDF417 (Encode)",
-        "QR (Encode)",
-        "UPC-A (Encode)"
-      ],
-      "missingComparisonIds": [
-        "AztecCompareBenchmarks",
-        "Code128CompareBenchmarks",
-        "Code39CompareBenchmarks",
-        "Code93CompareBenchmarks",
-        "DataMatrixCompareBenchmarks",
-        "EanCompareBenchmarks",
-        "Pdf417CompareBenchmarks",
-        "QrCompareBenchmarks",
-        "UpcACompareBenchmarks"
-      ],
+      "missingComparisons": [],
+      "missingComparisonIds": [],
       "howToRead": [
         "Mean: average time per operation. Lower is better.",
         "Allocated: managed memory allocated per operation. Lower is better.",
-        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
-        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the fastest allocation for that scenario. 1 x means CodeGlyphX allocates the least; higher is more allocations.",
+        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x (fastest) means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
+        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the allocation of the fastest-time vendor for that scenario. Lower than 1 x means fewer allocations than the fastest-time vendor.",
         "Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).",
+        "Δ lines in comparison tables show vendor ratios vs CodeGlyphX (time / alloc).",
         "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
       ],
       "notes": [
@@ -1001,9 +983,516 @@
         "Barcoder uses Barcoder.Renderer.Image (ImageSharp renderer).",
         "QRCoder uses PngByteQRCode (managed PNG output, no external renderer).",
         "QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).",
-        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy)."
+        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy).",
+        "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
       ],
-      "summary": []
+      "summary": [
+        {
+          "codeGlyphXAlloc": "61.34 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Aztec (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "270.8 μs",
+          "scenario": "Aztec PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 270800.0,
+              "mean": "270.8 μs",
+              "allocated": "61.34 KB"
+            }
+          },
+          "codeGlyphXMean": "270.8 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "14.44 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 128 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "150.3 μs",
+          "scenario": "Code128 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 150300.0,
+              "mean": "150.3 μs",
+              "allocated": "14.44 KB"
+            }
+          },
+          "codeGlyphXMean": "150.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "10.02 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 39 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "128.0 μs",
+          "scenario": "Code39 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 128000.0,
+              "mean": "128.0 μs",
+              "allocated": "10.02 KB"
+            }
+          },
+          "codeGlyphXMean": "128.0 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "8.14 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 93 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "144.5 μs",
+          "scenario": "Code93 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 144500.0,
+              "mean": "144.5 μs",
+              "allocated": "8.14 KB"
+            }
+          },
+          "codeGlyphXMean": "144.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "15.53 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Data Matrix (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "200.9 μs",
+          "scenario": "Data Matrix PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 200900.0,
+              "mean": "200.9 μs",
+              "allocated": "15.53 KB"
+            }
+          },
+          "codeGlyphXMean": "200.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "6.85 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "EAN-13 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "168.9 μs",
+          "scenario": "EAN-13 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 168900.0,
+              "mean": "168.9 μs",
+              "allocated": "6.85 KB"
+            }
+          },
+          "codeGlyphXMean": "168.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "49.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "PDF417 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "907.9 μs",
+          "scenario": "PDF417 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 907900.0,
+              "mean": "907.9 μs",
+              "allocated": "49.91 KB"
+            }
+          },
+          "codeGlyphXMean": "907.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "14.27 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "614.1 μs",
+          "scenario": "QR PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 614100.0,
+              "mean": "614.1 μs",
+              "allocated": "14.27 KB"
+            }
+          },
+          "codeGlyphXMean": "614.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "3.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Clean)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "956.5 μs",
+          "scenario": "QR Decode (clean)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 956500.0,
+              "mean": "956.5 μs",
+              "allocated": "3.91 KB"
+            }
+          },
+          "codeGlyphXMean": "956.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "160.77 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Noisy)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "41.20 ms",
+          "scenario": "QR Decode (noisy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 41200000.0,
+              "mean": "41.20 ms",
+              "allocated": "160.77 KB"
+            }
+          },
+          "codeGlyphXMean": "41.20 ms",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "2.68 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "353.4 μs",
+          "scenario": "QR Decode (fancy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 353400.0,
+              "mean": "353.4 μs",
+              "allocated": "2.68 KB"
+            }
+          },
+          "codeGlyphXMean": "353.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "45.09 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "11,185.1 μs",
+          "scenario": "QR Decode (no quiet zone)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 11185100.0,
+              "mean": "11,185.1 μs",
+              "allocated": "45.09 KB"
+            }
+          },
+          "codeGlyphXMean": "11,185.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "1.88 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "557.4 μs",
+          "scenario": "QR Decode (resampled)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 557400.0,
+              "mean": "557.4 μs",
+              "allocated": "1.88 KB"
+            }
+          },
+          "codeGlyphXMean": "557.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "7.16 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "UPC-A (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "197.3 μs",
+          "scenario": "UPC-A PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 197300.0,
+              "mean": "197.3 μs",
+              "allocated": "7.16 KB"
+            }
+          },
+          "codeGlyphXMean": "197.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        }
+      ],
+      "packRunner": {
+        "reportPath": "/tmp/cgx-psquick-smoke/linux-20260127-151049/pack-runner/qr-decode-packs-quick.json",
+        "generatedUtc": "2026-01-27T14:11:19.2732196Z",
+        "mode": "quick",
+        "packs": [
+          {
+            "name": "art",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 8.0,
+                "decodeRate": 0.875,
+                "expectedRate": 0.875,
+                "medianMs": 2910.0688,
+                "p95Ms": 9471.7427,
+                "failingScenarios": [
+                  "art-jess3-grid"
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ideal",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 1446.0706,
+                "p95Ms": 1579.5812,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "multi",
+            "scenarioCount": 1,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 3.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 5683.2641,
+                "p95Ms": 5684.814,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "screenshot",
+            "scenarioCount": 3,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 9.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 4269.6355,
+                "p95Ms": 4432.9162,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "stress",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 2149.8542,
+                "p95Ms": 3327.857,
+                "failingScenarios": []
+              }
+            ]
+          }
+        ],
+        "engines": {
+          "name": "CodeGlyphX",
+          "isExternal": false,
+          "runs": 44.0,
+          "decodeRate": 0.9772727272727273,
+          "expectedRate": 0.9772727272727273,
+          "failingScenarios": "art-jess3-grid",
+          "failingPacks": "art"
+        },
+        "note": "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
+      }
     },
     "full": null
   },

--- a/Assets/Data/benchmark.json
+++ b/Assets/Data/benchmark.json
@@ -31,7 +31,7 @@
       "publish": false,
       "artifacts": "C:\\Support\\GitHub\\CodeMatrix\\Build\\BenchmarkResults\\windows-20260124-124033",
       "missingComparisonIds": [],
-      "generatedUtc": "2026-01-24T11:41:47.0013230Z",
+      "generatedUtc": "2026-01-24T11:41:47.001323Z",
       "comparisons": [
         {
           "scenarios": [
@@ -2153,56 +2153,253 @@
   },
   "linux": {
     "quick": {
-      "generatedUtc": "2026-01-22T23:04:32.829577+01:00",
-      "schemaVersion": 1,
       "os": "linux",
-      "framework": "net8.0",
-      "configuration": "Release",
-      "runMode": "quick",
-      "runModeDetails": "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
-      "publish": false,
-      "artifacts": "/mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352",
       "meta": {
         "commit": null,
         "branch": null,
-        "dotnetSdk": null,
-        "runtime": null,
-        "osDescription": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
-        "osArchitecture": "x86_64",
-        "processArchitecture": "x86_64",
+        "dotnetSdk": "10.0.100",
+        "runtime": ".NET 9.0.10",
+        "osDescription": "Ubuntu 24.04.3 LTS",
+        "osArchitecture": "X64",
+        "processArchitecture": "X64",
         "machineName": "EVOMONSTER",
         "processorCount": 32
       },
-      "missingComparisons": [
-        "Aztec (Encode)",
-        "Code 128 (Encode)",
-        "Code 39 (Encode)",
-        "Code 93 (Encode)",
-        "Data Matrix (Encode)",
-        "EAN-13 (Encode)",
-        "PDF417 (Encode)",
-        "QR (Encode)",
-        "UPC-A (Encode)"
+      "generatedUtc": "2026-01-27T14:16:09.1385475Z",
+      "baseline": [],
+      "comparisons": [
+        {
+          "title": "Aztec (Encode)",
+          "id": "AztecCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Aztec PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 270800.0,
+                  "mean": "270.8 μs",
+                  "allocated": "61.34 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Code 128 (Encode)",
+          "id": "Code128CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Code128 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 150300.0,
+                  "mean": "150.3 μs",
+                  "allocated": "14.44 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Code 39 (Encode)",
+          "id": "Code39CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Code39 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 128000.0,
+                  "mean": "128.0 μs",
+                  "allocated": "10.02 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Code 93 (Encode)",
+          "id": "Code93CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Code93 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 144500.0,
+                  "mean": "144.5 μs",
+                  "allocated": "8.14 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Data Matrix (Encode)",
+          "id": "DataMatrixCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Data Matrix PNG (medium)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 200900.0,
+                  "mean": "200.9 μs",
+                  "allocated": "15.53 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "EAN-13 (Encode)",
+          "id": "EanCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "EAN-13 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 168900.0,
+                  "mean": "168.9 μs",
+                  "allocated": "6.85 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "PDF417 (Encode)",
+          "id": "Pdf417CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "PDF417 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 907900.0,
+                  "mean": "907.9 μs",
+                  "allocated": "49.91 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR (Encode)",
+          "id": "QrCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR PNG (medium)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 614100.0,
+                  "mean": "614.1 μs",
+                  "allocated": "14.27 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR Decode (Clean)",
+          "id": "QrDecodeCleanCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR Decode (clean)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 956500.0,
+                  "mean": "956.5 μs",
+                  "allocated": "3.91 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR Decode (Noisy)",
+          "id": "QrDecodeNoisyCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR Decode (noisy)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 41200000.0,
+                  "mean": "41.20 ms",
+                  "allocated": "160.77 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR Decode (Stress)",
+          "id": "QrDecodeStressCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR Decode (fancy)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 353400.0,
+                  "mean": "353.4 μs",
+                  "allocated": "2.68 KB"
+                }
+              },
+              "ratios": {}
+            },
+            {
+              "name": "QR Decode (no quiet zone)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 11185100.0,
+                  "mean": "11,185.1 μs",
+                  "allocated": "45.09 KB"
+                }
+              },
+              "ratios": {}
+            },
+            {
+              "name": "QR Decode (resampled)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 557400.0,
+                  "mean": "557.4 μs",
+                  "allocated": "1.88 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "UPC-A (Encode)",
+          "id": "UpcACompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "UPC-A PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 197300.0,
+                  "mean": "197.3 μs",
+                  "allocated": "7.16 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        }
       ],
-      "missingComparisonIds": [
-        "AztecCompareBenchmarks",
-        "Code128CompareBenchmarks",
-        "Code39CompareBenchmarks",
-        "Code93CompareBenchmarks",
-        "DataMatrixCompareBenchmarks",
-        "EanCompareBenchmarks",
-        "Pdf417CompareBenchmarks",
-        "QrCompareBenchmarks",
-        "UpcACompareBenchmarks"
-      ],
-      "howToRead": [
-        "Mean: average time per operation. Lower is better.",
-        "Allocated: managed memory allocated per operation. Lower is better.",
-        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
-        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the fastest allocation for that scenario. 1 x means CodeGlyphX allocates the least; higher is more allocations.",
-        "Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).",
-        "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
-      ],
+      "artifacts": "/tmp/cgx-psquick-smoke/linux-20260127-151049",
+      "publish": false,
+      "runMode": "quick",
+      "missingComparisonIds": [],
+      "runModeSource": "explicit",
       "notes": [
         "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
         "Comparisons target PNG output and include encode+render (not encode-only).",
@@ -2211,87 +2408,530 @@
         "Barcoder uses Barcoder.Renderer.Image (ImageSharp renderer).",
         "QRCoder uses PngByteQRCode (managed PNG output, no external renderer).",
         "QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).",
-        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy)."
+        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy).",
+        "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
       ],
-      "summary": [],
-      "baseline": [
-        {
-          "id": "QrDecodeBenchmarks",
-          "title": "QR (Decode)",
-          "scenarios": [
-            {
-              "name": "QR Decode (clean, fast)",
-              "mean": "3,076.8 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (clean, balanced)",
-              "mean": "3,052.8 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (clean, robust)",
-              "mean": "2,435.8 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (noisy, robust)",
-              "mean": "4,481.1 μs",
-              "meanNs": null,
-              "allocated": "5.45 KB"
-            },
-            {
-              "name": "QR Decode (screenshot, balanced)",
-              "mean": "7,166.1 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (antialias, robust)",
-              "mean": "477.0 μs",
-              "meanNs": null,
-              "allocated": "1.31 KB"
-            }
-          ]
-        }
+      "howToRead": [
+        "Mean: average time per operation. Lower is better.",
+        "Allocated: managed memory allocated per operation. Lower is better.",
+        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x (fastest) means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
+        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the allocation of the fastest-time vendor for that scenario. Lower than 1 x means fewer allocations than the fastest-time vendor.",
+        "Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).",
+        "Δ lines in comparison tables show vendor ratios vs CodeGlyphX (time / alloc).",
+        "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
       ],
-      "comparisons": [
-        {
-          "id": "QrDecodeCleanCompareBenchmarks",
-          "title": "QR Decode (Clean)",
-          "scenarios": [
-            {
-              "name": "QR Decode (clean)",
-              "vendors": {
-                "CodeGlyphX": {
-                  "mean": "2.215 ms",
-                  "meanNs": null,
-                  "allocated": "5.26 KB"
-                }
+      "schemaVersion": 1,
+      "packRunner": {
+        "reportPath": "/tmp/cgx-psquick-smoke/linux-20260127-151049/pack-runner/qr-decode-packs-quick.json",
+        "generatedUtc": "2026-01-27T14:11:19.2732196Z",
+        "mode": "quick",
+        "packs": [
+          {
+            "name": "art",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 8.0,
+                "decodeRate": 0.875,
+                "expectedRate": 0.875,
+                "medianMs": 2910.0688,
+                "p95Ms": 9471.7427,
+                "failingScenarios": [
+                  "art-jess3-grid"
+                ]
               }
+            ]
+          },
+          {
+            "name": "ideal",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 1446.0706,
+                "p95Ms": 1579.5812,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "multi",
+            "scenarioCount": 1,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 3.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 5683.2641,
+                "p95Ms": 5684.814,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "screenshot",
+            "scenarioCount": 3,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 9.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 4269.6355,
+                "p95Ms": 4432.9162,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "stress",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 2149.8542,
+                "p95Ms": 3327.857,
+                "failingScenarios": []
+              }
+            ]
+          }
+        ],
+        "engines": {
+          "name": "CodeGlyphX",
+          "isExternal": false,
+          "runs": 44.0,
+          "decodeRate": 0.9772727272727273,
+          "expectedRate": 0.9772727272727273,
+          "failingScenarios": "art-jess3-grid",
+          "failingPacks": "art"
+        },
+        "note": "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
+      },
+      "summary": [
+        {
+          "codeGlyphXAlloc": "61.34 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Aztec (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "270.8 μs",
+          "scenario": "Aztec PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 270800.0,
+              "mean": "270.8 μs",
+              "allocated": "61.34 KB"
             }
-          ]
+          },
+          "codeGlyphXMean": "270.8 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
         },
         {
-          "id": "QrDecodeNoisyCompareBenchmarks",
-          "title": "QR Decode (Noisy)",
-          "scenarios": [
-            {
-              "name": "QR Decode (noisy)",
-              "vendors": {
-                "CodeGlyphX": {
-                  "mean": "4.090 ms",
-                  "meanNs": null,
-                  "allocated": "5.45 KB"
-                }
-              }
+          "codeGlyphXAlloc": "14.44 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 128 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "150.3 μs",
+          "scenario": "Code128 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 150300.0,
+              "mean": "150.3 μs",
+              "allocated": "14.44 KB"
             }
-          ]
+          },
+          "codeGlyphXMean": "150.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "10.02 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 39 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "128.0 μs",
+          "scenario": "Code39 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 128000.0,
+              "mean": "128.0 μs",
+              "allocated": "10.02 KB"
+            }
+          },
+          "codeGlyphXMean": "128.0 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "8.14 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 93 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "144.5 μs",
+          "scenario": "Code93 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 144500.0,
+              "mean": "144.5 μs",
+              "allocated": "8.14 KB"
+            }
+          },
+          "codeGlyphXMean": "144.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "15.53 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Data Matrix (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "200.9 μs",
+          "scenario": "Data Matrix PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 200900.0,
+              "mean": "200.9 μs",
+              "allocated": "15.53 KB"
+            }
+          },
+          "codeGlyphXMean": "200.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "6.85 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "EAN-13 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "168.9 μs",
+          "scenario": "EAN-13 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 168900.0,
+              "mean": "168.9 μs",
+              "allocated": "6.85 KB"
+            }
+          },
+          "codeGlyphXMean": "168.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "49.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "PDF417 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "907.9 μs",
+          "scenario": "PDF417 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 907900.0,
+              "mean": "907.9 μs",
+              "allocated": "49.91 KB"
+            }
+          },
+          "codeGlyphXMean": "907.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "14.27 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "614.1 μs",
+          "scenario": "QR PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 614100.0,
+              "mean": "614.1 μs",
+              "allocated": "14.27 KB"
+            }
+          },
+          "codeGlyphXMean": "614.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "3.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Clean)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "956.5 μs",
+          "scenario": "QR Decode (clean)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 956500.0,
+              "mean": "956.5 μs",
+              "allocated": "3.91 KB"
+            }
+          },
+          "codeGlyphXMean": "956.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "160.77 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Noisy)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "41.20 ms",
+          "scenario": "QR Decode (noisy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 41200000.0,
+              "mean": "41.20 ms",
+              "allocated": "160.77 KB"
+            }
+          },
+          "codeGlyphXMean": "41.20 ms",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "2.68 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "353.4 μs",
+          "scenario": "QR Decode (fancy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 353400.0,
+              "mean": "353.4 μs",
+              "allocated": "2.68 KB"
+            }
+          },
+          "codeGlyphXMean": "353.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "45.09 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "11,185.1 μs",
+          "scenario": "QR Decode (no quiet zone)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 11185100.0,
+              "mean": "11,185.1 μs",
+              "allocated": "45.09 KB"
+            }
+          },
+          "codeGlyphXMean": "11,185.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "1.88 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "557.4 μs",
+          "scenario": "QR Decode (resampled)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 557400.0,
+              "mean": "557.4 μs",
+              "allocated": "1.88 KB"
+            }
+          },
+          "codeGlyphXMean": "557.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "7.16 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "UPC-A (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "197.3 μs",
+          "scenario": "UPC-A PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 197300.0,
+              "mean": "197.3 μs",
+              "allocated": "7.16 KB"
+            }
+          },
+          "codeGlyphXMean": "197.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
         }
-      ]
+      ],
+      "runModeDetails": "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
+      "configuration": "Release",
+      "missingComparisons": [],
+      "framework": "net8.0"
     },
     "full": null
   },

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -359,21 +359,27 @@ Artifacts: Build/BenchmarkResults/windows-20260124-091830
 <!-- BENCHMARK:WINDOWS:FULL:END -->
 
 <!-- BENCHMARK:LINUX:QUICK:START -->
-## LINUX
+## LINUX (Quick)
 
-Updated: 2026-01-22 22:04:32 UTC
+Updated: 2026-01-27 14:16:09 UTC
 Framework: net8.0
 Configuration: Release
-Artifacts: /mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352
-How to read:
+Artifacts: /tmp/cgx-psquick-smoke/linux-20260127-151049
+### How to read
 - Mean: average time per operation. Lower is better.
 - Allocated: managed memory allocated per operation. Lower is better.
-- CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x means CodeGlyphX is fastest; 1.5 x means ~50% slower.
-- CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the fastest allocation for that scenario. 1 x means CodeGlyphX allocates the least; higher is more allocations.
+- CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. If CodeGlyphX is fastest, the text shows the lead vs the runner-up; otherwise it shows the lag vs the fastest vendor.
+- CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the allocation of the fastest-time vendor for that scenario. Lower than 1 x means fewer allocations than the fastest-time vendor.
 - Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).
+- Δ lines in comparison tables show vendor ratios vs CodeGlyphX (time / alloc).
 - Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing.
-Notes:
+- Quick and Full runs include the same scenario list; only the iteration settings differ.
+- Benchmarks run under controlled, ideal conditions on a single machine; treat results as directional, not definitive.
+
+### Notes
 - Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).
+- QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)
+- Quick runs include the same scenario set as Full runs; run time is driven by iteration counts.
 - Comparisons target PNG output and include encode+render (not encode-only).
 - Module size and quiet zone are matched to CodeGlyphX defaults where possible; image size is derived from CodeGlyphX modules.
 - ZXing.Net uses ZXing.Net.Bindings.ImageSharp.V3 (ImageSharp 3.x renderer).
@@ -381,35 +387,101 @@ Notes:
 - QRCoder uses PngByteQRCode (managed PNG output, no external renderer).
 - QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).
 - QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy).
-Warnings:
-- Missing compare results: Aztec (Encode), Code 128 (Encode), Code 39 (Encode), Code 93 (Encode), Data Matrix (Encode), EAN-13 (Encode), PDF417 (Encode), QR (Encode), UPC-A (Encode).
 
-### Baseline
+### Summary (Comparisons) - Quick
 
-#### QR (Decode)
-
-| Scenario | Mean | Allocated |
-| --- | --- | --- |
-| QR Decode (clean, fast) | 3,076.8 μs | 5.26 KB |
-| QR Decode (clean, balanced) | 3,052.8 μs | 5.26 KB |
-| QR Decode (clean, robust) | 2,435.8 μs | 5.26 KB |
-| QR Decode (noisy, robust) | 4,481.1 μs | 5.45 KB |
-| QR Decode (screenshot, balanced) | 7,166.1 μs | 5.26 KB |
-| QR Decode (antialias, robust) | 477.0 μs | 1.31 KB |
+| Benchmark | Scenario | Fastest | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) | CodeGlyphX vs Fastest | CodeGlyphX Alloc vs Fastest | Rating |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Aztec (Encode) | Aztec PNG | CodeGlyphX 270.8 μs | 270.8 μs<br>61.34 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| Code 128 (Encode) | Code128 PNG | CodeGlyphX 150.3 μs | 150.3 μs<br>14.44 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| Code 39 (Encode) | Code39 PNG | CodeGlyphX 128.0 μs | 128.0 μs<br>10.02 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| Code 93 (Encode) | Code93 PNG | CodeGlyphX 144.5 μs | 144.5 μs<br>8.14 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| Data Matrix (Encode) | Data Matrix PNG (medium) | CodeGlyphX 200.9 μs | 200.9 μs<br>15.53 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| EAN-13 (Encode) | EAN-13 PNG | CodeGlyphX 168.9 μs | 168.9 μs<br>6.85 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| PDF417 (Encode) | PDF417 PNG | CodeGlyphX 907.9 μs | 907.9 μs<br>49.91 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| QR (Encode) | QR PNG (medium) | CodeGlyphX 614.1 μs | 614.1 μs<br>14.27 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| QR Decode (Clean) | QR Decode (clean) | CodeGlyphX 956.5 μs | 956.5 μs<br>3.91 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| QR Decode (Noisy) | QR Decode (noisy) | CodeGlyphX 41.20 ms | 41.20 ms<br>160.77 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| QR Decode (Stress) | QR Decode (fancy) | CodeGlyphX 353.4 μs | 353.4 μs<br>2.68 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| QR Decode (Stress) | QR Decode (no quiet zone) | CodeGlyphX 11,185.1 μs | 11,185.1 μs<br>45.09 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| QR Decode (Stress) | QR Decode (resampled) | CodeGlyphX 557.4 μs | 557.4 μs<br>1.88 KB |  |  |  | 1 x (fastest) | 1 x | good |
+| UPC-A (Encode) | UPC-A PNG | CodeGlyphX 197.3 μs | 197.3 μs<br>7.16 KB |  |  |  | 1 x (fastest) | 1 x | good |
 
 ### Comparisons
+
+#### Aztec (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| Aztec PNG | 270.8 μs<br>61.34 KB |  |  |  |
+
+#### Code 128 (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| Code128 PNG | 150.3 μs<br>14.44 KB |  |  |  |
+
+#### Code 39 (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| Code39 PNG | 128.0 μs<br>10.02 KB |  |  |  |
+
+#### Code 93 (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| Code93 PNG | 144.5 μs<br>8.14 KB |  |  |  |
+
+#### Data Matrix (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| Data Matrix PNG (medium) | 200.9 μs<br>15.53 KB |  |  |  |
+
+#### EAN-13 (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| EAN-13 PNG | 168.9 μs<br>6.85 KB |  |  |  |
+
+#### PDF417 (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| PDF417 PNG | 907.9 μs<br>49.91 KB |  |  |  |
+
+#### QR (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| QR PNG (medium) | 614.1 μs<br>14.27 KB |  |  |  |
 
 #### QR Decode (Clean)
 
 | Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
 | --- | --- | --- | --- | --- |
-| QR Decode (clean) | 2.215 ms<br>5.26 KB |  |  |  |
+| QR Decode (clean) | 956.5 μs<br>3.91 KB |  |  |  |
 
 #### QR Decode (Noisy)
 
 | Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
 | --- | --- | --- | --- | --- |
-| QR Decode (noisy) | 4.090 ms<br>5.45 KB |  |  |  |
+| QR Decode (noisy) | 41.20 ms<br>160.77 KB |  |  |  |
+
+#### QR Decode (Stress)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| QR Decode (fancy) | 353.4 μs<br>2.68 KB |  |  |  |
+| QR Decode (no quiet zone) | 11,185.1 μs<br>45.09 KB |  |  |  |
+| QR Decode (resampled) | 557.4 μs<br>1.88 KB |  |  |  |
+
+#### UPC-A (Encode)
+
+| Scenario | CodeGlyphX (Mean / Alloc) | ZXing.Net (Mean / Alloc) | QRCoder (Mean / Alloc) | Barcoder (Mean / Alloc) |
+| --- | --- | --- | --- | --- |
+| UPC-A PNG | 197.3 μs<br>7.16 KB |  |  |  |
 <!-- BENCHMARK:LINUX:QUICK:END -->
 
 <!-- BENCHMARK:LINUX:FULL:START -->

--- a/Build/Generate-BenchmarkReport.ps1
+++ b/Build/Generate-BenchmarkReport.ps1
@@ -384,14 +384,34 @@ function Get-PackRunnerPayload([string]$artifactsPath, [string]$runMode) {
             $decodeRate = $acc.decodeWeighted / $runs
             $expectedRate = $acc.expectedWeighted / $runs
         }
+        $failingScenariosSet = $acc.failingScenarios
+        if ($failingScenariosSet -isnot [System.Collections.Generic.HashSet[string]]) {
+            $failingScenariosSet = New-Object "System.Collections.Generic.HashSet[string]"
+            foreach ($fs in @($acc.failingScenarios)) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$fs)) {
+                    [void]$failingScenariosSet.Add([string]$fs)
+                }
+            }
+        }
+        $failingPacksSet = $acc.failingPacks
+        if ($failingPacksSet -isnot [System.Collections.Generic.HashSet[string]]) {
+            $failingPacksSet = New-Object "System.Collections.Generic.HashSet[string]"
+            foreach ($fp in @($acc.failingPacks)) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$fp)) {
+                    [void]$failingPacksSet.Add([string]$fp)
+                }
+            }
+        }
+        $failingScenariosArr = @($failingScenariosSet)
+        $failingPacksArr = @($failingPacksSet)
         $engineSummariesAcc += [pscustomobject]@{
             name = $acc.name
             isExternal = $acc.isExternal
             runs = $runs
             decodeRate = $decodeRate
             expectedRate = $expectedRate
-            failingScenarios = ($acc.failingScenarios.ToArray() | Sort-Object)
-            failingPacks = ($acc.failingPacks.ToArray() | Sort-Object)
+            failingScenarios = ($failingScenariosArr | Sort-Object)
+            failingPacks = ($failingPacksArr | Sort-Object)
         }
     }
 

--- a/Build/Net472-SmokeTest.md
+++ b/Build/Net472-SmokeTest.md
@@ -1,0 +1,76 @@
+# net472 QR Decode Smoke Test (Windows)
+
+Goal: quickly confirm the legacy QR image fallback is healthy without committing large images.
+
+## 1) Build the net472 target
+
+From the repo root:
+
+```powershell
+dotnet build .\CodeGlyphX\CodeGlyphX.csproj -c Release -f net472
+```
+
+## 2) Sanity-check the fallback via tests (fast)
+
+These run on net8 but force the fallback path:
+
+```powershell
+dotnet test .\CodeGlyphX.Tests\CodeGlyphX.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~QrImageDecoderFallbackTests"
+```
+
+## 3) Local round-trip console check on net472
+
+Create a temporary console:
+
+```powershell
+mkdir .\artifacts\net472-smoke -Force | Out-Null
+cd .\artifacts\net472-smoke
+dotnet new console -f net472
+dotnet add reference ..\..\CodeGlyphX\CodeGlyphX.csproj
+```
+
+Replace `Program.cs` with:
+
+```csharp
+using System;
+using CodeGlyphX;
+using CodeGlyphX.Rendering.Png;
+
+var payload = $"NET472-SMOKE-{DateTime.UtcNow:yyyyMMddHHmmss}";
+var qr = QrCodeEncoder.EncodeText(payload);
+
+var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+    ModuleSize = 16,
+    QuietZone = 6
+});
+
+var ok = QrImageDecoder.TryDecodeImage(png, out var decoded, out var info, new QrPixelDecodeOptions {
+    MaxDimension = 2048
+});
+
+Console.WriteLine($"OK: {ok}");
+Console.WriteLine(decoded?.Text);
+Console.WriteLine($"Dimension: {info.Dimension}, Threshold: {info.Threshold}");
+Environment.ExitCode = ok && decoded.Text == payload ? 0 : 1;
+```
+
+Run it:
+
+```powershell
+dotnet run -c Release
+```
+
+## 4) Real-world screenshot spot-checks (optional but recommended)
+
+Add a few local images (not committed), then try:
+
+```csharp
+var bytes = System.IO.File.ReadAllBytes(@"C:\path\to\sample.png");
+if (QrImageDecoder.TryDecodeImage(bytes, out var decoded)) {
+    Console.WriteLine(decoded.Text);
+}
+```
+
+Notes:
+- Expect best results on clean/generated images.
+- Multi-code and heavily stylized/artistic inputs remain best-effort on net472.

--- a/Build/Run-Benchmarks-Compare.ps1
+++ b/Build/Run-Benchmarks-Compare.ps1
@@ -44,6 +44,12 @@ if ($benchQuick) {
     $quickProps += "/p:BenchQuick=true"
 }
 
+# Keep the default quick run focused on compare suites so it stays fast.
+$baseFilterBound = $PSBoundParameters.ContainsKey("BaseFilter")
+if ($benchQuick -and -not $baseFilterBound) {
+    $BaseFilter = "*CompareBenchmarks*"
+}
+
 $expectedCompare = @(
     "QrCompareBenchmarks",
     "QrDecodeCleanCompareBenchmarks",

--- a/Build/run-benchmarks-compare.sh
+++ b/Build/run-benchmarks-compare.sh
@@ -11,6 +11,8 @@ COMPARE_QRCODER=0
 COMPARE_BARCODER=0
 BASE_FILTER="*"
 COMPARE_FILTER="*Compare*"
+BASE_FILTER_SET=0
+COMPARE_FILTER_SET=0
 BENCH_QUICK=1
 ALLOW_PARTIAL=0
 SKIP_PREFLIGHT=0
@@ -48,8 +50,8 @@ while [[ $# -gt 0 ]]; do
     --compare-zxing) COMPARE_ZXING=1; shift ;;
     --compare-qrcoder) COMPARE_QRCODER=1; shift ;;
     --compare-barcoder) COMPARE_BARCODER=1; shift ;;
-    --base-filter) BASE_FILTER="$2"; shift 2 ;;
-    --compare-filter) COMPARE_FILTER="$2"; shift 2 ;;
+    --base-filter) BASE_FILTER="$2"; BASE_FILTER_SET=1; shift 2 ;;
+    --compare-filter) COMPARE_FILTER="$2"; COMPARE_FILTER_SET=1; shift 2 ;;
     --full) BENCH_QUICK=0; shift ;;
     --allow-partial) ALLOW_PARTIAL=1; shift ;;
     --skip-preflight) SKIP_PREFLIGHT=1; shift ;;
@@ -57,6 +59,11 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
 done
+
+# Keep the default quick run focused on compare suites so it stays fast.
+if [[ $BENCH_QUICK -eq 1 && $BASE_FILTER_SET -eq 0 ]]; then
+  BASE_FILTER="*CompareBenchmarks*"
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_PATH="$SCRIPT_DIR/../CodeGlyphX.Benchmarks/CodeGlyphX.Benchmarks.csproj"

--- a/CodeGlyphX.Benchmarks/Compare/QrDecodeStressCompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/QrDecodeStressCompareBenchmarks.cs
@@ -20,12 +20,16 @@ namespace CodeGlyphX.Benchmarks;
 public class QrDecodeStressCompareBenchmarks
 {
     private const string SampleText = "https://github.com/EvotecIT/CodeGlyphX";
+#if !BENCH_QUICK
     private byte[] _logoRgba = Array.Empty<byte>();
+#endif
     private byte[] _fancyRgba = Array.Empty<byte>();
     private byte[] _resampledRgba = Array.Empty<byte>();
     private byte[] _noQuietRgba = Array.Empty<byte>();
+#if !BENCH_QUICK
     private int _logoWidth;
     private int _logoHeight;
+#endif
     private int _fancyWidth;
     private int _fancyHeight;
     private int _resampledWidth;
@@ -55,12 +59,15 @@ public class QrDecodeStressCompareBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+#if !BENCH_QUICK
         BuildLogoSample(out _logoRgba, out _logoWidth, out _logoHeight);
+#endif
         BuildFancySample(out _fancyRgba, out _fancyWidth, out _fancyHeight);
         BuildResampledSample(out _resampledRgba, out _resampledWidth, out _resampledHeight);
         BuildNoQuietSample(out _noQuietRgba, out _noQuietWidth, out _noQuietHeight);
     }
 
+#if !BENCH_QUICK
     [Benchmark(Baseline = true, Description = "CodeGlyphX QR Decode (logo)")]
     public bool CodeGlyphX_DecodeLogoRobust()
     {
@@ -73,6 +80,7 @@ public class QrDecodeStressCompareBenchmarks
     {
         return _zxingReader.Decode(_logoRgba, _logoWidth, _logoHeight, RGBLuminanceSource.BitmapFormat.RGBA32) is not null;
     }
+#endif
 #endif
 
     [Benchmark(Description = "CodeGlyphX QR Decode (fancy)")]
@@ -117,6 +125,7 @@ public class QrDecodeStressCompareBenchmarks
     }
 #endif
 
+#if !BENCH_QUICK
     private static void BuildLogoSample(out byte[] rgba, out int width, out int height)
     {
         var logo = LogoBuilder.CreateCirclePng(
@@ -129,6 +138,7 @@ public class QrDecodeStressCompareBenchmarks
         var png = QrEasy.RenderPng(SampleText, options);
         DecodePng(png, out rgba, out width, out height);
     }
+#endif
 
     private static void BuildFancySample(out byte[] rgba, out int width, out int height)
     {

--- a/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
@@ -28,12 +28,16 @@ public class QrDecodeBenchmarks
     private int _screenshotHeight;
     private int _antialiasWidth;
     private int _antialiasHeight;
+#if !BENCH_QUICK
     private byte[] _logoRgba = Array.Empty<byte>();
+#endif
     private byte[] _fancyRgba = Array.Empty<byte>();
     private byte[] _resampledRgba = Array.Empty<byte>();
     private byte[] _noQuietRgba = Array.Empty<byte>();
+#if !BENCH_QUICK
     private int _logoWidth;
     private int _logoHeight;
+#endif
     private int _fancyWidth;
     private int _fancyHeight;
     private int _resampledWidth;
@@ -60,7 +64,9 @@ public class QrDecodeBenchmarks
         LoadRgba("Assets/DecodingSamples/qr-noisy-ui.png", out _noisyRgba, out _noisyWidth, out _noisyHeight);
         LoadRgba("Assets/DecodingSamples/qr-screenshot-1.png", out _screenshotRgba, out _screenshotWidth, out _screenshotHeight);
         LoadRgba("Assets/DecodingSamples/qr-dot-aa.png", out _antialiasRgba, out _antialiasWidth, out _antialiasHeight);
+#if !BENCH_QUICK
         BuildLogoSample(out _logoRgba, out _logoWidth, out _logoHeight);
+#endif
         BuildFancySample(out _fancyRgba, out _fancyWidth, out _fancyHeight);
         BuildResampledSample(out _resampledRgba, out _resampledWidth, out _resampledHeight);
         BuildNoQuietSample(out _noQuietRgba, out _noQuietWidth, out _noQuietHeight);
@@ -102,11 +108,13 @@ public class QrDecodeBenchmarks
         return QrDecoder.TryDecode(_antialiasRgba, _antialiasWidth, _antialiasHeight, _antialiasWidth * 4, PixelFormat.Rgba32, out _, _robust);
     }
 
+#if !BENCH_QUICK
     [Benchmark(Description = "QR Decode (logo, robust)")]
     public bool DecodeLogoRobust()
     {
         return QrDecoder.TryDecode(_logoRgba, _logoWidth, _logoHeight, _logoWidth * 4, PixelFormat.Rgba32, out _, _robust);
     }
+#endif
 
     [Benchmark(Description = "QR Decode (fancy, robust)")]
     public bool DecodeFancyRobust()
@@ -135,6 +143,7 @@ public class QrDecodeBenchmarks
         }
     }
 
+#if !BENCH_QUICK
     private static void BuildLogoSample(out byte[] rgba, out int width, out int height)
     {
         var logo = LogoBuilder.CreateCirclePng(
@@ -147,6 +156,7 @@ public class QrDecodeBenchmarks
         var png = QrEasy.RenderPng(SampleText, options);
         DecodePng(png, out rgba, out width, out height);
     }
+#endif
 
     private static void BuildFancySample(out byte[] rgba, out int width, out int height)
     {

--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -35,7 +35,8 @@ internal static class QrDecodePackRunner {
         QrDecodeScenarioPacks.Ideal,
         QrDecodeScenarioPacks.Stress,
         QrDecodeScenarioPacks.Screenshot,
-        QrDecodeScenarioPacks.Multi
+        QrDecodeScenarioPacks.Multi,
+        QrDecodeScenarioPacks.Art
     };
 
     public static bool TryParseArgs(string[] args, out QrDecodePackRunnerOptions options, out string[] remainingArgs) {

--- a/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
+++ b/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
@@ -5,6 +5,11 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\CodeGlyphX\CodeGlyphX.csproj" />
   </ItemGroup>
@@ -15,6 +20,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Compile Include="Net472\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
+++ b/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
@@ -1,11 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\CodeGlyphX\CodeGlyphX.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <Compile Include="**\*.cs" Exclude="bin\**;obj\**;Net472\**" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Include="Net472\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -107,6 +107,33 @@ public sealed class QrNet472SmokeTests {
         Assert.Equal(Payload, decoded.Text);
     }
 
+    [Fact]
+    public void Net472_QrImageDecoder_DecodeImageResult_Succeeds() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 22,
+            QuietZone = 8
+        });
+
+        var imageOptions = ImageDecodeOptions.Screen(maxMilliseconds: 700, maxDimension: 1200);
+        var result = QrImageDecoder.DecodeImageResult(png, imageOptions, new QrPixelDecodeOptions {
+            MaxDimension = 2500
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(DecodeFailureReason.None, result.Failure);
+        Assert.Equal(Payload, result.Value?.Text);
+    }
+
+    [Fact]
+    public void Net472_QrImageDecoder_DecodeImageResult_UnsupportedFormat() {
+        var bad = new byte[] { 1, 2, 3, 4, 5 };
+        var result = QrImageDecoder.DecodeImageResult(bad);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DecodeFailureReason.UnsupportedFormat, result.Failure);
+    }
+
     private static void AddLightNoise(byte[] rgba, int width, int height, int stride) {
         var rng = new Random(12345);
         for (var y = 0; y < height; y++) {

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -192,6 +192,21 @@ public sealed class QrNet472SmokeTests {
     }
 
     [Fact]
+    public void Net472_QrImageDecoder_DisableTransforms_Fails_On_Rotation() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var pixels = QrPngRenderer.RenderPixels(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 10,
+            QuietZone = 6
+        }, out var width, out var height, out var stride);
+
+        var rotated = Rotate90(pixels, width, height, stride, out var rw, out var rh, out var rstride);
+        var ok = QrImageDecoder.TryDecode(rotated, rw, rh, rstride, PixelFormat.Rgba32, new QrPixelDecodeOptions {
+            DisableTransforms = true
+        }, out _);
+        Assert.False(ok);
+    }
+
+    [Fact]
     public void Net472_QrImageDecoder_Decodes_Mirrored_Pixels() {
         var qr = QrCodeEncoder.EncodeText(Payload);
         var pixels = QrPngRenderer.RenderPixels(qr.Modules, new QrPngRenderOptions {

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -143,6 +143,25 @@ public sealed class QrNet472SmokeTests {
         Assert.Equal("net472", CodeGlyphXFeatures.TargetFramework);
     }
 
+    [Fact]
+    public void Net472_QrImageDecoder_TileScan_Succeeds_On_Single() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 14,
+            QuietZone = 6
+        });
+
+        var opts = new QrPixelDecodeOptions {
+            EnableTileScan = true,
+            TileGrid = 2,
+            MaxDimension = 1200
+        };
+
+        var ok = QrImageDecoder.TryDecodeAllImage(png, imageOptions: null, opts, out var decoded);
+        Assert.True(ok);
+        Assert.Contains(decoded, d => d.Text == Payload);
+    }
+
     private static void AddLightNoise(byte[] rgba, int width, int height, int stride) {
         var rng = new Random(12345);
         for (var y = 0; y < height; y++) {
@@ -172,4 +191,5 @@ public sealed class QrNet472SmokeTests {
         }
         return PngWriter.WriteRgba8(width, height, scanlines, scanlines.Length);
     }
+
 }

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -134,6 +134,15 @@ public sealed class QrNet472SmokeTests {
         Assert.Equal(DecodeFailureReason.UnsupportedFormat, result.Failure);
     }
 
+    [Fact]
+    public void Net472_FeatureFlags_ReportFallback() {
+        Assert.False(CodeGlyphXFeatures.SupportsQrPixelDecode);
+        Assert.True(CodeGlyphXFeatures.SupportsQrPixelDecodeFallback);
+        Assert.False(CodeGlyphXFeatures.SupportsQrPixelDebug);
+        Assert.False(CodeGlyphXFeatures.SupportsSpanPixelPipeline);
+        Assert.Equal("net472", CodeGlyphXFeatures.TargetFramework);
+    }
+
     private static void AddLightNoise(byte[] rgba, int width, int height, int stride) {
         var rng = new Random(12345);
         for (var y = 0; y < height; y++) {

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -1,0 +1,45 @@
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Png;
+using Xunit;
+
+namespace CodeGlyphX.Tests.Net472;
+
+// Keep this suite small and net472-safe: it should run fast on Windows CI.
+public sealed class QrNet472SmokeTests {
+    private const string Payload = "NET472-CI-SMOKE";
+
+    [Fact]
+    public void Net472_QrImageDecoder_Decodes_RenderedPng() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 14,
+            QuietZone = 6
+        });
+
+        var ok = QrImageDecoder.TryDecodeImage(png, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+
+    [Fact]
+    public void Net472_QrImageDecoder_Decodes_RenderedJpeg() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var jpg = QrJpegRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 14,
+            QuietZone = 6
+        }, quality: 100);
+
+        var ok = QrImageDecoder.TryDecodeImage(jpg, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+
+    [Fact]
+    public void Net472_QrDecoder_Decodes_Modules() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var ok = QrDecoder.TryDecode(qr.Modules, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+}
+

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -162,6 +162,21 @@ public sealed class QrNet472SmokeTests {
         Assert.Contains(decoded, d => d.Text == Payload);
     }
 
+    [Fact]
+    public void Net472_QrImageDecoder_Decodes_Inverted_Colors() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 12,
+            QuietZone = 6,
+            Foreground = new CodeGlyphX.Rendering.Png.Rgba32(255, 255, 255, 255),
+            Background = new CodeGlyphX.Rendering.Png.Rgba32(0, 0, 0, 255)
+        });
+
+        var ok = QrImageDecoder.TryDecodeImage(png, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+
     private static void AddLightNoise(byte[] rgba, int width, int height, int stride) {
         var rng = new Random(12345);
         for (var y = 0; y < height; y++) {

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -41,5 +41,33 @@ public sealed class QrNet472SmokeTests {
         Assert.True(ok);
         Assert.Equal(Payload, decoded.Text);
     }
-}
 
+    [Fact]
+    public void Net472_QrImageDecoder_ImageOptions_ByteArray_Overload_Works() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 24,
+            QuietZone = 8
+        });
+
+        var imageOptions = ImageDecodeOptions.Screen(maxMilliseconds: 600, maxDimension: 900);
+        var ok = QrImageDecoder.TryDecodeImage(png, imageOptions, options: null, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+
+    [Fact]
+    public void Net472_QrImageDecoder_ImageOptions_Stream_Overload_Works() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 20,
+            QuietZone = 6
+        });
+
+        using var stream = new System.IO.MemoryStream(png);
+        var imageOptions = ImageDecodeOptions.Screen(maxMilliseconds: 600, maxDimension: 1000);
+        var ok = QrImageDecoder.TryDecodeImage(stream, imageOptions, options: null, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+}

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
 using Xunit;
@@ -69,5 +70,70 @@ public sealed class QrNet472SmokeTests {
         var ok = QrImageDecoder.TryDecodeImage(stream, imageOptions, options: null, out var decoded);
         Assert.True(ok);
         Assert.Equal(Payload, decoded.Text);
+    }
+
+    [Fact]
+    public void Net472_QrImageDecoder_Downscale_Still_Decodes() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var opts = new QrPngRenderOptions {
+            ModuleSize = 64,
+            QuietZone = 12
+        };
+        var png = QrPngRenderer.Render(qr.Modules, opts);
+
+        // Force a heavy downscale via ImageDecodeOptions.
+        var imageOptions = ImageDecodeOptions.Screen(maxMilliseconds: 800, maxDimension: 700);
+        var ok = QrImageDecoder.TryDecodeImage(png, imageOptions, options: new QrPixelDecodeOptions {
+            MaxDimension = 4000
+        }, out var decoded);
+
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+
+    [Fact]
+    public void Net472_QrImageDecoder_LightNoise_RoundTrip_Works() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var pixels = QrPngRenderer.RenderPixels(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 18,
+            QuietZone = 6
+        }, out var width, out var height, out var stride);
+
+        AddLightNoise(pixels, width, height, stride);
+        var png = EncodePng(pixels, width, height, stride);
+
+        var ok = QrImageDecoder.TryDecodeImage(png, out var decoded);
+        Assert.True(ok);
+        Assert.Equal(Payload, decoded.Text);
+    }
+
+    private static void AddLightNoise(byte[] rgba, int width, int height, int stride) {
+        var rng = new Random(12345);
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                if (rng.NextDouble() > 0.02) continue; // 2% pixels
+                var i = row + (x * 4);
+                for (var c = 0; c < 3; c++) {
+                    var delta = rng.Next(-16, 17);
+                    var value = rgba[i + c] + delta;
+                    if (value < 0) value = 0;
+                    if (value > 255) value = 255;
+                    rgba[i + c] = (byte)value;
+                }
+                rgba[i + 3] = 255;
+            }
+        }
+    }
+
+    private static byte[] EncodePng(byte[] rgba, int width, int height, int stride) {
+        var rowLength = stride + 1;
+        var scanlines = new byte[height * rowLength];
+        for (var y = 0; y < height; y++) {
+            var rowStart = y * rowLength;
+            scanlines[rowStart] = 0;
+            Buffer.BlockCopy(rgba, y * stride, scanlines, rowStart + 1, stride);
+        }
+        return PngWriter.WriteRgba8(width, height, scanlines, scanlines.Length);
     }
 }

--- a/CodeGlyphX.Tests/QrImageDecoderFallbackTests.cs
+++ b/CodeGlyphX.Tests/QrImageDecoderFallbackTests.cs
@@ -1,0 +1,62 @@
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Png;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class QrImageDecoderFallbackTests {
+    private const string Payload = "LEGACY-FALLBACK-ROUNDTRIP";
+
+    [Fact]
+    public void Fallback_Decodes_Large_Png_Render() {
+        var png = RenderPng(moduleSize: 18, quietZone: 6);
+        WithForcedFallback(() => {
+            var ok = QrImageDecoder.TryDecodeImage(png, out var decoded, out var info, new QrPixelDecodeOptions {
+                MaxDimension = 2048
+            });
+            Assert.True(ok);
+            Assert.Equal(Payload, decoded.Text);
+            Assert.True(info.Dimension >= 21);
+        });
+    }
+
+    [Fact]
+    public void Fallback_Decodes_Large_Jpeg_Render() {
+        var jpg = RenderJpeg(moduleSize: 18, quietZone: 6, quality: 100);
+        WithForcedFallback(() => {
+            var ok = QrImageDecoder.TryDecodeImage(jpg, out var decoded, out var info, new QrPixelDecodeOptions {
+                MaxDimension = 2048
+            });
+            Assert.True(ok);
+            Assert.Equal(Payload, decoded.Text);
+            Assert.True(info.Dimension >= 21);
+        });
+    }
+
+    private static byte[] RenderPng(int moduleSize, int quietZone) {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        return QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone
+        });
+    }
+
+    private static byte[] RenderJpeg(int moduleSize, int quietZone, int quality) {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        return QrJpegRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone
+        }, quality);
+    }
+
+    private static void WithForcedFallback(System.Action action) {
+        var previous = CodeGlyphXFeatures.ForceQrFallbackForTests;
+        CodeGlyphXFeatures.ForceQrFallbackForTests = true;
+        try {
+            action();
+        } finally {
+            CodeGlyphXFeatures.ForceQrFallbackForTests = previous;
+        }
+    }
+}
+

--- a/CodeGlyphX.Website/wwwroot/data/benchmark-index.json
+++ b/CodeGlyphX.Website/wwwroot/data/benchmark-index.json
@@ -2,26 +2,6 @@
   "schemaVersion": 1,
   "entries": [
     {
-      "os": "linux",
-      "runMode": "quick",
-      "generatedUtc": "2026-01-22T23:04:32.829577+01:00",
-      "publish": false,
-      "framework": "net8.0",
-      "configuration": "Release",
-      "artifacts": "/mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352",
-      "meta": {
-        "commit": null,
-        "branch": null,
-        "dotnetSdk": null,
-        "runtime": null,
-        "osDescription": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
-        "osArchitecture": "x86_64",
-        "processArchitecture": "x86_64",
-        "machineName": "EVOMONSTER",
-        "processorCount": 32
-      }
-    },
-    {
       "os": "windows",
       "runMode": "Full",
       "generatedUtc": "2026-01-24T10:49:40.7910358Z",
@@ -45,7 +25,7 @@
     {
       "os": "windows",
       "runMode": "quick",
-      "generatedUtc": "2026-01-24T11:41:47.0013230Z",
+      "generatedUtc": "2026-01-24T11:41:47.001323Z",
       "publish": false,
       "framework": "net8.0",
       "configuration": "Release",
@@ -56,6 +36,27 @@
         "dotnetSdk": "10.0.102",
         "runtime": ".NET 9.0.10",
         "osDescription": "Microsoft Windows 10.0.26200",
+        "osArchitecture": "X64",
+        "processArchitecture": "X64",
+        "machineName": "EVOMONSTER",
+        "processorCount": 32
+      },
+      "runModeSource": "explicit"
+    },
+    {
+      "os": "linux",
+      "runMode": "quick",
+      "generatedUtc": "2026-01-27T14:16:09.1385475Z",
+      "publish": false,
+      "framework": "net8.0",
+      "configuration": "Release",
+      "artifacts": "/tmp/cgx-psquick-smoke/linux-20260127-151049",
+      "meta": {
+        "commit": null,
+        "branch": null,
+        "dotnetSdk": "10.0.100",
+        "runtime": ".NET 9.0.10",
+        "osDescription": "Ubuntu 24.04.3 LTS",
         "osArchitecture": "X64",
         "processArchitecture": "X64",
         "machineName": "EVOMONSTER",

--- a/CodeGlyphX.Website/wwwroot/data/benchmark-summary.json
+++ b/CodeGlyphX.Website/wwwroot/data/benchmark-summary.json
@@ -1,7 +1,7 @@
 {
   "windows": {
     "quick": {
-      "generatedUtc": "2026-01-24T11:41:47.0013230Z",
+      "generatedUtc": "2026-01-24T11:41:47.001323Z",
       "schemaVersion": 1,
       "os": "windows",
       "framework": "net8.0",
@@ -943,54 +943,36 @@
   },
   "linux": {
     "quick": {
-      "generatedUtc": "2026-01-22T23:04:32.829577+01:00",
+      "generatedUtc": "2026-01-27T14:16:09.1385475Z",
       "schemaVersion": 1,
       "os": "linux",
       "framework": "net8.0",
       "configuration": "Release",
       "runMode": "quick",
       "runModeDetails": "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
+      "runModeSource": "explicit",
       "publish": false,
-      "artifacts": "/mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352",
+      "artifacts": "/tmp/cgx-psquick-smoke/linux-20260127-151049",
       "meta": {
         "commit": null,
         "branch": null,
-        "dotnetSdk": null,
-        "runtime": null,
-        "osDescription": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
-        "osArchitecture": "x86_64",
-        "processArchitecture": "x86_64",
+        "dotnetSdk": "10.0.100",
+        "runtime": ".NET 9.0.10",
+        "osDescription": "Ubuntu 24.04.3 LTS",
+        "osArchitecture": "X64",
+        "processArchitecture": "X64",
         "machineName": "EVOMONSTER",
         "processorCount": 32
       },
-      "missingComparisons": [
-        "Aztec (Encode)",
-        "Code 128 (Encode)",
-        "Code 39 (Encode)",
-        "Code 93 (Encode)",
-        "Data Matrix (Encode)",
-        "EAN-13 (Encode)",
-        "PDF417 (Encode)",
-        "QR (Encode)",
-        "UPC-A (Encode)"
-      ],
-      "missingComparisonIds": [
-        "AztecCompareBenchmarks",
-        "Code128CompareBenchmarks",
-        "Code39CompareBenchmarks",
-        "Code93CompareBenchmarks",
-        "DataMatrixCompareBenchmarks",
-        "EanCompareBenchmarks",
-        "Pdf417CompareBenchmarks",
-        "QrCompareBenchmarks",
-        "UpcACompareBenchmarks"
-      ],
+      "missingComparisons": [],
+      "missingComparisonIds": [],
       "howToRead": [
         "Mean: average time per operation. Lower is better.",
         "Allocated: managed memory allocated per operation. Lower is better.",
-        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
-        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the fastest allocation for that scenario. 1 x means CodeGlyphX allocates the least; higher is more allocations.",
+        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x (fastest) means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
+        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the allocation of the fastest-time vendor for that scenario. Lower than 1 x means fewer allocations than the fastest-time vendor.",
         "Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).",
+        "Δ lines in comparison tables show vendor ratios vs CodeGlyphX (time / alloc).",
         "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
       ],
       "notes": [
@@ -1001,9 +983,516 @@
         "Barcoder uses Barcoder.Renderer.Image (ImageSharp renderer).",
         "QRCoder uses PngByteQRCode (managed PNG output, no external renderer).",
         "QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).",
-        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy)."
+        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy).",
+        "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
       ],
-      "summary": []
+      "summary": [
+        {
+          "codeGlyphXAlloc": "61.34 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Aztec (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "270.8 μs",
+          "scenario": "Aztec PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 270800.0,
+              "mean": "270.8 μs",
+              "allocated": "61.34 KB"
+            }
+          },
+          "codeGlyphXMean": "270.8 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "14.44 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 128 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "150.3 μs",
+          "scenario": "Code128 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 150300.0,
+              "mean": "150.3 μs",
+              "allocated": "14.44 KB"
+            }
+          },
+          "codeGlyphXMean": "150.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "10.02 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 39 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "128.0 μs",
+          "scenario": "Code39 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 128000.0,
+              "mean": "128.0 μs",
+              "allocated": "10.02 KB"
+            }
+          },
+          "codeGlyphXMean": "128.0 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "8.14 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 93 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "144.5 μs",
+          "scenario": "Code93 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 144500.0,
+              "mean": "144.5 μs",
+              "allocated": "8.14 KB"
+            }
+          },
+          "codeGlyphXMean": "144.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "15.53 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Data Matrix (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "200.9 μs",
+          "scenario": "Data Matrix PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 200900.0,
+              "mean": "200.9 μs",
+              "allocated": "15.53 KB"
+            }
+          },
+          "codeGlyphXMean": "200.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "6.85 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "EAN-13 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "168.9 μs",
+          "scenario": "EAN-13 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 168900.0,
+              "mean": "168.9 μs",
+              "allocated": "6.85 KB"
+            }
+          },
+          "codeGlyphXMean": "168.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "49.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "PDF417 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "907.9 μs",
+          "scenario": "PDF417 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 907900.0,
+              "mean": "907.9 μs",
+              "allocated": "49.91 KB"
+            }
+          },
+          "codeGlyphXMean": "907.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "14.27 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "614.1 μs",
+          "scenario": "QR PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 614100.0,
+              "mean": "614.1 μs",
+              "allocated": "14.27 KB"
+            }
+          },
+          "codeGlyphXMean": "614.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "3.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Clean)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "956.5 μs",
+          "scenario": "QR Decode (clean)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 956500.0,
+              "mean": "956.5 μs",
+              "allocated": "3.91 KB"
+            }
+          },
+          "codeGlyphXMean": "956.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "160.77 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Noisy)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "41.20 ms",
+          "scenario": "QR Decode (noisy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 41200000.0,
+              "mean": "41.20 ms",
+              "allocated": "160.77 KB"
+            }
+          },
+          "codeGlyphXMean": "41.20 ms",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "2.68 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "353.4 μs",
+          "scenario": "QR Decode (fancy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 353400.0,
+              "mean": "353.4 μs",
+              "allocated": "2.68 KB"
+            }
+          },
+          "codeGlyphXMean": "353.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "45.09 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "11,185.1 μs",
+          "scenario": "QR Decode (no quiet zone)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 11185100.0,
+              "mean": "11,185.1 μs",
+              "allocated": "45.09 KB"
+            }
+          },
+          "codeGlyphXMean": "11,185.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "1.88 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "557.4 μs",
+          "scenario": "QR Decode (resampled)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 557400.0,
+              "mean": "557.4 μs",
+              "allocated": "1.88 KB"
+            }
+          },
+          "codeGlyphXMean": "557.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "7.16 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "UPC-A (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "197.3 μs",
+          "scenario": "UPC-A PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 197300.0,
+              "mean": "197.3 μs",
+              "allocated": "7.16 KB"
+            }
+          },
+          "codeGlyphXMean": "197.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        }
+      ],
+      "packRunner": {
+        "reportPath": "/tmp/cgx-psquick-smoke/linux-20260127-151049/pack-runner/qr-decode-packs-quick.json",
+        "generatedUtc": "2026-01-27T14:11:19.2732196Z",
+        "mode": "quick",
+        "packs": [
+          {
+            "name": "art",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 8.0,
+                "decodeRate": 0.875,
+                "expectedRate": 0.875,
+                "medianMs": 2910.0688,
+                "p95Ms": 9471.7427,
+                "failingScenarios": [
+                  "art-jess3-grid"
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ideal",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 1446.0706,
+                "p95Ms": 1579.5812,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "multi",
+            "scenarioCount": 1,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 3.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 5683.2641,
+                "p95Ms": 5684.814,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "screenshot",
+            "scenarioCount": 3,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 9.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 4269.6355,
+                "p95Ms": 4432.9162,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "stress",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 2149.8542,
+                "p95Ms": 3327.857,
+                "failingScenarios": []
+              }
+            ]
+          }
+        ],
+        "engines": {
+          "name": "CodeGlyphX",
+          "isExternal": false,
+          "runs": 44.0,
+          "decodeRate": 0.9772727272727273,
+          "expectedRate": 0.9772727272727273,
+          "failingScenarios": "art-jess3-grid",
+          "failingPacks": "art"
+        },
+        "note": "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
+      }
     },
     "full": null
   },

--- a/CodeGlyphX.Website/wwwroot/data/benchmark.json
+++ b/CodeGlyphX.Website/wwwroot/data/benchmark.json
@@ -31,7 +31,7 @@
       "publish": false,
       "artifacts": "C:\\Support\\GitHub\\CodeMatrix\\Build\\BenchmarkResults\\windows-20260124-124033",
       "missingComparisonIds": [],
-      "generatedUtc": "2026-01-24T11:41:47.0013230Z",
+      "generatedUtc": "2026-01-24T11:41:47.001323Z",
       "comparisons": [
         {
           "scenarios": [
@@ -2153,56 +2153,253 @@
   },
   "linux": {
     "quick": {
-      "generatedUtc": "2026-01-22T23:04:32.829577+01:00",
-      "schemaVersion": 1,
       "os": "linux",
-      "framework": "net8.0",
-      "configuration": "Release",
-      "runMode": "quick",
-      "runModeDetails": "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
-      "publish": false,
-      "artifacts": "/mnt/c/Support/GitHub/CodeMatrix/Build/BenchmarkResults/linux-20260122-230352",
       "meta": {
         "commit": null,
         "branch": null,
-        "dotnetSdk": null,
-        "runtime": null,
-        "osDescription": "Linux-6.6.87.2-microsoft-standard-WSL2-x86_64-with-glibc2.39",
-        "osArchitecture": "x86_64",
-        "processArchitecture": "x86_64",
+        "dotnetSdk": "10.0.100",
+        "runtime": ".NET 9.0.10",
+        "osDescription": "Ubuntu 24.04.3 LTS",
+        "osArchitecture": "X64",
+        "processArchitecture": "X64",
         "machineName": "EVOMONSTER",
         "processorCount": 32
       },
-      "missingComparisons": [
-        "Aztec (Encode)",
-        "Code 128 (Encode)",
-        "Code 39 (Encode)",
-        "Code 93 (Encode)",
-        "Data Matrix (Encode)",
-        "EAN-13 (Encode)",
-        "PDF417 (Encode)",
-        "QR (Encode)",
-        "UPC-A (Encode)"
+      "generatedUtc": "2026-01-27T14:16:09.1385475Z",
+      "baseline": [],
+      "comparisons": [
+        {
+          "title": "Aztec (Encode)",
+          "id": "AztecCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Aztec PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 270800.0,
+                  "mean": "270.8 μs",
+                  "allocated": "61.34 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Code 128 (Encode)",
+          "id": "Code128CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Code128 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 150300.0,
+                  "mean": "150.3 μs",
+                  "allocated": "14.44 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Code 39 (Encode)",
+          "id": "Code39CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Code39 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 128000.0,
+                  "mean": "128.0 μs",
+                  "allocated": "10.02 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Code 93 (Encode)",
+          "id": "Code93CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Code93 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 144500.0,
+                  "mean": "144.5 μs",
+                  "allocated": "8.14 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "Data Matrix (Encode)",
+          "id": "DataMatrixCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "Data Matrix PNG (medium)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 200900.0,
+                  "mean": "200.9 μs",
+                  "allocated": "15.53 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "EAN-13 (Encode)",
+          "id": "EanCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "EAN-13 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 168900.0,
+                  "mean": "168.9 μs",
+                  "allocated": "6.85 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "PDF417 (Encode)",
+          "id": "Pdf417CompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "PDF417 PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 907900.0,
+                  "mean": "907.9 μs",
+                  "allocated": "49.91 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR (Encode)",
+          "id": "QrCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR PNG (medium)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 614100.0,
+                  "mean": "614.1 μs",
+                  "allocated": "14.27 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR Decode (Clean)",
+          "id": "QrDecodeCleanCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR Decode (clean)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 956500.0,
+                  "mean": "956.5 μs",
+                  "allocated": "3.91 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR Decode (Noisy)",
+          "id": "QrDecodeNoisyCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR Decode (noisy)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 41200000.0,
+                  "mean": "41.20 ms",
+                  "allocated": "160.77 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "QR Decode (Stress)",
+          "id": "QrDecodeStressCompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "QR Decode (fancy)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 353400.0,
+                  "mean": "353.4 μs",
+                  "allocated": "2.68 KB"
+                }
+              },
+              "ratios": {}
+            },
+            {
+              "name": "QR Decode (no quiet zone)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 11185100.0,
+                  "mean": "11,185.1 μs",
+                  "allocated": "45.09 KB"
+                }
+              },
+              "ratios": {}
+            },
+            {
+              "name": "QR Decode (resampled)",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 557400.0,
+                  "mean": "557.4 μs",
+                  "allocated": "1.88 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        },
+        {
+          "title": "UPC-A (Encode)",
+          "id": "UpcACompareBenchmarks",
+          "scenarios": [
+            {
+              "name": "UPC-A PNG",
+              "vendors": {
+                "CodeGlyphX": {
+                  "meanNs": 197300.0,
+                  "mean": "197.3 μs",
+                  "allocated": "7.16 KB"
+                }
+              },
+              "ratios": {}
+            }
+          ]
+        }
       ],
-      "missingComparisonIds": [
-        "AztecCompareBenchmarks",
-        "Code128CompareBenchmarks",
-        "Code39CompareBenchmarks",
-        "Code93CompareBenchmarks",
-        "DataMatrixCompareBenchmarks",
-        "EanCompareBenchmarks",
-        "Pdf417CompareBenchmarks",
-        "QrCompareBenchmarks",
-        "UpcACompareBenchmarks"
-      ],
-      "howToRead": [
-        "Mean: average time per operation. Lower is better.",
-        "Allocated: managed memory allocated per operation. Lower is better.",
-        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
-        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the fastest allocation for that scenario. 1 x means CodeGlyphX allocates the least; higher is more allocations.",
-        "Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).",
-        "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
-      ],
+      "artifacts": "/tmp/cgx-psquick-smoke/linux-20260127-151049",
+      "publish": false,
+      "runMode": "quick",
+      "missingComparisonIds": [],
+      "runModeSource": "explicit",
       "notes": [
         "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
         "Comparisons target PNG output and include encode+render (not encode-only).",
@@ -2211,87 +2408,530 @@
         "Barcoder uses Barcoder.Renderer.Image (ImageSharp renderer).",
         "QRCoder uses PngByteQRCode (managed PNG output, no external renderer).",
         "QR decode comparisons use raw RGBA32 bytes (ZXing via RGBLuminanceSource).",
-        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy)."
+        "QR decode clean uses CodeGlyphX Balanced; noisy uses CodeGlyphX Robust with aggressive sampling/limits; ZXing uses default (clean) and TryHarder (noisy).",
+        "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
       ],
-      "summary": [],
-      "baseline": [
-        {
-          "id": "QrDecodeBenchmarks",
-          "title": "QR (Decode)",
-          "scenarios": [
-            {
-              "name": "QR Decode (clean, fast)",
-              "mean": "3,076.8 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (clean, balanced)",
-              "mean": "3,052.8 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (clean, robust)",
-              "mean": "2,435.8 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (noisy, robust)",
-              "mean": "4,481.1 μs",
-              "meanNs": null,
-              "allocated": "5.45 KB"
-            },
-            {
-              "name": "QR Decode (screenshot, balanced)",
-              "mean": "7,166.1 μs",
-              "meanNs": null,
-              "allocated": "5.26 KB"
-            },
-            {
-              "name": "QR Decode (antialias, robust)",
-              "mean": "477.0 μs",
-              "meanNs": null,
-              "allocated": "1.31 KB"
-            }
-          ]
-        }
+      "howToRead": [
+        "Mean: average time per operation. Lower is better.",
+        "Allocated: managed memory allocated per operation. Lower is better.",
+        "CodeGlyphX vs Fastest: CodeGlyphX mean divided by the fastest mean for that scenario. 1 x (fastest) means CodeGlyphX is fastest; 1.5 x means ~50% slower.",
+        "CodeGlyphX Alloc vs Fastest: CodeGlyphX allocated divided by the allocation of the fastest-time vendor for that scenario. Lower than 1 x means fewer allocations than the fastest-time vendor.",
+        "Rating: good/ok/bad based on time + allocation ratios (good <=1.1x and <=1.25x alloc, ok <=1.5x and <=2.0x alloc).",
+        "Δ lines in comparison tables show vendor ratios vs CodeGlyphX (time / alloc).",
+        "Quick runs use fewer iterations for fast feedback; Full runs use BenchmarkDotNet defaults and are recommended for publishing."
       ],
-      "comparisons": [
-        {
-          "id": "QrDecodeCleanCompareBenchmarks",
-          "title": "QR Decode (Clean)",
-          "scenarios": [
-            {
-              "name": "QR Decode (clean)",
-              "vendors": {
-                "CodeGlyphX": {
-                  "mean": "2.215 ms",
-                  "meanNs": null,
-                  "allocated": "5.26 KB"
-                }
+      "schemaVersion": 1,
+      "packRunner": {
+        "reportPath": "/tmp/cgx-psquick-smoke/linux-20260127-151049/pack-runner/qr-decode-packs-quick.json",
+        "generatedUtc": "2026-01-27T14:11:19.2732196Z",
+        "mode": "quick",
+        "packs": [
+          {
+            "name": "art",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 8.0,
+                "decodeRate": 0.875,
+                "expectedRate": 0.875,
+                "medianMs": 2910.0688,
+                "p95Ms": 9471.7427,
+                "failingScenarios": [
+                  "art-jess3-grid"
+                ]
               }
+            ]
+          },
+          {
+            "name": "ideal",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 1446.0706,
+                "p95Ms": 1579.5812,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "multi",
+            "scenarioCount": 1,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 3.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 5683.2641,
+                "p95Ms": 5684.814,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "screenshot",
+            "scenarioCount": 3,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 9.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 4269.6355,
+                "p95Ms": 4432.9162,
+                "failingScenarios": []
+              }
+            ]
+          },
+          {
+            "name": "stress",
+            "scenarioCount": 4,
+            "engines": [
+              {
+                "name": "CodeGlyphX",
+                "isExternal": false,
+                "runs": 12.0,
+                "decodeRate": 1.0,
+                "expectedRate": 1.0,
+                "medianMs": 2149.8542,
+                "p95Ms": 3327.857,
+                "failingScenarios": []
+              }
+            ]
+          }
+        ],
+        "engines": {
+          "name": "CodeGlyphX",
+          "isExternal": false,
+          "runs": 44.0,
+          "decodeRate": 0.9772727272727273,
+          "expectedRate": 0.9772727272727273,
+          "failingScenarios": "art-jess3-grid",
+          "failingPacks": "art"
+        },
+        "note": "QR pack runner (quick): CodeGlyphX expected=98 % (misses: art-jess3-grid)"
+      },
+      "summary": [
+        {
+          "codeGlyphXAlloc": "61.34 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Aztec (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "270.8 μs",
+          "scenario": "Aztec PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 270800.0,
+              "mean": "270.8 μs",
+              "allocated": "61.34 KB"
             }
-          ]
+          },
+          "codeGlyphXMean": "270.8 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
         },
         {
-          "id": "QrDecodeNoisyCompareBenchmarks",
-          "title": "QR Decode (Noisy)",
-          "scenarios": [
-            {
-              "name": "QR Decode (noisy)",
-              "vendors": {
-                "CodeGlyphX": {
-                  "mean": "4.090 ms",
-                  "meanNs": null,
-                  "allocated": "5.45 KB"
-                }
-              }
+          "codeGlyphXAlloc": "14.44 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 128 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "150.3 μs",
+          "scenario": "Code128 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 150300.0,
+              "mean": "150.3 μs",
+              "allocated": "14.44 KB"
             }
-          ]
+          },
+          "codeGlyphXMean": "150.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "10.02 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 39 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "128.0 μs",
+          "scenario": "Code39 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 128000.0,
+              "mean": "128.0 μs",
+              "allocated": "10.02 KB"
+            }
+          },
+          "codeGlyphXMean": "128.0 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "8.14 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Code 93 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "144.5 μs",
+          "scenario": "Code93 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 144500.0,
+              "mean": "144.5 μs",
+              "allocated": "8.14 KB"
+            }
+          },
+          "codeGlyphXMean": "144.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "15.53 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "Data Matrix (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "200.9 μs",
+          "scenario": "Data Matrix PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 200900.0,
+              "mean": "200.9 μs",
+              "allocated": "15.53 KB"
+            }
+          },
+          "codeGlyphXMean": "200.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "6.85 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "EAN-13 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "168.9 μs",
+          "scenario": "EAN-13 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 168900.0,
+              "mean": "168.9 μs",
+              "allocated": "6.85 KB"
+            }
+          },
+          "codeGlyphXMean": "168.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "49.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "PDF417 (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "907.9 μs",
+          "scenario": "PDF417 PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 907900.0,
+              "mean": "907.9 μs",
+              "allocated": "49.91 KB"
+            }
+          },
+          "codeGlyphXMean": "907.9 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "14.27 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "614.1 μs",
+          "scenario": "QR PNG (medium)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 614100.0,
+              "mean": "614.1 μs",
+              "allocated": "14.27 KB"
+            }
+          },
+          "codeGlyphXMean": "614.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "3.91 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Clean)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "956.5 μs",
+          "scenario": "QR Decode (clean)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 956500.0,
+              "mean": "956.5 μs",
+              "allocated": "3.91 KB"
+            }
+          },
+          "codeGlyphXMean": "956.5 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "160.77 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Noisy)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "41.20 ms",
+          "scenario": "QR Decode (noisy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 41200000.0,
+              "mean": "41.20 ms",
+              "allocated": "160.77 KB"
+            }
+          },
+          "codeGlyphXMean": "41.20 ms",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "2.68 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "353.4 μs",
+          "scenario": "QR Decode (fancy)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 353400.0,
+              "mean": "353.4 μs",
+              "allocated": "2.68 KB"
+            }
+          },
+          "codeGlyphXMean": "353.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "45.09 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "11,185.1 μs",
+          "scenario": "QR Decode (no quiet zone)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 11185100.0,
+              "mean": "11,185.1 μs",
+              "allocated": "45.09 KB"
+            }
+          },
+          "codeGlyphXMean": "11,185.1 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "1.88 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "QR Decode (Stress)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "557.4 μs",
+          "scenario": "QR Decode (resampled)",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 557400.0,
+              "mean": "557.4 μs",
+              "allocated": "1.88 KB"
+            }
+          },
+          "codeGlyphXMean": "557.4 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
+        },
+        {
+          "codeGlyphXAlloc": "7.16 KB",
+          "fastestVendor": "CodeGlyphX",
+          "codeGlyphXLeadOverRunnerUpText": "",
+          "codeGlyphXLeadOverRunnerUp": null,
+          "benchmark": "UPC-A (Encode)",
+          "runnerUpMean": null,
+          "deltas": {
+            "ZXing.Net": "",
+            "Barcoder": "",
+            "QRCoder": ""
+          },
+          "codeGlyphXAllocVsFastest": 1.0,
+          "codeGlyphXVsFastestText": "1 x (fastest)",
+          "fastestMean": "197.3 μs",
+          "scenario": "UPC-A PNG",
+          "runnerUpVendor": null,
+          "vendors": {
+            "CodeGlyphX": {
+              "meanNs": 197300.0,
+              "mean": "197.3 μs",
+              "allocated": "7.16 KB"
+            }
+          },
+          "codeGlyphXMean": "197.3 μs",
+          "rating": "good",
+          "codeGlyphXAllocVsFastestText": "1 x",
+          "codeGlyphXVsFastest": 1.0
         }
-      ]
+      ],
+      "runModeDetails": "Run mode: Quick (warmupCount=1, iterationCount=3, invocationCount=1).",
+      "configuration": "Release",
+      "missingComparisons": [],
+      "framework": "net8.0"
     },
     "full": null
   },

--- a/CodeGlyphX.Website/wwwroot/docs/index.html
+++ b/CodeGlyphX.Website/wwwroot/docs/index.html
@@ -221,7 +221,7 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
             </ul>
 
             <h2>Feature Availability</h2>
-            <p>Most features are available across all targets, but the QR pixel pipeline and Span-based APIs are net8+ only.</p>
+            <p>Most features are available across all targets, but the full QR pixel pipeline and Span-based APIs are net8+ only.</p>
             <table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
                 <thead>
                     <tr style="border-bottom: 1px solid var(--border);">
@@ -254,7 +254,7 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">QR pixel decode from raw pixels / screenshots</td>
                         <td style="padding: 0.75rem;">Yes</td>
-                        <td style="padding: 0.75rem;">No (returns false)</td>
+                        <td style="padding: 0.75rem;">Limited fallback (clean/generated)</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">QR pixel debug rendering</td>
@@ -268,9 +268,9 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
                     </tr>
                 </tbody>
             </table>
-            <p class="text-muted">QR pixel decode APIs are net8+ only (e.g., <code>QrImageDecoder.TryDecodeImage(...)</code> and <code>QrDecoder.TryDecode(...)</code> from pixels).</p>
+            <p class="text-muted">net8+ provides the full QR pixel pipeline; <code>net472</code>/<code>netstandard2.0</code> use a limited fallback for QR image decode via <code>QrImageDecoder.TryDecodeImage(...)</code> and byte[] overloads.</p>
             <p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code> and <code>SupportsQrPixelDebug</code>).</p>
-            <p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps that only need encoding, rendering, and module-grid decode.</p>
+            <p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for the most robust QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps; QR image decode is available via a best-effort fallback but is less reliable on heavily styled/artistic inputs.</p>
         </section>
 
         <section id="quickstart">
@@ -1318,4 +1318,3 @@ if (docsOverlay && docsSidebar) {
   </script>
 </body>
 </html>
-

--- a/CodeGlyphX.Website/wwwroot/docs/index.html
+++ b/CodeGlyphX.Website/wwwroot/docs/index.html
@@ -269,7 +269,7 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
                 </tbody>
             </table>
             <p class="text-muted">net8+ provides the full QR pixel pipeline; <code>net472</code>/<code>netstandard2.0</code> use a limited fallback for QR image decode via <code>QrImageDecoder.TryDecodeImage(...)</code> and byte[] overloads.</p>
-            <p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code> and <code>SupportsQrPixelDebug</code>).</p>
+            <p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code>, <code>SupportsQrPixelDecodeFallback</code>, and <code>SupportsQrPixelDebug</code>).</p>
             <p class="text-muted"><strong>net472 QR decode expectations:</strong> clean/generated PNG/JPEG renders are supported; multi-code screenshots and heavily styled/artistic inputs remain best-effort. Use the quick smoke checklist in <code>Build/Net472-SmokeTest.md</code>.</p>
             <p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for the most robust QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps; QR image decode is available via a best-effort fallback but is less reliable on heavily styled/artistic inputs.</p>
         </section>

--- a/CodeGlyphX.Website/wwwroot/docs/index.html
+++ b/CodeGlyphX.Website/wwwroot/docs/index.html
@@ -270,6 +270,7 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
             </table>
             <p class="text-muted">net8+ provides the full QR pixel pipeline; <code>net472</code>/<code>netstandard2.0</code> use a limited fallback for QR image decode via <code>QrImageDecoder.TryDecodeImage(...)</code> and byte[] overloads.</p>
             <p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code> and <code>SupportsQrPixelDebug</code>).</p>
+            <p class="text-muted"><strong>net472 QR decode expectations:</strong> clean/generated PNG/JPEG renders are supported; multi-code screenshots and heavily styled/artistic inputs remain best-effort. Use the quick smoke checklist in <code>Build/Net472-SmokeTest.md</code>.</p>
             <p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for the most robust QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps; QR image decode is available via a best-effort fallback but is less reliable on heavily styled/artistic inputs.</p>
         </section>
 

--- a/CodeGlyphX/CodeGlyphXFeatures.cs
+++ b/CodeGlyphX/CodeGlyphXFeatures.cs
@@ -25,6 +25,19 @@ public static class CodeGlyphXFeatures {
     }
 
     /// <summary>
+    /// True when the legacy QR pixel fallback path is active (non-net8 targets).
+    /// </summary>
+    public static bool SupportsQrPixelDecodeFallback {
+        get {
+#if NET8_0_OR_GREATER
+            return false;
+#else
+            return true;
+#endif
+        }
+    }
+
+    /// <summary>
     /// True when QR pixel debug rendering is available (net8+).
     /// </summary>
     public static bool SupportsQrPixelDebug {

--- a/CodeGlyphX/CodeGlyphXFeatures.cs
+++ b/CodeGlyphX/CodeGlyphXFeatures.cs
@@ -4,6 +4,13 @@ namespace CodeGlyphX;
 /// Runtime feature flags for CodeGlyphX capabilities.
 /// </summary>
 public static class CodeGlyphXFeatures {
+#if NET8_0_OR_GREATER
+    // Test hook: allows exercising the legacy QR fallback on net8+.
+    internal static bool ForceQrFallbackForTests { get; set; }
+#else
+    internal static bool ForceQrFallbackForTests => false;
+#endif
+
     /// <summary>
     /// True when the high-performance QR pixel pipeline is available (net8+).
     /// </summary>

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -1037,6 +1037,14 @@ public static class QrImageDecoder {
         return gray;
     }
 
+    private static byte[] InvertGrayscale(byte[] gray) {
+        var inverted = new byte[gray.Length];
+        for (var i = 0; i < gray.Length; i++) {
+            inverted[i] = (byte)(255 - gray[i]);
+        }
+        return inverted;
+    }
+
     private static int ComputeMean(byte[] gray) {
         long sum = 0;
         for (var i = 0; i < gray.Length; i++) sum += gray[i];
@@ -1081,6 +1089,19 @@ public static class QrImageDecoder {
     }
 
     private static bool TryDecodeWithThreshold(byte[] gray, int width, int height, byte threshold, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
+        decoded = null!;
+        info = default;
+
+        if (TryDecodeWithThresholdCore(gray, width, height, threshold, cancellationToken, out decoded, out info)) {
+            return true;
+        }
+
+        var inverted = InvertGrayscale(gray);
+        var invertedThreshold = (byte)ClampByte(255 - threshold);
+        return TryDecodeWithThresholdCore(inverted, width, height, invertedThreshold, cancellationToken, out decoded, out info);
+    }
+
+    private static bool TryDecodeWithThresholdCore(byte[] gray, int width, int height, byte threshold, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
         decoded = null!;
         info = default;
 

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -27,6 +27,9 @@ public static class QrImageDecoder {
     /// </summary>
     public static bool TryDecode(byte[] pixels, int width, int height, int stride, PixelFormat format, out QrDecoded decoded) {
 #if NET8_0_OR_GREATER
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeFallback(pixels, width, height, stride, format, options: null, cancellationToken: default, out decoded, out _);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, out decoded);
 #else
         return TryDecodeFallback(pixels, width, height, stride, format, options: null, cancellationToken: default, out decoded, out _);
@@ -38,6 +41,9 @@ public static class QrImageDecoder {
     /// </summary>
     public static bool TryDecode(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded decoded) {
 #if NET8_0_OR_GREATER
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken: default, out decoded, out _);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, out decoded);
 #else
         return TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken: default, out decoded, out _);
@@ -49,6 +55,9 @@ public static class QrImageDecoder {
     /// </summary>
     public static bool TryDecode(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded) {
 #if NET8_0_OR_GREATER
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken, out decoded, out _);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, cancellationToken, out decoded);
 #else
         return TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken, out decoded, out _);
@@ -60,6 +69,9 @@ public static class QrImageDecoder {
     /// </summary>
     public static bool TryDecodeAll(byte[] pixels, int width, int height, int stride, PixelFormat format, out QrDecoded[] decoded) {
 #if NET8_0_OR_GREATER
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeAllFallback(pixels, width, height, stride, format, options: null, cancellationToken: default, out decoded);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, out decoded);
 #else
         return TryDecodeAllFallback(pixels, width, height, stride, format, options: null, cancellationToken: default, out decoded);
@@ -71,6 +83,9 @@ public static class QrImageDecoder {
     /// </summary>
     public static bool TryDecodeAll(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded[] decoded) {
 #if NET8_0_OR_GREATER
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeAllFallback(pixels, width, height, stride, format, options, cancellationToken: default, out decoded);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, out decoded);
 #else
         return TryDecodeAllFallback(pixels, width, height, stride, format, options, cancellationToken: default, out decoded);
@@ -82,6 +97,9 @@ public static class QrImageDecoder {
     /// </summary>
     public static bool TryDecodeAll(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded[] decoded) {
 #if NET8_0_OR_GREATER
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeAllFallback(pixels, width, height, stride, format, options, cancellationToken, out decoded);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, cancellationToken, out decoded);
 #else
         return TryDecodeAllFallback(pixels, width, height, stride, format, options, cancellationToken, out decoded);
@@ -94,6 +112,9 @@ public static class QrImageDecoder {
     public static bool TryDecodeImage(byte[] image, out QrDecoded decoded) {
 #if NET8_0_OR_GREATER
         if (image is null) throw new ArgumentNullException(nameof(image));
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeImageFallback(image, options: null, cancellationToken: default, out decoded, out _);
+        }
         if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
             decoded = null!;
             return false;
@@ -110,6 +131,9 @@ public static class QrImageDecoder {
     public static bool TryDecodeImage(byte[] image, out QrDecoded decoded, out QrPixelDecodeInfo info, QrPixelDecodeOptions? options = null) {
 #if NET8_0_OR_GREATER
         if (image is null) throw new ArgumentNullException(nameof(image));
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeImageFallback(image, options, cancellationToken: default, out decoded, out info);
+        }
         if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
             decoded = null!;
             info = default;
@@ -127,6 +151,9 @@ public static class QrImageDecoder {
     public static bool TryDecodeImage(byte[] image, out QrDecoded decoded, out QrPixelDecodeInfo info, QrPixelDecodeOptions? options, CancellationToken cancellationToken) {
 #if NET8_0_OR_GREATER
         if (image is null) throw new ArgumentNullException(nameof(image));
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeImageFallback(image, options, cancellationToken, out decoded, out info);
+        }
         if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
             decoded = null!;
             info = default;
@@ -181,6 +208,9 @@ public static class QrImageDecoder {
     public static bool TryDecodeImage(byte[] image, QrPixelDecodeOptions? options, out QrDecoded decoded) {
 #if NET8_0_OR_GREATER
         if (image is null) throw new ArgumentNullException(nameof(image));
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeImageFallback(image, options, cancellationToken: default, out decoded, out _);
+        }
         if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
             decoded = null!;
             return false;
@@ -402,6 +432,10 @@ public static class QrImageDecoder {
     public static bool TryDecodeImage(Stream stream, out QrDecoded decoded, out QrPixelDecodeInfo info, QrPixelDecodeOptions? options = null) {
 #if NET8_0_OR_GREATER
         if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            var data = RenderIO.ReadBinary(stream);
+            return TryDecodeImageFallback(data, options, cancellationToken: default, out decoded, out info);
+        }
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options);
 #else
@@ -417,6 +451,10 @@ public static class QrImageDecoder {
     public static bool TryDecodeImage(Stream stream, QrPixelDecodeOptions? options, out QrDecoded decoded) {
 #if NET8_0_OR_GREATER
         if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            var data = RenderIO.ReadBinary(stream);
+            return TryDecodeImageFallback(data, options, cancellationToken: default, out decoded, out _);
+        }
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
@@ -501,6 +539,14 @@ public static class QrImageDecoder {
             }
 
             info = DecodeResultHelpers.EnsureDimensions(info, formatKnown, width, height);
+
+            if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+                if (TryDecodeFallback(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out var decodedFallback, out _)) {
+                    return new DecodeResult<QrDecoded>(decodedFallback, info, stopwatch.Elapsed);
+                }
+                var fallbackFailure = DecodeResultHelpers.FailureForDecode(token);
+                return new DecodeResult<QrDecoded>(fallbackFailure, info, stopwatch.Elapsed);
+            }
 
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) {
                 return new DecodeResult<QrDecoded>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
@@ -639,6 +685,9 @@ public static class QrImageDecoder {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, imageOptions, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
+            if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+                return TryDecodeImageFallback(image, options, token, out decoded, out _);
+            }
             if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out decoded);
@@ -655,6 +704,9 @@ public static class QrImageDecoder {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, imageOptions, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
+            if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+                return TryDecodeImageFallback(image, options, token, out decoded, out info);
+            }
             if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options, token);
@@ -669,6 +721,9 @@ public static class QrImageDecoder {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, imageOptions, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
+            if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+                return TryDecodeImageFallback(image.ToArray(), options, token, out decoded, out _);
+            }
             if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out decoded);
@@ -684,6 +739,9 @@ public static class QrImageDecoder {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, imageOptions, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
+            if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+                return TryDecodeImageFallback(image.ToArray(), options, token, out decoded, out info);
+            }
             if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options, token);
@@ -699,6 +757,11 @@ public static class QrImageDecoder {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, imageOptions, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
+            if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+                if (!TryDecodeImageFallback(image, options, token, out var single, out _)) return false;
+                decoded = new[] { single };
+                return true;
+            }
             if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out decoded);
@@ -709,7 +772,6 @@ public static class QrImageDecoder {
     }
 #endif
 
-#if !NET8_0_OR_GREATER
     private static bool TryDecodeImageFallback(byte[] image, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
         if (image is null) throw new ArgumentNullException(nameof(image));
         decoded = null!;
@@ -750,22 +812,49 @@ public static class QrImageDecoder {
             return false;
         }
 
-        var dimension = EstimateDimension(grayscale, width, minX, minY, maxX, maxY, threshold);
-        if (dimension < 21) return false;
+        var dimensionEstimate = EstimateDimension(grayscale, width, minX, minY, maxX, maxY, threshold);
+        var versionEstimate = dimensionEstimate >= 21 ? ClampInt((dimensionEstimate - 17) / 4, 1, 40) : 1;
+        var moduleSize = EstimateModuleSize(grayscale, width, height, minX, minY, maxX, maxY, threshold);
+        if (moduleSize <= 0) moduleSize = 1;
 
-        var modules = SampleModules(grayscale, width, height, minX, minY, maxX, maxY, threshold, dimension);
-        if (cancellationToken.IsCancellationRequested) return false;
+        var padHalf = moduleSize / 2;
+        var pads = new[] { 0, padHalf, moduleSize, moduleSize * 2 };
+        var versions = new[] {
+            ClampInt(versionEstimate - 3, 1, 40),
+            ClampInt(versionEstimate - 2, 1, 40),
+            ClampInt(versionEstimate - 1, 1, 40),
+            versionEstimate,
+            ClampInt(versionEstimate + 1, 1, 40),
+            ClampInt(versionEstimate + 2, 1, 40),
+            ClampInt(versionEstimate + 3, 1, 40)
+        };
 
-        if (QrDecoder.TryDecode(modules, out decoded, out var moduleInfo)) {
-            info = new QrPixelDecodeInfo(1, threshold, invert: false, candidateCount: 0, candidateTriplesTried: 0, dimension, moduleInfo);
-            return true;
+        foreach (var pad in pads) {
+            var adjMinX = ClampInt(minX - pad, 0, width - 1);
+            var adjMinY = ClampInt(minY - pad, 0, height - 1);
+            var adjMaxX = ClampInt(maxX + pad, 0, width - 1);
+            var adjMaxY = ClampInt(maxY + pad, 0, height - 1);
+
+            foreach (var version in versions) {
+                var dimension = (version * 4) + 17;
+                var modules = SampleModules(grayscale, width, height, adjMinX, adjMinY, adjMaxX, adjMaxY, threshold, dimension);
+                if (cancellationToken.IsCancellationRequested) return false;
+
+                if (QrDecoder.TryDecode(modules, out decoded, out var moduleInfo)) {
+                    info = new QrPixelDecodeInfo(1, threshold, invert: false, candidateCount: 0, candidateTriplesTried: 0, dimension, moduleInfo);
+                    return true;
+                }
+
+                var inverted = modules.Clone();
+                inverted.Invert();
+                if (QrDecoder.TryDecode(inverted, out decoded, out moduleInfo)) {
+                    info = new QrPixelDecodeInfo(1, threshold, invert: true, candidateCount: 0, candidateTriplesTried: 0, dimension, moduleInfo);
+                    return true;
+                }
+            }
         }
 
-        var inverted = modules.Clone();
-        inverted.Invert();
-        var ok = QrDecoder.TryDecode(inverted, out decoded, out moduleInfo);
-        info = new QrPixelDecodeInfo(1, threshold, invert: true, candidateCount: 0, candidateTriplesTried: 0, dimension, moduleInfo);
-        return ok;
+        return false;
     }
 
     private static void ApplyMaxDimension(ref byte[] rgba, ref int width, ref int height, ref int stride, QrPixelDecodeOptions? options) {
@@ -884,6 +973,49 @@ public static class QrImageDecoder {
         return (version * 4) + 17;
     }
 
+    private static int EstimateModuleSize(byte[] gray, int width, int height, int minX, int minY, int maxX, int maxY, byte threshold) {
+        var boxWidth = (maxX - minX) + 1;
+        var boxHeight = (maxY - minY) + 1;
+        if (boxWidth <= 0 || boxHeight <= 0) return 1;
+
+        var midY = minY + (boxHeight / 2);
+        if (midY < 0) midY = 0;
+        if (midY >= height) midY = height - 1;
+
+        var rowStart = midY * width;
+        var runs = new List<int>(128);
+        var lastDark = gray[rowStart] < threshold;
+        var run = 0;
+        for (var x = 0; x < width; x++) {
+            var dark = gray[rowStart + x] < threshold;
+            if (dark == lastDark) {
+                run++;
+                continue;
+            }
+            if (run > 0) runs.Add(run);
+            run = 1;
+            lastDark = dark;
+        }
+        if (run > 0) runs.Add(run);
+        if (runs.Count == 0) return 1;
+
+        runs.Sort();
+        var baseline = runs[0];
+        var limit = baseline * 8;
+        var filtered = new List<int>(32);
+        for (var i = 0; i < runs.Count && filtered.Count < 32; i++) {
+            var value = runs[i];
+            if (value > limit) break;
+            filtered.Add(value);
+        }
+        if (filtered.Count == 0) return Math.Max(1, baseline);
+
+        filtered.Sort();
+        var mid = filtered.Count / 2;
+        var median = filtered[mid];
+        return Math.Max(1, median);
+    }
+
     private static BitMatrix SampleModules(byte[] gray, int width, int height, int minX, int minY, int maxX, int maxY, byte threshold, int dimension) {
         var matrix = new BitMatrix(dimension, dimension);
         var boxWidth = (maxX - minX) + 1;
@@ -910,13 +1042,15 @@ public static class QrImageDecoder {
         if (value > max) return max;
         return value;
     }
-#endif
 
 #if NET8_0_OR_GREATER
     /// <summary>
     /// Attempts to decode a QR code from a raw pixel buffer.
     /// </summary>
     public static bool TryDecode(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, out QrDecoded decoded) {
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeFallback(pixels.ToArray(), width, height, stride, format, options: null, cancellationToken: default, out decoded, out _);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, out decoded);
     }
 
@@ -924,6 +1058,9 @@ public static class QrImageDecoder {
     /// Attempts to decode a QR code from a raw pixel buffer.
     /// </summary>
     public static bool TryDecode(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded decoded) {
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeFallback(pixels.ToArray(), width, height, stride, format, options, cancellationToken: default, out decoded, out _);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, out decoded);
     }
 
@@ -931,6 +1068,9 @@ public static class QrImageDecoder {
     /// Attempts to decode all QR codes from a raw pixel buffer.
     /// </summary>
     public static bool TryDecodeAll(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, out QrDecoded[] decoded) {
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeAllFallback(pixels.ToArray(), width, height, stride, format, options: null, cancellationToken: default, out decoded);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, out decoded);
     }
 
@@ -938,6 +1078,9 @@ public static class QrImageDecoder {
     /// Attempts to decode all QR codes from a raw pixel buffer.
     /// </summary>
     public static bool TryDecodeAll(ReadOnlySpan<byte> pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, out QrDecoded[] decoded) {
+        if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
+            return TryDecodeAllFallback(pixels.ToArray(), width, height, stride, format, options, cancellationToken: default, out decoded);
+        }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, out decoded);
     }
 #endif

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -29,8 +29,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeFallback(pixels, width, height, stride, format, options: null, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -41,8 +40,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -53,8 +51,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(pixels, width, height, stride, format, options, cancellationToken, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken, out decoded, out _);
 #endif
     }
 
@@ -65,8 +62,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        return TryDecodeAllFallback(pixels, width, height, stride, format, options: null, cancellationToken: default, out decoded);
 #endif
     }
 
@@ -77,8 +73,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        return TryDecodeAllFallback(pixels, width, height, stride, format, options, cancellationToken: default, out decoded);
 #endif
     }
 
@@ -89,8 +84,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(pixels, width, height, stride, format, options, cancellationToken, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        return TryDecodeAllFallback(pixels, width, height, stride, format, options, cancellationToken, out decoded);
 #endif
     }
 
@@ -106,8 +100,7 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image, options: null, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -124,9 +117,7 @@ public static class QrImageDecoder {
         }
         return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        return TryDecodeImageFallback(image, options, cancellationToken: default, out decoded, out info);
 #endif
     }
 
@@ -143,9 +134,7 @@ public static class QrImageDecoder {
         }
         return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options, cancellationToken);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        return TryDecodeImageFallback(image, options, cancellationToken, out decoded, out info);
 #endif
     }
 
@@ -182,9 +171,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return TryDecodeImageCore(image, imageOptions, options, cancellationToken, out decoded, out info);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        return TryDecodeImageFallback(image, options, cancellationToken, out decoded, out info);
 #endif
     }
 
@@ -200,8 +187,7 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image, options, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -217,8 +203,7 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, cancellationToken, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image, options, cancellationToken, out decoded, out _);
 #endif
     }
 
@@ -233,8 +218,7 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options: null, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -250,9 +234,7 @@ public static class QrImageDecoder {
         }
         return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options, cancellationToken: default, out decoded, out info);
 #endif
     }
 
@@ -268,9 +250,7 @@ public static class QrImageDecoder {
         }
         return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options, cancellationToken);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options, cancellationToken, out decoded, out info);
 #endif
     }
 
@@ -288,8 +268,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return TryDecodeImageCore(image, imageOptions, options, cancellationToken, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options, cancellationToken, out decoded, out _);
 #endif
     }
 
@@ -307,9 +286,7 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return TryDecodeImageCore(image, imageOptions, options, cancellationToken, out decoded, out info);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options, cancellationToken, out decoded, out info);
 #endif
     }
 
@@ -324,8 +301,7 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -340,8 +316,7 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, cancellationToken, out decoded);
 #else
-        decoded = null!;
-        return false;
+        return TryDecodeImageFallback(image.ToArray(), options, cancellationToken, out decoded, out _);
 #endif
     }
 
@@ -374,8 +349,12 @@ public static class QrImageDecoder {
         }
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        if (!TryDecodeImageFallback(image, options, cancellationToken: default, out var single, out _)) {
+            decoded = Array.Empty<QrDecoded>();
+            return false;
+        }
+        decoded = new[] { single };
+        return true;
 #endif
     }
 
@@ -393,8 +372,12 @@ public static class QrImageDecoder {
 #if NET8_0_OR_GREATER
         return TryDecodeAllImageCore(image, imageOptions, options, cancellationToken, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        if (!TryDecodeImageFallback(image, options, cancellationToken, out var single, out _)) {
+            decoded = Array.Empty<QrDecoded>();
+            return false;
+        }
+        decoded = new[] { single };
+        return true;
 #endif
     }
 
@@ -407,8 +390,9 @@ public static class QrImageDecoder {
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
 #else
-        decoded = null!;
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeImageFallback(data, options: null, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -421,9 +405,9 @@ public static class QrImageDecoder {
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeImageFallback(data, options, cancellationToken: default, out decoded, out info);
 #endif
     }
 
@@ -436,8 +420,9 @@ public static class QrImageDecoder {
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
-        decoded = null!;
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeImageFallback(data, options, cancellationToken: default, out decoded, out _);
 #endif
     }
 
@@ -457,8 +442,9 @@ public static class QrImageDecoder {
         var data = RenderIO.ReadBinary(stream);
         return TryDecodeImageCore(data, imageOptions, options, cancellationToken, out decoded);
 #else
-        decoded = null!;
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeImageFallback(data, options, cancellationToken, out decoded, out _);
 #endif
     }
 
@@ -478,9 +464,9 @@ public static class QrImageDecoder {
         var data = RenderIO.ReadBinary(stream);
         return TryDecodeImageCore(data, imageOptions, options, cancellationToken, out decoded, out info);
 #else
-        decoded = null!;
-        info = default;
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeImageFallback(data, options, cancellationToken, out decoded, out info);
 #endif
     }
 
@@ -492,11 +478,8 @@ public static class QrImageDecoder {
         if (image is null) throw new ArgumentNullException(nameof(image));
         return DecodeImageResult((ReadOnlySpan<byte>)image, imageOptions, options, cancellationToken);
 #else
-        _ = imageOptions;
-        _ = options;
-        _ = cancellationToken;
         if (image is null) throw new ArgumentNullException(nameof(image));
-        return new DecodeResult<QrDecoded>(DecodeFailureReason.PlatformNotSupported, default, TimeSpan.Zero, "QR decoding requires .NET 8 or later.");
+        return DecodeImageResult((ReadOnlySpan<byte>)image, imageOptions, options, cancellationToken);
 #endif
     }
 
@@ -534,10 +517,26 @@ public static class QrImageDecoder {
             budgetScope?.Dispose();
         }
 #else
-        _ = imageOptions;
-        _ = options;
-        _ = cancellationToken;
-        return new DecodeResult<QrDecoded>(DecodeFailureReason.PlatformNotSupported, default, TimeSpan.Zero, "QR decoding requires .NET 8 or later.");
+        var stopwatch = Stopwatch.StartNew();
+        if (cancellationToken.IsCancellationRequested) {
+            return new DecodeResult<QrDecoded>(DecodeFailureReason.Cancelled, default, stopwatch.Elapsed);
+        }
+
+        ImageFormat format = ImageFormat.Unknown;
+        _ = ImageReader.TryDetectFormat(image, out format);
+
+        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            var infoFail = new ImageInfo(format, 0, 0);
+            return new DecodeResult<QrDecoded>(DecodeFailureReason.UnsupportedFormat, infoFail, stopwatch.Elapsed);
+        }
+
+        var info = new ImageInfo(format, width, height);
+        if (TryDecodeFallback(rgba, width, height, width * 4, PixelFormat.Rgba32, options, cancellationToken, out var decoded, out _)) {
+            return new DecodeResult<QrDecoded>(decoded, info, stopwatch.Elapsed);
+        }
+
+        var failure = cancellationToken.IsCancellationRequested ? DecodeFailureReason.Cancelled : DecodeFailureReason.NoResult;
+        return new DecodeResult<QrDecoded>(failure, info, stopwatch.Elapsed);
 #endif
     }
 
@@ -553,11 +552,9 @@ public static class QrImageDecoder {
         var data = RenderIO.ReadBinary(stream);
         return DecodeImageResult(data, imageOptions, options, cancellationToken);
 #else
-        _ = imageOptions;
-        _ = options;
-        _ = cancellationToken;
         if (stream is null) throw new ArgumentNullException(nameof(stream));
-        return new DecodeResult<QrDecoded>(DecodeFailureReason.PlatformNotSupported, default, TimeSpan.Zero, "QR decoding requires .NET 8 or later.");
+        var data = RenderIO.ReadBinary(stream);
+        return DecodeImageResult(data, imageOptions, options, cancellationToken);
 #endif
     }
 
@@ -577,8 +574,14 @@ public static class QrImageDecoder {
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        if (!TryDecodeImageFallback(data, options: null, cancellationToken: default, out var single, out _)) {
+            decoded = Array.Empty<QrDecoded>();
+            return false;
+        }
+        decoded = new[] { single };
+        return true;
 #endif
     }
 
@@ -591,8 +594,14 @@ public static class QrImageDecoder {
         var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
         return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, options, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        if (!TryDecodeImageFallback(data, options, cancellationToken: default, out var single, out _)) {
+            decoded = Array.Empty<QrDecoded>();
+            return false;
+        }
+        decoded = new[] { single };
+        return true;
 #endif
     }
 
@@ -612,8 +621,14 @@ public static class QrImageDecoder {
         var data = RenderIO.ReadBinary(stream);
         return TryDecodeAllImageCore(data, imageOptions, options, cancellationToken, out decoded);
 #else
-        decoded = Array.Empty<QrDecoded>();
-        return false;
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var data = RenderIO.ReadBinary(stream);
+        if (!TryDecodeImageFallback(data, options, cancellationToken, out var single, out _)) {
+            decoded = Array.Empty<QrDecoded>();
+            return false;
+        }
+        decoded = new[] { single };
+        return true;
 #endif
     }
 
@@ -691,6 +706,209 @@ public static class QrImageDecoder {
             budgetCts?.Dispose();
             budgetScope?.Dispose();
         }
+    }
+#endif
+
+#if !NET8_0_OR_GREATER
+    private static bool TryDecodeImageFallback(byte[] image, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
+        if (image is null) throw new ArgumentNullException(nameof(image));
+        decoded = null!;
+        info = default;
+        if (cancellationToken.IsCancellationRequested) return false;
+
+        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            return false;
+        }
+
+        var stride = width * 4;
+        return TryDecodeFallback(rgba, width, height, stride, PixelFormat.Rgba32, options, cancellationToken, out decoded, out info);
+    }
+
+    private static bool TryDecodeAllFallback(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded[] decoded) {
+        decoded = Array.Empty<QrDecoded>();
+        if (!TryDecodeFallback(pixels, width, height, stride, format, options, cancellationToken, out var single, out _)) {
+            return false;
+        }
+        decoded = new[] { single };
+        return true;
+    }
+
+    private static bool TryDecodeFallback(byte[] pixels, int width, int height, int stride, PixelFormat format, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
+        decoded = null!;
+        info = default;
+        if (pixels is null) throw new ArgumentNullException(nameof(pixels));
+        if (width <= 0 || height <= 0 || stride < width * 4) return false;
+        if (cancellationToken.IsCancellationRequested) return false;
+
+        var rgba = format == PixelFormat.Rgba32 ? pixels : ConvertBgraToRgba(pixels, width, height, stride);
+        ApplyMaxDimension(ref rgba, ref width, ref height, ref stride, options);
+        if (cancellationToken.IsCancellationRequested) return false;
+
+        var grayscale = BuildGrayscale(rgba, width, height, stride);
+        var threshold = ComputeMeanThreshold(grayscale);
+        if (!TryFindDarkBounds(grayscale, width, height, threshold, out var minX, out var minY, out var maxX, out var maxY)) {
+            return false;
+        }
+
+        var dimension = EstimateDimension(grayscale, width, minX, minY, maxX, maxY, threshold);
+        if (dimension < 21) return false;
+
+        var modules = SampleModules(grayscale, width, height, minX, minY, maxX, maxY, threshold, dimension);
+        if (cancellationToken.IsCancellationRequested) return false;
+
+        if (QrDecoder.TryDecode(modules, out decoded, out var moduleInfo)) {
+            info = new QrPixelDecodeInfo(1, threshold, invert: false, candidateCount: 0, candidateTriplesTried: 0, dimension, moduleInfo);
+            return true;
+        }
+
+        var inverted = modules.Clone();
+        inverted.Invert();
+        var ok = QrDecoder.TryDecode(inverted, out decoded, out moduleInfo);
+        info = new QrPixelDecodeInfo(1, threshold, invert: true, candidateCount: 0, candidateTriplesTried: 0, dimension, moduleInfo);
+        return ok;
+    }
+
+    private static void ApplyMaxDimension(ref byte[] rgba, ref int width, ref int height, ref int stride, QrPixelDecodeOptions? options) {
+        var maxDim = options?.MaxDimension ?? 0;
+        if (maxDim <= 0) return;
+
+        var currentMax = width > height ? width : height;
+        if (currentMax <= maxDim) return;
+
+        var scale = maxDim / (double)currentMax;
+        var dstWidth = Math.Max(1, (int)Math.Round(width * scale));
+        var dstHeight = Math.Max(1, (int)Math.Round(height * scale));
+        var background = new CodeGlyphX.Rendering.Png.Rgba32(255, 255, 255, 255);
+        rgba = ImageScaler.ResizeToFitNearest(rgba, width, height, stride, dstWidth, dstHeight, background, preserveAspectRatio: true);
+        width = dstWidth;
+        height = dstHeight;
+        stride = width * 4;
+    }
+
+    private static byte[] ConvertBgraToRgba(byte[] pixels, int width, int height, int stride) {
+        var rgba = new byte[checked(width * height * 4)];
+        var dst = 0;
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var i = row + (x * 4);
+                rgba[dst + 0] = pixels[i + 2];
+                rgba[dst + 1] = pixels[i + 1];
+                rgba[dst + 2] = pixels[i + 0];
+                rgba[dst + 3] = pixels[i + 3];
+                dst += 4;
+            }
+        }
+        return rgba;
+    }
+
+    private static byte[] BuildGrayscale(byte[] rgba, int width, int height, int stride) {
+        var gray = new byte[checked(width * height)];
+        var dst = 0;
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var i = row + (x * 4);
+                var r = rgba[i + 0];
+                var g = rgba[i + 1];
+                var b = rgba[i + 2];
+                var lum = (299 * r) + (587 * g) + (114 * b);
+                gray[dst++] = (byte)(lum / 1000);
+            }
+        }
+        return gray;
+    }
+
+    private static byte ComputeMeanThreshold(byte[] gray) {
+        long sum = 0;
+        for (var i = 0; i < gray.Length; i++) sum += gray[i];
+        var mean = (int)(sum / Math.Max(1, gray.Length));
+        var adjusted = mean - 8;
+        if (adjusted < 0) adjusted = 0;
+        if (adjusted > 255) adjusted = 255;
+        return (byte)adjusted;
+    }
+
+    private static bool TryFindDarkBounds(byte[] gray, int width, int height, byte threshold, out int minX, out int minY, out int maxX, out int maxY) {
+        minX = width;
+        minY = height;
+        maxX = -1;
+        maxY = -1;
+
+        var idx = 0;
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++, idx++) {
+                if (gray[idx] >= threshold) continue;
+                if (x < minX) minX = x;
+                if (y < minY) minY = y;
+                if (x > maxX) maxX = x;
+                if (y > maxY) maxY = y;
+            }
+        }
+
+        return maxX >= minX && maxY >= minY;
+    }
+
+    private static int EstimateDimension(byte[] gray, int width, int minX, int minY, int maxX, int maxY, byte threshold) {
+        var boxWidth = (maxX - minX) + 1;
+        var boxHeight = (maxY - minY) + 1;
+        if (boxWidth < 21 || boxHeight < 21) return 0;
+
+        var midY = minY + (boxHeight / 2);
+        var rowStart = (midY * width) + minX;
+        var rowEnd = rowStart + boxWidth;
+        var runs = new List<int>(64);
+        var lastDark = gray[rowStart] < threshold;
+        var run = 0;
+        for (var i = rowStart; i < rowEnd; i++) {
+            var dark = gray[i] < threshold;
+            if (dark == lastDark) {
+                run++;
+                continue;
+            }
+            if (run > 0) runs.Add(run);
+            run = 1;
+            lastDark = dark;
+        }
+        if (run > 0) runs.Add(run);
+        if (runs.Count == 0) return 0;
+
+        runs.Sort();
+        var take = runs.Count < 12 ? runs.Count : 12;
+        var smallSum = 0;
+        for (var i = 0; i < take; i++) smallSum += runs[i];
+        var moduleSize = Math.Max(1, smallSum / Math.Max(1, take));
+
+        var rawDim = (int)Math.Round(boxWidth / (double)moduleSize);
+        var version = ClampInt((int)Math.Round((rawDim - 17) / 4.0), 1, 40);
+        return (version * 4) + 17;
+    }
+
+    private static BitMatrix SampleModules(byte[] gray, int width, int height, int minX, int minY, int maxX, int maxY, byte threshold, int dimension) {
+        var matrix = new BitMatrix(dimension, dimension);
+        var boxWidth = (maxX - minX) + 1;
+        var boxHeight = (maxY - minY) + 1;
+        var stepX = boxWidth / (double)dimension;
+        var stepY = boxHeight / (double)dimension;
+
+        for (var y = 0; y < dimension; y++) {
+            var cy = minY + ((y + 0.5) * stepY);
+            var py = ClampInt((int)Math.Round(cy), 0, height - 1);
+            for (var x = 0; x < dimension; x++) {
+                var cx = minX + ((x + 0.5) * stepX);
+                var px = ClampInt((int)Math.Round(cx), 0, width - 1);
+                var idx = (py * width) + px;
+                matrix[x, y] = gray[idx] < threshold;
+            }
+        }
+
+        return matrix;
+    }
+
+    private static int ClampInt(int value, int min, int max) {
+        if (value < min) return min;
+        if (value > max) return max;
+        return value;
     }
 #endif
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,10 @@
     <!-- Avoid build failures caused by stale/Windows-only fallback folder paths from user/global NuGet configs. -->
     <RestoreFallbackFolders></RestoreFallbackFolders>
   </PropertyGroup>
+
+  <!-- Keep per-TFM obj folders isolated for the multi-target test project. -->
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'CodeGlyphX.Tests' and '$(TargetFramework)' != ''">
+    <BaseIntermediateOutputPath>obj/$(TargetFramework)/</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath>obj/$(TargetFramework)/</MSBuildProjectExtensionsPath>
+  </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ CodeGlyphX targets `netstandard2.0`, `net472`, `net8.0`, and `net10.0`. Most fea
 Notes:
 - `netstandard2.0` and `net472` require `System.Memory` 4.5.5 (automatically pulled by NuGet).
 - net8+ uses the full QR pixel pipeline; `net472`/`netstandard2.0` use a limited fallback for QR image decode via `QrImageDecoder` and byte[] overloads.
-- Runtime checks are available via `CodeGlyphXFeatures` (e.g., `SupportsQrPixelDecode`, `SupportsQrPixelDebug`).
+- Runtime checks are available via `CodeGlyphXFeatures` (e.g., `SupportsQrPixelDecode`, `SupportsQrPixelDecodeFallback`, `SupportsQrPixelDebug`).
 
 net472 capability notes (QR from images):
 - ✅ Clean/generated PNG/JPEG QR renders (including large module sizes)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dotnet add package CodeGlyphX
 
 ## Target Framework Feature Matrix
 
-CodeGlyphX targets `netstandard2.0`, `net472`, `net8.0`, and `net10.0`. Most features are available everywhere, but the QR pixel pipeline and Span-based APIs are net8+ only.
+CodeGlyphX targets `netstandard2.0`, `net472`, `net8.0`, and `net10.0`. Most features are available everywhere, but the full QR pixel pipeline and Span-based APIs are net8+ only.
 
 | Feature | net8.0 / net10.0 | net472 / netstandard2.0 |
 | --- | --- | --- |
@@ -62,18 +62,18 @@ CodeGlyphX targets `netstandard2.0`, `net472`, `net8.0`, and `net10.0`. Most fea
 | Decode from module grids (BitMatrix) | ✅ | ✅ |
 | Renderers + image file codecs (PNG/JPEG/SVG/PDF/etc) | ✅ | ✅ |
 | 1D/2D pixel decode (Barcode/DataMatrix/PDF417/Aztec) | ✅ | ✅ |
-| QR pixel decode from raw pixels / screenshots | ✅ | ⚠️ Not available (returns false) |
+| QR pixel decode from raw pixels / screenshots | ✅ | ⚠️ Limited fallback (clean/generated images) |
 | QR pixel debug rendering | ✅ | ✖ |
 | Span-based overloads | ✅ | ✖ (byte[] only) |
 
 Notes:
 - `netstandard2.0` and `net472` require `System.Memory` 4.5.5 (automatically pulled by NuGet).
-- `QrImageDecoder.TryDecodeImage(...)` and `QrDecoder.TryDecode(...)` from pixels are net8+ only.
+- net8+ uses the full QR pixel pipeline; `net472`/`netstandard2.0` use a limited fallback for QR image decode via `QrImageDecoder` and byte[] overloads.
 - Runtime checks are available via `CodeGlyphXFeatures` (e.g., `SupportsQrPixelDecode`, `SupportsQrPixelDebug`).
 
 Choosing a target:
-- Pick `net8.0`/`net10.0` when you need QR pixel decode from images/screenshots, pixel debug rendering, Span APIs, or maximum throughput.
-- Pick `net472`/`netstandard2.0` for legacy apps that only need encoding, rendering, and module-grid decode (QR pixel decode from images is unavailable).
+- Pick `net8.0`/`net10.0` when you need the most robust QR pixel decode from images/screenshots, pixel debug rendering, Span APIs, or maximum throughput.
+- Pick `net472`/`netstandard2.0` for legacy apps; QR image decode is available via a best-effort fallback, but it is less robust on heavily styled/artistic inputs.
 
 ## Decode (unified)
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Notes:
 - net8+ uses the full QR pixel pipeline; `net472`/`netstandard2.0` use a limited fallback for QR image decode via `QrImageDecoder` and byte[] overloads.
 - Runtime checks are available via `CodeGlyphXFeatures` (e.g., `SupportsQrPixelDecode`, `SupportsQrPixelDebug`).
 
+net472 capability notes (QR from images):
+- ✅ Clean/generated PNG/JPEG QR renders (including large module sizes)
+- ⚠️ Multi-code screenshots, heavy styling/art, blur, warp, and low-contrast scenes are best-effort
+- ✅ Recommended: run the quick smoke checklist in `Build/Net472-SmokeTest.md`
+
 Choosing a target:
 - Pick `net8.0`/`net10.0` when you need the most robust QR pixel decode from images/screenshots, pixel debug rendering, Span APIs, or maximum throughput.
 - Pick `net472`/`netstandard2.0` for legacy apps; QR image decode is available via a best-effort fallback, but it is less robust on heavily styled/artistic inputs.


### PR DESCRIPTION
Quick pack-runner runs are already tractable in practice, but the art reliability checks were only included in Full mode by default.

This change adds the `art` pack to the Quick default set so a normal quick run exercises stylized QR cases out of the box. The hard-art scenarios remain gated to Full mode by the scenario pack definitions.

Verification:
- `dotnet build CodeGlyphX.Benchmarks/CodeGlyphX.Benchmarks.csproj -c Release --framework net8.0`
- `dotnet run --project CodeGlyphX.Benchmarks/CodeGlyphX.Benchmarks.csproj -c Release --framework net8.0 -- --pack-runner --mode quick --pack art --iterations 1 --ops-cap 1`