### PR TITLE
Add QR-safe canvas frames (card/sticker)

### DIFF
--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -94,6 +94,28 @@ internal static class QrStyleBoardExample {
                     frameColor: R(18, 36, 66, 220),
                     accentColor: R(0, 150, 136, 220)))),
 
+            new("Top Badge", StyleDocs("top-badge"), () => BaseSticker(
+                fg: R(32, 48, 96),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(32, 48, 96), R(74, 112, 210), R(140, 210, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: Eye(QrPngEyeFrameStyle.DoubleRing, R(32, 48, 96), R(140, 210, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 28028),
+                canvas: CanvasBadge(
+                    background: R(246, 249, 255),
+                    badgeColor: R(32, 80, 200, 220),
+                    position: QrPngCanvasBadgePosition.Top))),
+
+            new("Ribbon Tab", StyleDocs("ribbon-tab"), () => BaseSticker(
+                fg: R(20, 38, 80),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(20, 38, 80), R(0, 150, 136), R(255, 127, 80)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: EyeGlow(R(20, 38, 80), R(0, 150, 136), R(255, 127, 80, 180)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 29029),
+                canvas: CanvasRibbon(
+                    background: R(250, 252, 255),
+                    ribbonColor: R(0, 150, 136, 220),
+                    position: QrPngCanvasBadgePosition.Bottom))),
+
             new("Candy Checker", StyleDocs("candy-checker"), () => BaseSticker(
                 fg: R(255, 107, 107),
                 palette: Palette(QrPngPaletteMode.Checker, 0, R(255, 107, 107), R(255, 217, 61)),
@@ -761,6 +783,51 @@ internal static class QrStyleBoardExample {
             ShadowOffsetX = 10,
             ShadowOffsetY = 14,
             ShadowColor = R(0, 0, 0, 64),
+        };
+    }
+
+    private static QrPngCanvasOptions CanvasBadge(Rgba32 background, Rgba32 badgeColor, QrPngCanvasBadgePosition position) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 34,
+            CornerRadiusPx = 28,
+            Background = background,
+            BorderPx = 2,
+            BorderColor = R(0, 0, 0, 18),
+            Badge = new QrPngCanvasBadgeOptions {
+                Shape = QrPngCanvasBadgeShape.Badge,
+                Position = position,
+                WidthPx = 140,
+                HeightPx = 34,
+                GapPx = 10,
+                CornerRadiusPx = 16,
+                Color = badgeColor,
+            },
+            ShadowOffsetX = 7,
+            ShadowOffsetY = 10,
+            ShadowColor = R(0, 0, 0, 55),
+        };
+    }
+
+    private static QrPngCanvasOptions CanvasRibbon(Rgba32 background, Rgba32 ribbonColor, QrPngCanvasBadgePosition position) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 36,
+            CornerRadiusPx = 28,
+            Background = background,
+            BorderPx = 2,
+            BorderColor = R(0, 0, 0, 18),
+            Badge = new QrPngCanvasBadgeOptions {
+                Shape = QrPngCanvasBadgeShape.Ribbon,
+                Position = position,
+                WidthPx = 150,
+                HeightPx = 30,
+                GapPx = 12,
+                CornerRadiusPx = 8,
+                TailPx = 12,
+                Color = ribbonColor,
+            },
+            ShadowOffsetX = 7,
+            ShadowOffsetY = 10,
+            ShadowColor = R(0, 0, 0, 55),
         };
     }
 

--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -71,6 +71,29 @@ internal static class QrStyleBoardExample {
                 scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.86, 1.0),
                 canvas: CanvasGradient(R(14, 18, 46), R(32, 26, 82)))),
 
+            new("Card Frame", StyleDocs("card-frame"), () => BaseSticker(
+                fg: R(24, 48, 120),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(24, 48, 120), R(52, 102, 220), R(110, 180, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: Eye(QrPngEyeFrameStyle.Badge, R(24, 48, 120), R(110, 180, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 26026),
+                canvas: CanvasCardFrame(
+                    start: R(245, 248, 255),
+                    end: R(224, 235, 255),
+                    frameColor: R(28, 64, 180, 220),
+                    innerFrameColor: R(120, 190, 255, 210)))),
+
+            new("Sticker Frame", StyleDocs("sticker-frame"), () => BaseSticker(
+                fg: R(18, 36, 66),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(18, 36, 66), R(0, 150, 136), R(255, 111, 97)),
+                shape: QrPngModuleShape.ConnectedSquircle,
+                eyes: EyeGlow(R(18, 36, 66), R(0, 150, 136), R(255, 111, 97, 180)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 27027),
+                canvas: CanvasStickerFrame(
+                    background: R(250, 252, 255),
+                    frameColor: R(18, 36, 66, 220),
+                    accentColor: R(0, 150, 136, 220)))),
+
             new("Candy Checker", StyleDocs("candy-checker"), () => BaseSticker(
                 fg: R(255, 107, 107),
                 palette: Palette(QrPngPaletteMode.Checker, 0, R(255, 107, 107), R(255, 217, 61)),
@@ -690,6 +713,54 @@ internal static class QrStyleBoardExample {
             ShadowOffsetX = 4,
             ShadowOffsetY = 6,
             ShadowColor = R(0, 0, 0, 45),
+        };
+    }
+
+    private static QrPngCanvasOptions CanvasCardFrame(Rgba32 start, Rgba32 end, Rgba32 frameColor, Rgba32 innerFrameColor) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 44,
+            CornerRadiusPx = 32,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = start,
+                EndColor = end,
+            },
+            BorderPx = 2,
+            BorderColor = R(255, 255, 255, 36),
+            Frame = new QrPngCanvasFrameOptions {
+                ThicknessPx = 16,
+                GapPx = 12,
+                RadiusPx = 28,
+                Color = frameColor,
+                InnerThicknessPx = 4,
+                InnerGapPx = 4,
+                InnerColor = innerFrameColor,
+            },
+            ShadowOffsetX = 8,
+            ShadowOffsetY = 12,
+            ShadowColor = R(0, 0, 0, 70),
+        };
+    }
+
+    private static QrPngCanvasOptions CanvasStickerFrame(Rgba32 background, Rgba32 frameColor, Rgba32 accentColor) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 42,
+            CornerRadiusPx = 36,
+            Background = background,
+            BorderPx = 6,
+            BorderColor = R(255, 255, 255),
+            Frame = new QrPngCanvasFrameOptions {
+                ThicknessPx = 12,
+                GapPx = 10,
+                RadiusPx = 30,
+                Color = frameColor,
+                InnerThicknessPx = 3,
+                InnerGapPx = 3,
+                InnerColor = accentColor,
+            },
+            ShadowOffsetX = 10,
+            ShadowOffsetY = 14,
+            ShadowColor = R(0, 0, 0, 64),
         };
     }
 

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1210,6 +1210,115 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_With_Canvas_Frame_Draws_Outside_Qr_Bounds() {
+        var qr = QrCodeEncoder.EncodeText("HELLO", QrErrorCorrectionLevel.H);
+        var moduleSize = 8;
+        var quietZone = 4;
+        var padding = 36;
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = padding,
+                CornerRadiusPx = 24,
+                Background = Rgba32.White,
+                Frame = new QrPngCanvasFrameOptions {
+                    ThicknessPx = 14,
+                    GapPx = 10,
+                    RadiusPx = 24,
+                    Color = new Rgba32(20, 40, 120, 220),
+                    InnerThicknessPx = 4,
+                    InnerGapPx = 4,
+                    InnerColor = new Rgba32(255, 120, 40, 220),
+                },
+            },
+        };
+
+        var png = QrPngRenderer.Render(qr.Modules, opts);
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var qrFullPx = (qr.Size + quietZone * 2) * moduleSize;
+        var qrX0 = padding;
+        var qrY0 = padding;
+        var qrX1 = qrX0 + qrFullPx - 1;
+        var qrY1 = qrY0 + qrFullPx - 1;
+
+        var foundFrame = false;
+        for (var y = 0; y < height && !foundFrame; y++) {
+            for (var x = 0; x < width; x++) {
+                if (x >= qrX0 && x <= qrX1 && y >= qrY0 && y <= qrY1) continue;
+                var p = y * stride + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                if (r != 255 || g != 255 || b != 255) {
+                    foundFrame = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.True(foundFrame, "Expected frame pixels outside the QR bounds.");
+    }
+
+    [Fact]
+    public void Render_With_Canvas_Frame_Clamps_To_Padding_And_Stays_Outside_Qr() {
+        var matrix = new BitMatrix(21, 21);
+        var moduleSize = 6;
+        var quietZone = 4;
+        var padding = 16;
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = padding,
+                CornerRadiusPx = 18,
+                Background = Rgba32.White,
+                Frame = new QrPngCanvasFrameOptions {
+                    ThicknessPx = 40,
+                    GapPx = 40,
+                    RadiusPx = 18,
+                    Color = new Rgba32(40, 80, 160, 220),
+                },
+            },
+        };
+
+        var png = QrPngRenderer.Render(matrix, opts);
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var qrFullPx = (matrix.Width + quietZone * 2) * moduleSize;
+        var qrX0 = padding;
+        var qrY0 = padding;
+        var qrX1 = qrX0 + qrFullPx - 1;
+        var qrY1 = qrY0 + qrFullPx - 1;
+
+        var foundFrame = false;
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                var p = y * stride + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+
+                var insideQr = x >= qrX0 && x <= qrX1 && y >= qrY0 && y <= qrY1;
+                if (insideQr) {
+                    Assert.True(r == 255 && g == 255 && b == 255, "Frame should not draw inside the QR bounds.");
+                } else if (r != 255 || g != 255 || b != 255) {
+                    foundFrame = true;
+                }
+            }
+        }
+
+        Assert.True(foundFrame, "Expected frame pixels outside the QR bounds.");
+    }
+
+    [Fact]
     public void Render_With_Eye_InsetRing_Leaves_Center_Light_And_Ring_Dark() {
         var qr = QrCodeEncoder.EncodeText("HELLO", QrErrorCorrectionLevel.H);
 

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -418,11 +418,27 @@ public static partial class QrEasy {
             Vignette = CloneVignette(canvas.Vignette),
             Grain = CloneGrain(canvas.Grain),
             Frame = CloneFrame(canvas.Frame),
+            Badge = CloneBadge(canvas.Badge),
             BorderPx = canvas.BorderPx,
             BorderColor = canvas.BorderColor,
             ShadowOffsetX = canvas.ShadowOffsetX,
             ShadowOffsetY = canvas.ShadowOffsetY,
             ShadowColor = canvas.ShadowColor,
+        };
+    }
+
+    private static QrPngCanvasBadgeOptions? CloneBadge(QrPngCanvasBadgeOptions? badge) {
+        if (badge is null) return null;
+        return new QrPngCanvasBadgeOptions {
+            Shape = badge.Shape,
+            Position = badge.Position,
+            WidthPx = badge.WidthPx,
+            HeightPx = badge.HeightPx,
+            GapPx = badge.GapPx,
+            OffsetPx = badge.OffsetPx,
+            CornerRadiusPx = badge.CornerRadiusPx,
+            Color = badge.Color,
+            TailPx = badge.TailPx,
         };
     }
 

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -417,11 +417,25 @@ public static partial class QrEasy {
             Halo = CloneHalo(canvas.Halo),
             Vignette = CloneVignette(canvas.Vignette),
             Grain = CloneGrain(canvas.Grain),
+            Frame = CloneFrame(canvas.Frame),
             BorderPx = canvas.BorderPx,
             BorderColor = canvas.BorderColor,
             ShadowOffsetX = canvas.ShadowOffsetX,
             ShadowOffsetY = canvas.ShadowOffsetY,
             ShadowColor = canvas.ShadowColor,
+        };
+    }
+
+    private static QrPngCanvasFrameOptions? CloneFrame(QrPngCanvasFrameOptions? frame) {
+        if (frame is null) return null;
+        return new QrPngCanvasFrameOptions {
+            ThicknessPx = frame.ThicknessPx,
+            GapPx = frame.GapPx,
+            RadiusPx = frame.RadiusPx,
+            Color = frame.Color,
+            InnerThicknessPx = frame.InnerThicknessPx,
+            InnerGapPx = frame.InnerGapPx,
+            InnerColor = frame.InnerColor,
         };
     }
 

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Decorative badge/tab/ribbon options drawn outside the QR bounds.
+/// </summary>
+public sealed class QrPngCanvasBadgeOptions {
+    /// <summary>
+    /// Badge shape.
+    /// </summary>
+    public QrPngCanvasBadgeShape Shape { get; set; } = QrPngCanvasBadgeShape.Badge;
+
+    /// <summary>
+    /// Badge position relative to the QR bounds.
+    /// </summary>
+    public QrPngCanvasBadgePosition Position { get; set; } = QrPngCanvasBadgePosition.Top;
+
+    /// <summary>
+    /// Badge width in pixels.
+    /// </summary>
+    public int WidthPx { get; set; } = 120;
+
+    /// <summary>
+    /// Badge height in pixels.
+    /// </summary>
+    public int HeightPx { get; set; } = 32;
+
+    /// <summary>
+    /// Gap between the QR bounds and the badge.
+    /// </summary>
+    public int GapPx { get; set; } = 8;
+
+    /// <summary>
+    /// Offset along the edge (horizontal for top/bottom, vertical for left/right).
+    /// </summary>
+    public int OffsetPx { get; set; }
+
+    /// <summary>
+    /// Badge corner radius in pixels.
+    /// </summary>
+    public int CornerRadiusPx { get; set; } = 12;
+
+    /// <summary>
+    /// Badge color.
+    /// </summary>
+    public Rgba32 Color { get; set; } = new(30, 40, 80, 220);
+
+    /// <summary>
+    /// Ribbon tail length in pixels (applies to <see cref="QrPngCanvasBadgeShape.Ribbon"/>).
+    /// </summary>
+    public int TailPx { get; set; } = 10;
+
+    internal void Validate() {
+        if (WidthPx < 0) throw new ArgumentOutOfRangeException(nameof(WidthPx));
+        if (HeightPx < 0) throw new ArgumentOutOfRangeException(nameof(HeightPx));
+        if (GapPx < 0) throw new ArgumentOutOfRangeException(nameof(GapPx));
+        if (CornerRadiusPx < 0) throw new ArgumentOutOfRangeException(nameof(CornerRadiusPx));
+        if (TailPx < 0) throw new ArgumentOutOfRangeException(nameof(TailPx));
+    }
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBadgePosition.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBadgePosition.cs
@@ -1,0 +1,39 @@
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Badge anchor position relative to the QR bounds.
+/// </summary>
+public enum QrPngCanvasBadgePosition {
+    /// <summary>
+    /// Above the QR (centered).
+    /// </summary>
+    Top,
+    /// <summary>
+    /// Below the QR (centered).
+    /// </summary>
+    Bottom,
+    /// <summary>
+    /// Left of the QR (centered).
+    /// </summary>
+    Left,
+    /// <summary>
+    /// Right of the QR (centered).
+    /// </summary>
+    Right,
+    /// <summary>
+    /// Above-left of the QR.
+    /// </summary>
+    TopLeft,
+    /// <summary>
+    /// Above-right of the QR.
+    /// </summary>
+    TopRight,
+    /// <summary>
+    /// Below-left of the QR.
+    /// </summary>
+    BottomLeft,
+    /// <summary>
+    /// Below-right of the QR.
+    /// </summary>
+    BottomRight
+}

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeShape.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeShape.cs
@@ -1,0 +1,19 @@
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Badge shapes drawn around the QR bounds.
+/// </summary>
+public enum QrPngCanvasBadgeShape {
+    /// <summary>
+    /// Rounded badge/pill.
+    /// </summary>
+    Badge,
+    /// <summary>
+    /// Tab-style rounded rectangle.
+    /// </summary>
+    Tab,
+    /// <summary>
+    /// Ribbon-style badge with optional tails.
+    /// </summary>
+    Ribbon
+}

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasFrameOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasFrameOptions.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Decorative frame options drawn around the QR bounds (outside the QR area).
+/// </summary>
+public sealed class QrPngCanvasFrameOptions {
+    /// <summary>
+    /// Frame thickness in pixels.
+    /// </summary>
+    public int ThicknessPx { get; set; } = 12;
+
+    /// <summary>
+    /// Gap between the QR bounds (including quiet zone) and the frame.
+    /// </summary>
+    public int GapPx { get; set; } = 8;
+
+    /// <summary>
+    /// Frame corner radius in pixels.
+    /// </summary>
+    public int RadiusPx { get; set; } = 20;
+
+    /// <summary>
+    /// Frame color.
+    /// </summary>
+    public Rgba32 Color { get; set; } = new(20, 24, 40, 220);
+
+    /// <summary>
+    /// Optional inner frame thickness in pixels (0 = disabled).
+    /// </summary>
+    public int InnerThicknessPx { get; set; }
+
+    /// <summary>
+    /// Gap from the QR bounds to the inner frame.
+    /// </summary>
+    public int InnerGapPx { get; set; } = 3;
+
+    /// <summary>
+    /// Optional inner frame color. When null, <see cref="Color"/> is used.
+    /// </summary>
+    public Rgba32? InnerColor { get; set; }
+
+    internal void Validate() {
+        if (ThicknessPx < 0) throw new ArgumentOutOfRangeException(nameof(ThicknessPx));
+        if (GapPx < 0) throw new ArgumentOutOfRangeException(nameof(GapPx));
+        if (RadiusPx < 0) throw new ArgumentOutOfRangeException(nameof(RadiusPx));
+        if (InnerThicknessPx < 0) throw new ArgumentOutOfRangeException(nameof(InnerThicknessPx));
+        if (InnerGapPx < 0) throw new ArgumentOutOfRangeException(nameof(InnerGapPx));
+    }
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
@@ -52,6 +52,11 @@ public sealed class QrPngCanvasOptions {
     public QrPngCanvasGrainOptions? Grain { get; set; }
 
     /// <summary>
+    /// Optional decorative frame drawn around the QR bounds (kept outside the QR area).
+    /// </summary>
+    public QrPngCanvasFrameOptions? Frame { get; set; }
+
+    /// <summary>
     /// Border thickness in pixels (0 = no border).
     /// </summary>
     public int BorderPx { get; set; }
@@ -86,5 +91,6 @@ public sealed class QrPngCanvasOptions {
         Halo?.Validate();
         Vignette?.Validate();
         Grain?.Validate();
+        Frame?.Validate();
     }
 }

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
@@ -57,6 +57,11 @@ public sealed class QrPngCanvasOptions {
     public QrPngCanvasFrameOptions? Frame { get; set; }
 
     /// <summary>
+    /// Optional badge/tab/ribbon drawn outside the QR bounds.
+    /// </summary>
+    public QrPngCanvasBadgeOptions? Badge { get; set; }
+
+    /// <summary>
     /// Border thickness in pixels (0 = no border).
     /// </summary>
     public int BorderPx { get; set; }
@@ -92,5 +97,6 @@ public sealed class QrPngCanvasOptions {
         Vignette?.Validate();
         Grain?.Validate();
         Frame?.Validate();
+        Badge?.Validate();
     }
 }

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1367,11 +1367,27 @@ public static partial class QrPngRenderer {
             Vignette = ScaleVignette(canvas.Vignette, scale),
             Grain = ScaleGrain(canvas.Grain, scale),
             Frame = ScaleFrame(canvas.Frame, scale),
+            Badge = ScaleBadge(canvas.Badge, scale),
             BorderPx = canvas.BorderPx * scale,
             BorderColor = canvas.BorderColor,
             ShadowOffsetX = canvas.ShadowOffsetX * scale,
             ShadowOffsetY = canvas.ShadowOffsetY * scale,
             ShadowColor = canvas.ShadowColor
+        };
+    }
+
+    private static QrPngCanvasBadgeOptions? ScaleBadge(QrPngCanvasBadgeOptions? badge, int scale) {
+        if (badge is null) return null;
+        return new QrPngCanvasBadgeOptions {
+            Shape = badge.Shape,
+            Position = badge.Position,
+            WidthPx = badge.WidthPx <= 0 ? 0 : Math.Max(1, badge.WidthPx * scale),
+            HeightPx = badge.HeightPx <= 0 ? 0 : Math.Max(1, badge.HeightPx * scale),
+            GapPx = Math.Max(0, badge.GapPx * scale),
+            OffsetPx = badge.OffsetPx * scale,
+            CornerRadiusPx = Math.Max(0, badge.CornerRadiusPx * scale),
+            Color = badge.Color,
+            TailPx = Math.Max(0, badge.TailPx * scale),
         };
     }
 

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1366,11 +1366,25 @@ public static partial class QrPngRenderer {
             Halo = ScaleHalo(canvas.Halo, scale),
             Vignette = ScaleVignette(canvas.Vignette, scale),
             Grain = ScaleGrain(canvas.Grain, scale),
+            Frame = ScaleFrame(canvas.Frame, scale),
             BorderPx = canvas.BorderPx * scale,
             BorderColor = canvas.BorderColor,
             ShadowOffsetX = canvas.ShadowOffsetX * scale,
             ShadowOffsetY = canvas.ShadowOffsetY * scale,
             ShadowColor = canvas.ShadowColor
+        };
+    }
+
+    private static QrPngCanvasFrameOptions? ScaleFrame(QrPngCanvasFrameOptions? frame, int scale) {
+        if (frame is null) return null;
+        return new QrPngCanvasFrameOptions {
+            ThicknessPx = frame.ThicknessPx <= 0 ? 0 : Math.Max(1, frame.ThicknessPx * scale),
+            GapPx = Math.Max(0, frame.GapPx * scale),
+            RadiusPx = Math.Max(0, frame.RadiusPx * scale),
+            Color = frame.Color,
+            InnerThicknessPx = frame.InnerThicknessPx <= 0 ? 0 : Math.Max(1, frame.InnerThicknessPx * scale),
+            InnerGapPx = Math.Max(0, frame.InnerGapPx * scale),
+            InnerColor = frame.InnerColor,
         };
     }
 


### PR DESCRIPTION
## Summary
Adds QR-safe canvas frames plus decorative badges/tabs/ribbons that render entirely outside the QR bounds, with new style-board presets and tests.

## Changes
- Add `QrPngCanvasFrameOptions` (frame ring) and `QrPngCanvasBadgeOptions` (badge/tab/ribbon).
- Extend `QrPngCanvasOptions` validation and cloning.
- Scale frame/badge options during supersampling.
- Render frames as true rings (preserving canvas effects) with canvas rounded-rect clipping.
- Render badge/tab/ribbon shapes outside the QR bounds with optional ribbon tails.
- Add style-board presets: Card Frame, Sticker Frame, Top Badge, Ribbon Tab.
- Add renderer tests for frame and badge/ribbon placement safety.

## Safety
- All decorations are positioned relative to QR bounds and clamped to available padding.
- Rendering is clipped to the canvas rounded-rect silhouette.

## Validation
- `dotnet build -c Release`
- `dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release --filter "FullyQualifiedName~QrPngRendererTests|FullyQualifiedName~QrArtAutoTuneTests|FullyQualifiedName~QrArtSafetyPresetsTests|FullyQualifiedName~RendererFormatTests"`
- `dotnet run -c Release --project CodeGlyphX.Examples/CodeGlyphX.Examples.csproj`
