### PR TITLE
Add canvas bands and edge patterns for QR art

### DIFF
--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -289,6 +289,45 @@ internal static class QrStyleBoardExample {
                 pattern: Speckle(R(0, 80, 120, 96), seed: 4242, sizePx: 7, thicknessPx: 2, variation: 0.84, density: 0.94),
                 canvas: CanvasGradient(R(8, 20, 36), R(16, 44, 72)))),
 
+            new("Bead Cluster", StyleDocs("bead-cluster"), () => BaseSticker(
+                fg: R(18, 32, 72),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(18, 32, 72), R(52, 130, 200), R(0, 180, 150)),
+                shape: QrPngModuleShape.Rounded,
+                eyes: Eye(QrPngEyeFrameStyle.Target, R(18, 32, 72), R(255, 255, 255)),
+                pattern: new QrPngForegroundPatternOptions {
+                    Type = QrPngForegroundPatternType.StippleDots,
+                    SizePx = 5,
+                    ThicknessPx = 2,
+                    BlendMode = QrPngForegroundPatternBlendMode.Mask,
+                    ApplyToModules = true,
+                },
+                canvas: CanvasGradient(R(238, 244, 255), R(214, 228, 248)))),
+
+            new("Shape Blend", StyleDocs("shape-blend"), () => BaseSticker(
+                fg: R(30, 44, 84),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(30, 44, 84), R(64, 120, 190), R(120, 190, 255)),
+                shape: QrPngModuleShape.Squircle,
+                eyes: EyeGlow(R(30, 44, 84), R(120, 190, 255), R(64, 120, 190, 160)),
+                shapeMap: new QrPngModuleShapeMapOptions {
+                    Mode = QrPngModuleShapeMapMode.Radial,
+                    PrimaryShape = QrPngModuleShape.Dot,
+                    SecondaryShape = QrPngModuleShape.Squircle,
+                    Split = 0.55,
+                },
+                canvas: CanvasGradient(R(244, 248, 255), R(220, 232, 248)))),
+
+            new("Jittered Ink", StyleDocs("jittered-ink"), () => BaseSticker(
+                fg: R(24, 28, 40),
+                palette: Palette(QrPngPaletteMode.Random, 7071, R(24, 28, 40), R(60, 90, 140), R(220, 140, 90)),
+                shape: QrPngModuleShape.Blob,
+                eyes: EyeInsetRing(R(24, 28, 40), R(220, 140, 90)),
+                jitter: new QrPngModuleJitterOptions {
+                    MaxOffsetPx = 2,
+                    Seed = 7071,
+                    ClampToShape = true,
+                },
+                canvas: CanvasGradient(R(246, 242, 236), R(230, 220, 208)))),
+
             new("Edge Drips", StyleDocs("edge-drips"), () => BaseSticker(
                 fg: R(22, 40, 92),
                 palette: Palette(QrPngPaletteMode.Cycle, 0, R(22, 40, 92), R(24, 138, 216), R(0, 190, 150)),
@@ -517,6 +556,8 @@ internal static class QrStyleBoardExample {
         QrPngEyeOptions eyes,
         QrPngCanvasOptions canvas,
         QrPngModuleScaleMapOptions? scaleMap = null,
+        QrPngModuleShapeMapOptions? shapeMap = null,
+        QrPngModuleJitterOptions? jitter = null,
         QrPngPaletteZoneOptions? zones = null,
         QrPngForegroundPatternOptions? pattern = null,
         byte[]? logo = null,
@@ -536,6 +577,8 @@ internal static class QrStyleBoardExample {
             ForegroundPalette = palette,
             ForegroundPaletteZones = zones,
             ModuleScaleMap = scaleMap,
+            ModuleShapeMap = shapeMap,
+            ModuleJitter = jitter,
             ForegroundPattern = pattern,
             Eyes = eyes,
             Canvas = canvas,

--- a/CodeGlyphX.Examples/QrStyleBoardExample.cs
+++ b/CodeGlyphX.Examples/QrStyleBoardExample.cs
@@ -116,6 +116,62 @@ internal static class QrStyleBoardExample {
                     ribbonColor: R(0, 150, 136, 220),
                     position: QrPngCanvasBadgePosition.Bottom))),
 
+            new("Gradient Frame", StyleDocs("gradient-frame"), () => BaseSticker(
+                fg: R(24, 40, 100),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(24, 40, 100), R(64, 120, 220), R(150, 210, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: Eye(QrPngEyeFrameStyle.Target, R(24, 40, 100), R(150, 210, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 30030),
+                canvas: CanvasGradientFrame(
+                    bgStart: R(246, 249, 255),
+                    bgEnd: R(220, 235, 255),
+                    frameStart: R(24, 84, 220),
+                    frameEnd: R(120, 210, 255)))),
+
+            new("Stitched Frame", StyleDocs("stitched-frame"), () => BaseSticker(
+                fg: R(28, 28, 48),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(28, 28, 48), R(96, 130, 210), R(255, 189, 89)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: Eye(QrPngEyeFrameStyle.Single, R(28, 28, 48), R(255, 189, 89)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 31031),
+                canvas: CanvasStitchedFrame(
+                    background: R(252, 250, 245),
+                    stitchColor: R(28, 28, 48, 190)))),
+
+            new("Quiet Band", StyleDocs("quiet-band"), () => BaseSticker(
+                fg: R(16, 30, 62),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(16, 30, 62), R(60, 120, 200), R(150, 210, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: EyeInsetRing(R(16, 30, 62), R(150, 210, 255)),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 32032),
+                canvas: CanvasBand(
+                    background: R(248, 251, 255),
+                    bandStart: R(60, 120, 200, 210),
+                    bandEnd: R(150, 210, 255, 210)))),
+
+            new("Warm Harmony", StyleDocs("warm-harmony"), () => {
+                var warm = QrArtPalettes.Warm();
+                return BaseSticker(
+                    fg: warm.Foreground,
+                    palette: warm.Palette,
+                    shape: QrPngModuleShape.ConnectedRounded,
+                    eyes: QrEyePresets.MinimalRing(),
+                    canvas: CanvasBadge(
+                        background: warm.Background,
+                        badgeColor: R(201, 86, 46, 210),
+                        position: QrPngCanvasBadgePosition.Top),
+                    background: warm.Background);
+            }),
+
+            new("Eye Sparkle", StyleDocs("eye-sparkle"), () => BaseSticker(
+                fg: R(0, 240, 220),
+                palette: Palette(QrPngPaletteMode.Cycle, 0, R(0, 240, 220), R(64, 180, 255)),
+                shape: QrPngModuleShape.ConnectedRounded,
+                eyes: QrEyePresets.NeonSparkle(),
+                scaleMap: ScaleMap(QrPngModuleScaleMode.Radial, 0.9, 1.0, 33033),
+                canvas: CanvasGradient(R(10, 12, 22), R(30, 34, 64)),
+                background: R(10, 12, 22))),
+
             new("Candy Checker", StyleDocs("candy-checker"), () => BaseSticker(
                 fg: R(255, 107, 107),
                 palette: Palette(QrPngPaletteMode.Checker, 0, R(255, 107, 107), R(255, 217, 61)),
@@ -463,7 +519,8 @@ internal static class QrStyleBoardExample {
         QrPngModuleScaleMapOptions? scaleMap = null,
         QrPngPaletteZoneOptions? zones = null,
         QrPngForegroundPatternOptions? pattern = null,
-        byte[]? logo = null) {
+        byte[]? logo = null,
+        Rgba32? background = null) {
         return new QrEasyOptions {
             ErrorCorrectionLevel = QrErrorCorrectionLevel.H,
             // Web-friendly size: keeps assets lightweight while remaining crisp in the grid.
@@ -472,7 +529,7 @@ internal static class QrStyleBoardExample {
             ModuleSize = 10,
             QuietZone = 4,
             Foreground = fg,
-            Background = R(255, 255, 255),
+            Background = background ?? R(255, 255, 255),
             BackgroundSupersample = 2,
             ModuleShape = shape,
             ModuleScale = 0.9,
@@ -786,6 +843,97 @@ internal static class QrStyleBoardExample {
         };
     }
 
+    private static QrPngCanvasOptions CanvasGradientFrame(Rgba32 bgStart, Rgba32 bgEnd, Rgba32 frameStart, Rgba32 frameEnd) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 34,
+            CornerRadiusPx = 30,
+            BackgroundGradient = new QrPngGradientOptions {
+                Type = QrPngGradientType.DiagonalDown,
+                StartColor = bgStart,
+                EndColor = bgEnd,
+            },
+            BorderPx = 2,
+            BorderColor = R(255, 255, 255, 36),
+            Frame = new QrPngCanvasFrameOptions {
+                ThicknessPx = 14,
+                GapPx = 10,
+                RadiusPx = 26,
+                Gradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.DiagonalDown,
+                    StartColor = frameStart,
+                    EndColor = frameEnd,
+                },
+                EdgePattern = EdgePattern(QrPngCanvasEdgePatternType.Dots, R(255, 255, 255, 160), thicknessPx: 2, spacingPx: 8, dashPx: 10),
+            },
+            ShadowOffsetX = 7,
+            ShadowOffsetY = 10,
+            ShadowColor = R(0, 0, 0, 60),
+        };
+    }
+
+    private static QrPngCanvasOptions CanvasStitchedFrame(Rgba32 background, Rgba32 stitchColor) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 32,
+            CornerRadiusPx = 26,
+            Background = background,
+            BorderPx = 2,
+            BorderColor = R(0, 0, 0, 18),
+            Frame = new QrPngCanvasFrameOptions {
+                ThicknessPx = 12,
+                GapPx = 10,
+                RadiusPx = 22,
+                Color = R(255, 255, 255),
+                EdgePattern = EdgePattern(QrPngCanvasEdgePatternType.Stitches, stitchColor, thicknessPx: 2, spacingPx: 10, dashPx: 6, insetPx: 2),
+            },
+            ShadowOffsetX = 6,
+            ShadowOffsetY = 9,
+            ShadowColor = R(0, 0, 0, 50),
+        };
+    }
+
+    private static QrPngCanvasOptions CanvasBand(Rgba32 background, Rgba32 bandStart, Rgba32 bandEnd) {
+        return new QrPngCanvasOptions {
+            PaddingPx = 28,
+            CornerRadiusPx = 24,
+            Background = background,
+            BorderPx = 2,
+            BorderColor = R(0, 0, 0, 18),
+            Band = new QrPngCanvasBandOptions {
+                BandPx = 12,
+                GapPx = 0,
+                RadiusPx = 20,
+                Gradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.Radial,
+                    StartColor = bandStart,
+                    EndColor = bandEnd,
+                    CenterX = 0.3,
+                    CenterY = 0.3,
+                },
+                EdgePattern = EdgePattern(QrPngCanvasEdgePatternType.Dashes, R(255, 255, 255, 140), thicknessPx: 2, spacingPx: 10, dashPx: 8, insetPx: 1),
+            },
+            ShadowOffsetX = 6,
+            ShadowOffsetY = 9,
+            ShadowColor = R(0, 0, 0, 50),
+        };
+    }
+
+    private static QrPngCanvasEdgePatternOptions EdgePattern(
+        QrPngCanvasEdgePatternType type,
+        Rgba32 color,
+        int thicknessPx = 2,
+        int spacingPx = 8,
+        int dashPx = 10,
+        int insetPx = 1) {
+        return new QrPngCanvasEdgePatternOptions {
+            Type = type,
+            Color = color,
+            ThicknessPx = thicknessPx,
+            SpacingPx = spacingPx,
+            DashPx = dashPx,
+            InsetPx = insetPx,
+        };
+    }
+
     private static QrPngCanvasOptions CanvasBadge(Rgba32 background, Rgba32 badgeColor, QrPngCanvasBadgePosition position) {
         return new QrPngCanvasOptions {
             PaddingPx = 34,
@@ -801,6 +949,7 @@ internal static class QrStyleBoardExample {
                 GapPx = 10,
                 CornerRadiusPx = 16,
                 Color = badgeColor,
+                EdgePattern = EdgePattern(QrPngCanvasEdgePatternType.Dots, R(255, 255, 255, 150), thicknessPx: 2, spacingPx: 10, dashPx: 8, insetPx: 2),
             },
             ShadowOffsetX = 7,
             ShadowOffsetY = 10,
@@ -824,6 +973,7 @@ internal static class QrStyleBoardExample {
                 CornerRadiusPx = 8,
                 TailPx = 12,
                 Color = ribbonColor,
+                EdgePattern = EdgePattern(QrPngCanvasEdgePatternType.Dashes, R(255, 255, 255, 150), thicknessPx: 2, spacingPx: 10, dashPx: 8, insetPx: 2),
             },
             ShadowOffsetX = 7,
             ShadowOffsetY = 10,

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1650,8 +1650,7 @@ public sealed class QrPngRendererTests {
         }
 
         Assert.True(maxX >= 0, "Expected badge pixels outside the QR bounds.");
-        Assert.True(maxX - minX == 0, "Expected no ribbon tails outside the badge bounds.");
-        Assert.True(maxY - minY == 0, "Expected no ribbon tails outside the badge bounds.");
+        Assert.True(maxX - minX == 0 && maxY - minY == 0, "Expected no ribbon tails outside the badge bounds.");
     }
 
     [Fact]

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1535,7 +1535,6 @@ public sealed class QrPngRendererTests {
         }
 
         Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
-        Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
     }
 
     [Fact]

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1535,6 +1535,123 @@ public sealed class QrPngRendererTests {
         }
 
         Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
+        Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
+    }
+
+    [Fact]
+    public void Render_With_Zero_Size_Badge_Skips_Drawing() {
+        var matrix = new BitMatrix(21, 21);
+        var moduleSize = 6;
+        var quietZone = 4;
+        var padding = 20;
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = padding,
+                Background = Rgba32.White,
+                Badge = new QrPngCanvasBadgeOptions {
+                    Shape = QrPngCanvasBadgeShape.Badge,
+                    Position = QrPngCanvasBadgePosition.Top,
+                    WidthPx = 0,
+                    HeightPx = 24,
+                    GapPx = 8,
+                    Color = new Rgba32(200, 20, 60, 220),
+                },
+            },
+        };
+
+        var png = QrPngRenderer.Render(matrix, opts);
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var qrFullPx = (matrix.Width + quietZone * 2) * moduleSize;
+        var qrX0 = padding;
+        var qrY0 = padding;
+        var qrX1 = qrX0 + qrFullPx - 1;
+        var qrY1 = qrY0 + qrFullPx - 1;
+
+        var foundBadge = false;
+        for (var y = 0; y < height && !foundBadge; y++) {
+            for (var x = 0; x < width; x++) {
+                if (x >= qrX0 && x <= qrX1 && y >= qrY0 && y <= qrY1) continue;
+                var p = y * stride + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                if (r != 255 || g != 255 || b != 255) {
+                    foundBadge = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.False(foundBadge, "Did not expect badge pixels outside the QR bounds.");
+    }
+
+    [Fact]
+    public void Render_With_Tiny_Ribbon_Badge_Skips_Tails() {
+        var matrix = new BitMatrix(21, 21);
+        var moduleSize = 5;
+        var quietZone = 4;
+        var padding = 12;
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = padding,
+                Background = Rgba32.White,
+                Badge = new QrPngCanvasBadgeOptions {
+                    Shape = QrPngCanvasBadgeShape.Ribbon,
+                    Position = QrPngCanvasBadgePosition.Top,
+                    WidthPx = 1,
+                    HeightPx = 1,
+                    GapPx = 6,
+                    TailPx = 20,
+                    CornerRadiusPx = 0,
+                    Color = new Rgba32(180, 30, 80, 220),
+                },
+            },
+        };
+
+        var png = QrPngRenderer.Render(matrix, opts);
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var qrFullPx = (matrix.Width + quietZone * 2) * moduleSize;
+        var qrX0 = padding;
+        var qrY0 = padding;
+        var qrX1 = qrX0 + qrFullPx - 1;
+        var qrY1 = qrY0 + qrFullPx - 1;
+
+        var minX = width;
+        var minY = height;
+        var maxX = -1;
+        var maxY = -1;
+
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                if (x >= qrX0 && x <= qrX1 && y >= qrY0 && y <= qrY1) continue;
+                var p = y * stride + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                if (r == 255 && g == 255 && b == 255) continue;
+
+                if (x < minX) minX = x;
+                if (y < minY) minY = y;
+                if (x > maxX) maxX = x;
+                if (y > maxY) maxY = y;
+            }
+        }
+
+        Assert.True(maxX >= 0, "Expected badge pixels outside the QR bounds.");
+        Assert.True(maxX - minX == 0, "Expected no ribbon tails outside the badge bounds.");
+        Assert.True(maxY - minY == 0, "Expected no ribbon tails outside the badge bounds.");
     }
 
     [Fact]

--- a/CodeGlyphX/QR.Builder.cs
+++ b/CodeGlyphX/QR.Builder.cs
@@ -124,6 +124,22 @@ public static partial class QR {
         }
 
         /// <summary>
+        /// Sets module shape map.
+        /// </summary>
+        public QrBuilder WithModuleShapeMap(QrPngModuleShapeMapOptions? map) {
+            Options.ModuleShapeMap = map;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets per-module jitter options.
+        /// </summary>
+        public QrBuilder WithModuleJitter(QrPngModuleJitterOptions? jitter) {
+            Options.ModuleJitter = jitter;
+            return this;
+        }
+
+        /// <summary>
         /// Sets module corner radius in pixels.
         /// </summary>
         public QrBuilder WithModuleCornerRadiusPx(int radiusPx) {

--- a/CodeGlyphX/QrArtPalettes.cs
+++ b/CodeGlyphX/QrArtPalettes.cs
@@ -1,0 +1,106 @@
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// Curated, scan-friendly palette sets for QR art.
+/// </summary>
+public static class QrArtPalettes {
+    /// <summary>
+    /// Warm palette with high contrast on a light background.
+    /// </summary>
+    public static QrArtPalette Warm() => new(
+        background: new Rgba32(252, 248, 242),
+        foreground: new Rgba32(120, 46, 28),
+        colors: new[] {
+            new Rgba32(120, 46, 28),
+            new Rgba32(201, 86, 46),
+            new Rgba32(248, 162, 73),
+            new Rgba32(255, 206, 124),
+        });
+
+    /// <summary>
+    /// Cool palette with high contrast on a light background.
+    /// </summary>
+    public static QrArtPalette Cool() => new(
+        background: new Rgba32(246, 249, 255),
+        foreground: new Rgba32(18, 36, 88),
+        colors: new[] {
+            new Rgba32(18, 36, 88),
+            new Rgba32(32, 96, 190),
+            new Rgba32(74, 156, 255),
+            new Rgba32(122, 204, 255),
+        });
+
+    /// <summary>
+    /// Pastel palette with contrast-anchored accents.
+    /// </summary>
+    public static QrArtPalette Pastel() => new(
+        background: new Rgba32(255, 252, 250),
+        foreground: new Rgba32(74, 72, 102),
+        colors: new[] {
+            new Rgba32(74, 72, 102),
+            new Rgba32(148, 120, 196),
+            new Rgba32(238, 156, 182),
+            new Rgba32(148, 210, 192),
+        });
+
+    /// <summary>
+    /// High-contrast palette suitable for strong scanning reliability.
+    /// </summary>
+    public static QrArtPalette HighContrast() => new(
+        background: new Rgba32(248, 248, 248),
+        foreground: new Rgba32(18, 18, 18),
+        colors: new[] {
+            new Rgba32(18, 18, 18),
+            new Rgba32(0, 88, 150),
+            new Rgba32(0, 150, 88),
+            new Rgba32(150, 44, 0),
+        });
+
+    /// <summary>
+    /// Neon palette for dark canvases.
+    /// </summary>
+    public static QrArtPalette Neon() => new(
+        background: new Rgba32(10, 12, 22),
+        foreground: new Rgba32(0, 240, 220),
+        colors: new[] {
+            new Rgba32(0, 240, 220),
+            new Rgba32(64, 180, 255),
+            new Rgba32(255, 92, 255),
+            new Rgba32(255, 220, 80),
+        });
+}
+
+/// <summary>
+/// Palette bundle with a suggested background/foreground and palette.
+/// </summary>
+public readonly struct QrArtPalette {
+    /// <summary>
+    /// Suggested background color.
+    /// </summary>
+    public Rgba32 Background { get; }
+
+    /// <summary>
+    /// Suggested foreground color.
+    /// </summary>
+    public Rgba32 Foreground { get; }
+
+    /// <summary>
+    /// Palette options for the foreground.
+    /// </summary>
+    public QrPngPaletteOptions Palette { get; }
+
+    /// <summary>
+    /// Create a palette bundle.
+    /// </summary>
+    public QrArtPalette(Rgba32 background, Rgba32 foreground, Rgba32[] colors) {
+        Background = background;
+        Foreground = foreground;
+        Palette = new QrPngPaletteOptions {
+            Mode = QrPngPaletteMode.Cycle,
+            Colors = colors ?? new[] { foreground },
+        };
+    }
+}
+

--- a/CodeGlyphX/QrArtSafety.cs
+++ b/CodeGlyphX/QrArtSafety.cs
@@ -139,6 +139,8 @@ public static class QrArtSafety {
         var hasDecorativeModules = options.ModuleShape != QrPngModuleShape.Square
             || options.ModuleScale < 1.0
             || options.ModuleScaleMap is not null
+            || options.ModuleShapeMap is not null
+            || options.ModuleJitter is not null
             || options.ForegroundGradient is not null
             || options.ForegroundPalette is not null
             || options.ForegroundPattern is not null
@@ -157,7 +159,7 @@ public static class QrArtSafety {
             ? new[] { options.Background }
             : new[] { options.BackgroundGradient.StartColor, options.BackgroundGradient.EndColor };
         var pattern = options.ForegroundPattern;
-        var patternActive = pattern is not null && pattern.Color.A != 0 && pattern.ThicknessPx > 0;
+        var patternActive = pattern is not null && pattern.ThicknessPx > 0 && (pattern.BlendMode == QrPngForegroundPatternBlendMode.Mask || pattern.Color.A != 0);
 
         if (options.ForegroundPalette is not null || options.ForegroundPaletteZones is not null) {
             var palettes = CollectPalettes(options.ForegroundPalette, options.ForegroundPaletteZones);

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -86,6 +86,8 @@ public static partial class QrEasy {
         if (opts.ForegroundPattern is not null) render.ForegroundPattern = opts.ForegroundPattern;
         if (opts.ForegroundPaletteZones is not null) render.ForegroundPaletteZones = opts.ForegroundPaletteZones;
         if (opts.ModuleScaleMap is not null) render.ModuleScaleMap = opts.ModuleScaleMap;
+        if (opts.ModuleShapeMap is not null) render.ModuleShapeMap = opts.ModuleShapeMap;
+        if (opts.ModuleJitter is not null) render.ModuleJitter = opts.ModuleJitter;
         if (opts.Canvas is not null) render.Canvas = opts.Canvas;
         if (opts.Eyes is not null) render.Eyes = opts.Eyes;
 
@@ -236,6 +238,8 @@ public static partial class QrEasy {
             ModuleShape = opts.ModuleShape,
             ModuleScale = opts.ModuleScale,
             ModuleScaleMap = CloneScaleMap(opts.ModuleScaleMap),
+            ModuleShapeMap = CloneShapeMap(opts.ModuleShapeMap),
+            ModuleJitter = CloneJitter(opts.ModuleJitter),
             ProtectFunctionalPatterns = opts.ProtectFunctionalPatterns,
             ProtectQuietZone = opts.ProtectQuietZone,
             ModuleCornerRadiusPx = opts.ModuleCornerRadiusPx,
@@ -298,6 +302,7 @@ public static partial class QrEasy {
             ModuleStep = pattern.ModuleStep,
             ApplyToModules = pattern.ApplyToModules,
             ApplyToEyes = pattern.ApplyToEyes,
+            BlendMode = pattern.BlendMode,
         };
     }
 
@@ -312,6 +317,34 @@ public static partial class QrEasy {
             ApplyToEyes = map.ApplyToEyes,
         };
     }
+
+    private static QrPngModuleShapeMapOptions? CloneShapeMap(QrPngModuleShapeMapOptions? map) {
+        if (map is null) return null;
+        return new QrPngModuleShapeMapOptions {
+            Mode = map.Mode,
+            PrimaryShape = map.PrimaryShape,
+            SecondaryShape = map.SecondaryShape,
+            Split = map.Split,
+            RingSize = map.RingSize,
+            Seed = map.Seed,
+            SecondaryChance = map.SecondaryChance,
+            CornerSize = map.CornerSize,
+            ApplyToEyes = map.ApplyToEyes,
+            ProtectFunctionalPatterns = map.ProtectFunctionalPatterns,
+        };
+    }
+
+    private static QrPngModuleJitterOptions? CloneJitter(QrPngModuleJitterOptions? jitter) {
+        if (jitter is null) return null;
+        return new QrPngModuleJitterOptions {
+            MaxOffsetPx = jitter.MaxOffsetPx,
+            Seed = jitter.Seed,
+            ApplyToEyes = jitter.ApplyToEyes,
+            ProtectFunctionalPatterns = jitter.ProtectFunctionalPatterns,
+            ClampToShape = jitter.ClampToShape,
+        };
+    }
+
 
     private static QrPngPaletteOptions? ClonePalette(QrPngPaletteOptions? palette) {
         if (palette is null) return null;
@@ -614,6 +647,8 @@ public static partial class QrEasy {
         if (preset.ModuleScale.HasValue) render.ModuleScale = preset.ModuleScale.Value;
         if (preset.ModuleCornerRadiusPx.HasValue) render.ModuleCornerRadiusPx = preset.ModuleCornerRadiusPx.Value;
         if (preset.ModuleScaleMap is not null) render.ModuleScaleMap = preset.ModuleScaleMap;
+        if (preset.ModuleShapeMap is not null) render.ModuleShapeMap = preset.ModuleShapeMap;
+        if (preset.ModuleJitter is not null) render.ModuleJitter = preset.ModuleJitter;
         if (preset.ForegroundGradient is not null) render.ForegroundGradient = preset.ForegroundGradient;
         if (preset.ForegroundPalette is not null) render.ForegroundPalette = preset.ForegroundPalette;
         if (preset.ForegroundPattern is not null) render.ForegroundPattern = preset.ForegroundPattern;
@@ -714,6 +749,8 @@ public static partial class QrEasy {
             || eyes.AccentStripeCount > 0);
         var hasArtHints = opts.Art is not null
             || opts.ForegroundPattern is not null
+            || opts.ModuleShapeMap is not null
+            || opts.ModuleJitter is not null
             || canvasIsArt
             || eyesIsArt
             || paletteIsArt;
@@ -758,6 +795,8 @@ public static partial class QrEasy {
             || eyes.AccentStripeCount > 0);
         var hasArtHints = opts.Art is not null
             || render.ForegroundPattern is not null
+            || render.ModuleShapeMap is not null
+            || render.ModuleJitter is not null
             || canvasIsArt
             || eyesIsArt
             || paletteIsArt;

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -418,6 +418,7 @@ public static partial class QrEasy {
             Vignette = CloneVignette(canvas.Vignette),
             Grain = CloneGrain(canvas.Grain),
             Frame = CloneFrame(canvas.Frame),
+            Band = CloneBand(canvas.Band),
             Badge = CloneBadge(canvas.Badge),
             BorderPx = canvas.BorderPx,
             BorderColor = canvas.BorderColor,
@@ -438,6 +439,8 @@ public static partial class QrEasy {
             OffsetPx = badge.OffsetPx,
             CornerRadiusPx = badge.CornerRadiusPx,
             Color = badge.Color,
+            Gradient = CloneGradient(badge.Gradient),
+            EdgePattern = CloneEdgePattern(badge.EdgePattern),
             TailPx = badge.TailPx,
         };
     }
@@ -449,9 +452,37 @@ public static partial class QrEasy {
             GapPx = frame.GapPx,
             RadiusPx = frame.RadiusPx,
             Color = frame.Color,
+            Gradient = CloneGradient(frame.Gradient),
+            EdgePattern = CloneEdgePattern(frame.EdgePattern),
             InnerThicknessPx = frame.InnerThicknessPx,
             InnerGapPx = frame.InnerGapPx,
             InnerColor = frame.InnerColor,
+            InnerGradient = CloneGradient(frame.InnerGradient),
+            InnerEdgePattern = CloneEdgePattern(frame.InnerEdgePattern),
+        };
+    }
+
+    private static QrPngCanvasBandOptions? CloneBand(QrPngCanvasBandOptions? band) {
+        if (band is null) return null;
+        return new QrPngCanvasBandOptions {
+            BandPx = band.BandPx,
+            GapPx = band.GapPx,
+            RadiusPx = band.RadiusPx,
+            Color = band.Color,
+            Gradient = CloneGradient(band.Gradient),
+            EdgePattern = CloneEdgePattern(band.EdgePattern),
+        };
+    }
+
+    private static QrPngCanvasEdgePatternOptions? CloneEdgePattern(QrPngCanvasEdgePatternOptions? pattern) {
+        if (pattern is null) return null;
+        return new QrPngCanvasEdgePatternOptions {
+            Type = pattern.Type,
+            Color = pattern.Color,
+            ThicknessPx = pattern.ThicknessPx,
+            SpacingPx = pattern.SpacingPx,
+            DashPx = pattern.DashPx,
+            InsetPx = pattern.InsetPx,
         };
     }
 

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -123,6 +123,17 @@ public sealed class QrEasyOptions {
     public QrPngModuleScaleMapOptions? ModuleScaleMap { get; set; }
 
     /// <summary>
+    /// Overrides the module shape map.
+    /// </summary>
+    public QrPngModuleShapeMapOptions? ModuleShapeMap { get; set; }
+
+    /// <summary>
+    /// Overrides per-module jitter options.
+    /// </summary>
+    public QrPngModuleJitterOptions? ModuleJitter { get; set; }
+
+
+    /// <summary>
     /// When true, keeps non-eye functional patterns at a stable, scan-friendly style.
     /// </summary>
     public bool ProtectFunctionalPatterns { get; set; } = true;

--- a/CodeGlyphX/QrEyePresets.cs
+++ b/CodeGlyphX/QrEyePresets.cs
@@ -1,0 +1,78 @@
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// Eye-only styling presets for QR codes.
+/// </summary>
+public static class QrEyePresets {
+    /// <summary>
+    /// Neon sparkle eyes for dark canvases.
+    /// </summary>
+    public static QrPngEyeOptions NeonSparkle() => new() {
+        UseFrame = true,
+        FrameStyle = QrPngEyeFrameStyle.Target,
+        OuterShape = QrPngModuleShape.Rounded,
+        InnerShape = QrPngModuleShape.Circle,
+        OuterColor = new Rgba32(0, 240, 220),
+        InnerColor = new Rgba32(10, 12, 22),
+        SparkleCount = 36,
+        SparkleRadiusPx = 3,
+        SparkleProtectQrArea = true,
+        SparkleColor = new Rgba32(255, 255, 255, 200),
+    };
+
+    /// <summary>
+    /// Sunburst rays around eyes with safe spacing.
+    /// </summary>
+    public static QrPngEyeOptions Sunburst() => new() {
+        UseFrame = true,
+        FrameStyle = QrPngEyeFrameStyle.Badge,
+        OuterShape = QrPngModuleShape.Rounded,
+        InnerShape = QrPngModuleShape.Rounded,
+        OuterColor = new Rgba32(36, 24, 80),
+        InnerColor = new Rgba32(252, 248, 242),
+        AccentRayCount = 18,
+        AccentRayLengthPx = 20,
+        AccentRayThicknessPx = 3,
+        AccentRaySpreadPx = 28,
+        AccentRayProtectQrArea = true,
+        AccentRayColor = new Rgba32(255, 172, 72, 190),
+    };
+
+    /// <summary>
+    /// Minimal ring eyes with subtle accents.
+    /// </summary>
+    public static QrPngEyeOptions MinimalRing() => new() {
+        UseFrame = true,
+        FrameStyle = QrPngEyeFrameStyle.InsetRing,
+        OuterShape = QrPngModuleShape.Rounded,
+        InnerShape = QrPngModuleShape.Rounded,
+        OuterColor = new Rgba32(24, 32, 64),
+        InnerColor = new Rgba32(250, 250, 250),
+        InnerScale = 0.9,
+        AccentRingCount = 6,
+        AccentRingThicknessPx = 2,
+        AccentRingProtectQrArea = true,
+        AccentRingColor = new Rgba32(90, 120, 210, 180),
+    };
+
+    /// <summary>
+    /// Retro target eyes with stripes.
+    /// </summary>
+    public static QrPngEyeOptions RetroTarget() => new() {
+        UseFrame = true,
+        FrameStyle = QrPngEyeFrameStyle.Target,
+        OuterShape = QrPngModuleShape.Rounded,
+        InnerShape = QrPngModuleShape.Rounded,
+        OuterColor = new Rgba32(18, 36, 66),
+        InnerColor = new Rgba32(255, 255, 255),
+        AccentStripeCount = 16,
+        AccentStripeLengthPx = 24,
+        AccentStripeThicknessPx = 3,
+        AccentStripeSpreadPx = 28,
+        AccentStripeProtectQrArea = true,
+        AccentStripeColor = new Rgba32(255, 111, 97, 180),
+    };
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
@@ -47,6 +47,16 @@ public sealed class QrPngCanvasBadgeOptions {
     public Rgba32 Color { get; set; } = new(30, 40, 80, 220);
 
     /// <summary>
+    /// Optional badge gradient (overrides <see cref="Color"/> when set).
+    /// </summary>
+    public QrPngGradientOptions? Gradient { get; set; }
+
+    /// <summary>
+    /// Optional edge pattern overlay.
+    /// </summary>
+    public QrPngCanvasEdgePatternOptions? EdgePattern { get; set; }
+
+    /// <summary>
     /// Ribbon tail length in pixels (applies to <see cref="QrPngCanvasBadgeShape.Ribbon"/>).
     /// </summary>
     public int TailPx { get; set; } = 10;
@@ -57,6 +67,7 @@ public sealed class QrPngCanvasBadgeOptions {
         if (GapPx < 0) throw new ArgumentOutOfRangeException(nameof(GapPx));
         if (CornerRadiusPx < 0) throw new ArgumentOutOfRangeException(nameof(CornerRadiusPx));
         if (TailPx < 0) throw new ArgumentOutOfRangeException(nameof(TailPx));
+        Gradient?.Validate();
+        EdgePattern?.Validate();
     }
 }
-

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
@@ -17,12 +17,12 @@ public sealed class QrPngCanvasBadgeOptions {
     public QrPngCanvasBadgePosition Position { get; set; } = QrPngCanvasBadgePosition.Top;
 
     /// <summary>
-    /// Badge width in pixels.
+    /// Badge width in pixels (0 disables drawing).
     /// </summary>
     public int WidthPx { get; set; } = 120;
 
     /// <summary>
-    /// Badge height in pixels.
+    /// Badge height in pixels (0 disables drawing).
     /// </summary>
     public int HeightPx { get; set; } = 32;
 

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBandOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBandOptions.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Decorative band drawn outside the QR bounds (often used as a quiet-zone ring).
+/// </summary>
+public sealed class QrPngCanvasBandOptions {
+    /// <summary>
+    /// Band thickness in pixels.
+    /// </summary>
+    public int BandPx { get; set; } = 12;
+
+    /// <summary>
+    /// Gap between the QR bounds (including quiet zone) and the band.
+    /// </summary>
+    public int GapPx { get; set; }
+
+    /// <summary>
+    /// Band corner radius in pixels.
+    /// </summary>
+    public int RadiusPx { get; set; } = 18;
+
+    /// <summary>
+    /// Band color.
+    /// </summary>
+    public Rgba32 Color { get; set; } = new(30, 50, 90, 210);
+
+    /// <summary>
+    /// Optional band gradient.
+    /// </summary>
+    public QrPngGradientOptions? Gradient { get; set; }
+
+    /// <summary>
+    /// Optional edge pattern overlay.
+    /// </summary>
+    public QrPngCanvasEdgePatternOptions? EdgePattern { get; set; }
+
+    internal void Validate() {
+        if (BandPx < 0) throw new ArgumentOutOfRangeException(nameof(BandPx));
+        if (GapPx < 0) throw new ArgumentOutOfRangeException(nameof(GapPx));
+        if (RadiusPx < 0) throw new ArgumentOutOfRangeException(nameof(RadiusPx));
+        Gradient?.Validate();
+        EdgePattern?.Validate();
+    }
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasEdgePatternOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasEdgePatternOptions.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Edge pattern options for frames and badges.
+/// </summary>
+public sealed class QrPngCanvasEdgePatternOptions {
+    /// <summary>
+    /// Pattern type.
+    /// </summary>
+    public QrPngCanvasEdgePatternType Type { get; set; } = QrPngCanvasEdgePatternType.Dots;
+
+    /// <summary>
+    /// Pattern color.
+    /// </summary>
+    public Rgba32 Color { get; set; } = new(255, 255, 255, 160);
+
+    /// <summary>
+    /// Pattern thickness in pixels.
+    /// </summary>
+    public int ThicknessPx { get; set; } = 2;
+
+    /// <summary>
+    /// Spacing between pattern elements in pixels.
+    /// </summary>
+    public int SpacingPx { get; set; } = 8;
+
+    /// <summary>
+    /// Dash length in pixels (used by dashes/stitches).
+    /// </summary>
+    public int DashPx { get; set; } = 10;
+
+    /// <summary>
+    /// Inset from the outer edge in pixels.
+    /// </summary>
+    public int InsetPx { get; set; } = 1;
+
+    internal void Validate() {
+        if (ThicknessPx < 0) throw new ArgumentOutOfRangeException(nameof(ThicknessPx));
+        if (SpacingPx < 0) throw new ArgumentOutOfRangeException(nameof(SpacingPx));
+        if (DashPx < 0) throw new ArgumentOutOfRangeException(nameof(DashPx));
+        if (InsetPx < 0) throw new ArgumentOutOfRangeException(nameof(InsetPx));
+    }
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasEdgePatternType.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasEdgePatternType.cs
@@ -1,0 +1,20 @@
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Edge pattern styles for canvas frames and badges.
+/// </summary>
+public enum QrPngCanvasEdgePatternType {
+    /// <summary>
+    /// Round dots along the edge.
+    /// </summary>
+    Dots,
+    /// <summary>
+    /// Short dashed segments along the edge.
+    /// </summary>
+    Dashes,
+    /// <summary>
+    /// Stitched-style short segments along the edge.
+    /// </summary>
+    Stitches
+}
+

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasFrameOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasFrameOptions.cs
@@ -27,6 +27,16 @@ public sealed class QrPngCanvasFrameOptions {
     public Rgba32 Color { get; set; } = new(20, 24, 40, 220);
 
     /// <summary>
+    /// Optional frame gradient (overrides <see cref="Color"/> when set).
+    /// </summary>
+    public QrPngGradientOptions? Gradient { get; set; }
+
+    /// <summary>
+    /// Optional edge pattern overlay.
+    /// </summary>
+    public QrPngCanvasEdgePatternOptions? EdgePattern { get; set; }
+
+    /// <summary>
     /// Optional inner frame thickness in pixels (0 = disabled).
     /// </summary>
     public int InnerThicknessPx { get; set; }
@@ -41,12 +51,25 @@ public sealed class QrPngCanvasFrameOptions {
     /// </summary>
     public Rgba32? InnerColor { get; set; }
 
+    /// <summary>
+    /// Optional inner frame gradient (overrides <see cref="InnerColor"/> when set).
+    /// </summary>
+    public QrPngGradientOptions? InnerGradient { get; set; }
+
+    /// <summary>
+    /// Optional inner edge pattern overlay.
+    /// </summary>
+    public QrPngCanvasEdgePatternOptions? InnerEdgePattern { get; set; }
+
     internal void Validate() {
         if (ThicknessPx < 0) throw new ArgumentOutOfRangeException(nameof(ThicknessPx));
         if (GapPx < 0) throw new ArgumentOutOfRangeException(nameof(GapPx));
         if (RadiusPx < 0) throw new ArgumentOutOfRangeException(nameof(RadiusPx));
         if (InnerThicknessPx < 0) throw new ArgumentOutOfRangeException(nameof(InnerThicknessPx));
         if (InnerGapPx < 0) throw new ArgumentOutOfRangeException(nameof(InnerGapPx));
+        Gradient?.Validate();
+        InnerGradient?.Validate();
+        EdgePattern?.Validate();
+        InnerEdgePattern?.Validate();
     }
 }
-

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasOptions.cs
@@ -57,6 +57,11 @@ public sealed class QrPngCanvasOptions {
     public QrPngCanvasFrameOptions? Frame { get; set; }
 
     /// <summary>
+    /// Optional decorative band drawn outside the QR bounds (quiet-zone ring).
+    /// </summary>
+    public QrPngCanvasBandOptions? Band { get; set; }
+
+    /// <summary>
     /// Optional badge/tab/ribbon drawn outside the QR bounds.
     /// </summary>
     public QrPngCanvasBadgeOptions? Badge { get; set; }
@@ -97,6 +102,7 @@ public sealed class QrPngCanvasOptions {
         Vignette?.Validate();
         Grain?.Validate();
         Frame?.Validate();
+        Band?.Validate();
         Badge?.Validate();
     }
 }

--- a/CodeGlyphX/Rendering/Png/QrPngForegroundPatternBlendMode.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngForegroundPatternBlendMode.cs
@@ -1,0 +1,19 @@
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Blend mode for foreground patterns.
+/// </summary>
+public enum QrPngForegroundPatternBlendMode {
+    /// <summary>
+    /// Overlay the pattern color on top of the module color.
+    /// </summary>
+    Overlay,
+    /// <summary>
+    /// Mask the module so only pattern pixels are drawn (bead/cluster look).
+    /// </summary>
+    Mask,
+    /// <summary>
+    /// Replace the module color with the pattern color at pattern pixels.
+    /// </summary>
+    Replace
+}

--- a/CodeGlyphX/Rendering/Png/QrPngForegroundPatternOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngForegroundPatternOptions.cs
@@ -17,6 +17,12 @@ public sealed class QrPngForegroundPatternOptions {
     public Rgba32 Color { get; set; } = new(0, 0, 0, 48);
 
     /// <summary>
+    /// Gets or sets the pattern blend mode.
+    /// </summary>
+    public QrPngForegroundPatternBlendMode BlendMode { get; set; } = QrPngForegroundPatternBlendMode.Overlay;
+
+
+    /// <summary>
     /// Gets or sets the pattern cell size in pixels.
     /// </summary>
     public int SizePx { get; set; } = 6;

--- a/CodeGlyphX/Rendering/Png/QrPngModuleJitterOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngModuleJitterOptions.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Options for per-module jitter offsets (organic placement).
+/// </summary>
+public sealed class QrPngModuleJitterOptions {
+    /// <summary>
+    /// Maximum jitter offset in pixels.
+    /// </summary>
+    public int MaxOffsetPx { get; set; } = 2;
+
+    /// <summary>
+    /// Random seed used to offset modules.
+    /// </summary>
+    public int Seed { get; set; } = 11021;
+
+    /// <summary>
+    /// When true, applies jitter to eye modules.
+    /// </summary>
+    public bool ApplyToEyes { get; set; }
+
+    /// <summary>
+    /// When true, functional patterns keep their original alignment.
+    /// </summary>
+    public bool ProtectFunctionalPatterns { get; set; } = true;
+
+    /// <summary>
+    /// When true, limits jitter to stay inside the module cell.
+    /// </summary>
+    public bool ClampToShape { get; set; } = true;
+
+    internal void Validate() {
+        if (MaxOffsetPx < 0) throw new ArgumentOutOfRangeException(nameof(MaxOffsetPx));
+    }
+}

--- a/CodeGlyphX/Rendering/Png/QrPngModuleShapeMapMode.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngModuleShapeMapMode.cs
@@ -1,0 +1,27 @@
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Modes for mapping module shapes across a QR matrix.
+/// </summary>
+public enum QrPngModuleShapeMapMode {
+    /// <summary>
+    /// Radial blend from center to edge using <see cref="QrPngModuleShapeMapOptions.Split"/>.
+    /// </summary>
+    Radial,
+    /// <summary>
+    /// Ring-based alternating shapes.
+    /// </summary>
+    Rings,
+    /// <summary>
+    /// Checkerboard alternation.
+    /// </summary>
+    Checker,
+    /// <summary>
+    /// Random selection between shapes.
+    /// </summary>
+    Random,
+    /// <summary>
+    /// Apply the secondary shape to corner zones.
+    /// </summary>
+    Corners
+}

--- a/CodeGlyphX/Rendering/Png/QrPngModuleShapeMapOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngModuleShapeMapOptions.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Png;
+
+/// <summary>
+/// Options for per-module shape mapping.
+/// </summary>
+public sealed class QrPngModuleShapeMapOptions {
+    /// <summary>
+    /// Default ring size (in modules) for <see cref="QrPngModuleShapeMapMode.Rings"/>.
+    /// </summary>
+    public const int DefaultRingSize = 2;
+
+    /// <summary>
+    /// Gets or sets the shape map mode.
+    /// </summary>
+    public QrPngModuleShapeMapMode Mode { get; set; } = QrPngModuleShapeMapMode.Radial;
+
+    /// <summary>
+    /// Primary shape (used for the center in radial mode).
+    /// </summary>
+    public QrPngModuleShape PrimaryShape { get; set; } = QrPngModuleShape.Rounded;
+
+    /// <summary>
+    /// Secondary shape (used for the edge in radial mode).
+    /// </summary>
+    public QrPngModuleShape SecondaryShape { get; set; } = QrPngModuleShape.Dot;
+
+    /// <summary>
+    /// Split point (0..1) used by <see cref="QrPngModuleShapeMapMode.Radial"/>.
+    /// </summary>
+    public double Split { get; set; } = 0.6;
+
+    /// <summary>
+    /// Ring size in modules for <see cref="QrPngModuleShapeMapMode.Rings"/>.
+    /// </summary>
+    public int RingSize { get; set; } = DefaultRingSize;
+
+    /// <summary>
+    /// Random seed used by <see cref="QrPngModuleShapeMapMode.Random"/>.
+    /// </summary>
+    public int Seed { get; set; } = 12345;
+
+    /// <summary>
+    /// Probability (0..1) of choosing the secondary shape in random mode.
+    /// </summary>
+    public double SecondaryChance { get; set; } = 0.5;
+
+    /// <summary>
+    /// Corner zone size in modules for <see cref="QrPngModuleShapeMapMode.Corners"/>.
+    /// </summary>
+    public int CornerSize { get; set; }
+
+    /// <summary>
+    /// When true, allows the shape map to affect eye modules.
+    /// </summary>
+    public bool ApplyToEyes { get; set; }
+
+    /// <summary>
+    /// When true, functional patterns keep the base module shape.
+    /// </summary>
+    public bool ProtectFunctionalPatterns { get; set; } = true;
+
+    internal void Validate() {
+        if (Split is < 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(Split));
+        if (RingSize <= 0) throw new ArgumentOutOfRangeException(nameof(RingSize));
+        if (SecondaryChance is < 0 or > 1.0) throw new ArgumentOutOfRangeException(nameof(SecondaryChance));
+        if (CornerSize < 0) throw new ArgumentOutOfRangeException(nameof(CornerSize));
+    }
+}

--- a/CodeGlyphX/Rendering/Png/QrPngRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderOptions.cs
@@ -92,6 +92,17 @@ public sealed partial class QrPngRenderOptions {
     public QrPngModuleScaleMapOptions? ModuleScaleMap { get; set; }
 
     /// <summary>
+    /// Optional per-module shape mapping.
+    /// </summary>
+    public QrPngModuleShapeMapOptions? ModuleShapeMap { get; set; }
+
+    /// <summary>
+    /// Optional per-module jitter (organic placement).
+    /// </summary>
+    public QrPngModuleJitterOptions? ModuleJitter { get; set; }
+
+
+    /// <summary>
     /// When true, keeps non-eye functional patterns (timing/alignment/format/version/dark module)
     /// at full scale and a stable foreground color for scan reliability.
     /// </summary>

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
@@ -2572,9 +2572,11 @@ public static partial class QrPngRenderer {
         var rightPad = innerCanvasX + innerCanvasW - (qrX + qrSize);
         var bottomPad = innerCanvasY + innerCanvasH - (qrY + qrSize);
 
+        if (badge.WidthPx <= 0 || badge.HeightPx <= 0) return;
+
         var gap = Math.Max(0, badge.GapPx);
-        var desiredW = Math.Max(1, badge.WidthPx);
-        var desiredH = Math.Max(1, badge.HeightPx);
+        var desiredW = badge.WidthPx;
+        var desiredH = badge.HeightPx;
         var offset = badge.OffsetPx;
 
         var x = 0;
@@ -2713,7 +2715,10 @@ public static partial class QrPngRenderer {
             tail = Math.Min(tail, tailMax);
             if (tail <= 0) return;
 
-            var tailWidth = Math.Max(6, Math.Min(w / 3, h * 2));
+            var tailBase = Math.Max(4, Math.Min(w / 3, h * 2));
+            var maxTailWidth = Math.Max(1, w / 2);
+            var tailWidth = Math.Min(maxTailWidth, tailBase);
+            if (tailWidth < 2) return;
             var leftBaseX0 = x;
             var leftBaseX1 = x + tailWidth;
             var rightBaseX0 = x + w - tailWidth;
@@ -2758,7 +2763,10 @@ public static partial class QrPngRenderer {
             tail = Math.Min(tail, tailMax);
             if (tail <= 0) return;
 
-            var tailHeight = Math.Max(6, Math.Min(h / 3, w * 2));
+            var tailBase = Math.Max(4, Math.Min(h / 3, w * 2));
+            var maxTailHeight = Math.Max(1, h / 2);
+            var tailHeight = Math.Min(maxTailHeight, tailBase);
+            if (tailHeight < 2) return;
             var topBaseY0 = y;
             var topBaseY1 = y + tailHeight;
             var bottomBaseY0 = y + h - tailHeight;

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1367,12 +1367,25 @@ public static partial class QrPngRenderer {
             Vignette = ScaleVignette(canvas.Vignette, scale),
             Grain = ScaleGrain(canvas.Grain, scale),
             Frame = ScaleFrame(canvas.Frame, scale),
+            Band = ScaleBand(canvas.Band, scale),
             Badge = ScaleBadge(canvas.Badge, scale),
             BorderPx = canvas.BorderPx * scale,
             BorderColor = canvas.BorderColor,
             ShadowOffsetX = canvas.ShadowOffsetX * scale,
             ShadowOffsetY = canvas.ShadowOffsetY * scale,
             ShadowColor = canvas.ShadowColor
+        };
+    }
+
+    private static QrPngCanvasBandOptions? ScaleBand(QrPngCanvasBandOptions? band, int scale) {
+        if (band is null) return null;
+        return new QrPngCanvasBandOptions {
+            BandPx = band.BandPx <= 0 ? 0 : Math.Max(1, band.BandPx * scale),
+            GapPx = Math.Max(0, band.GapPx * scale),
+            RadiusPx = Math.Max(0, band.RadiusPx * scale),
+            Color = band.Color,
+            Gradient = band.Gradient,
+            EdgePattern = ScaleEdgePattern(band.EdgePattern, scale),
         };
     }
 
@@ -1387,6 +1400,8 @@ public static partial class QrPngRenderer {
             OffsetPx = badge.OffsetPx * scale,
             CornerRadiusPx = Math.Max(0, badge.CornerRadiusPx * scale),
             Color = badge.Color,
+            Gradient = badge.Gradient,
+            EdgePattern = ScaleEdgePattern(badge.EdgePattern, scale),
             TailPx = Math.Max(0, badge.TailPx * scale),
         };
     }
@@ -1398,9 +1413,25 @@ public static partial class QrPngRenderer {
             GapPx = Math.Max(0, frame.GapPx * scale),
             RadiusPx = Math.Max(0, frame.RadiusPx * scale),
             Color = frame.Color,
+            Gradient = frame.Gradient,
+            EdgePattern = ScaleEdgePattern(frame.EdgePattern, scale),
             InnerThicknessPx = frame.InnerThicknessPx <= 0 ? 0 : Math.Max(1, frame.InnerThicknessPx * scale),
             InnerGapPx = Math.Max(0, frame.InnerGapPx * scale),
             InnerColor = frame.InnerColor,
+            InnerGradient = frame.InnerGradient,
+            InnerEdgePattern = ScaleEdgePattern(frame.InnerEdgePattern, scale),
+        };
+    }
+
+    private static QrPngCanvasEdgePatternOptions? ScaleEdgePattern(QrPngCanvasEdgePatternOptions? pattern, int scale) {
+        if (pattern is null) return null;
+        return new QrPngCanvasEdgePatternOptions {
+            Type = pattern.Type,
+            Color = pattern.Color,
+            ThicknessPx = pattern.ThicknessPx <= 0 ? 0 : Math.Max(1, pattern.ThicknessPx * scale),
+            SpacingPx = Math.Max(0, pattern.SpacingPx * scale),
+            DashPx = pattern.DashPx <= 0 ? 0 : Math.Max(1, pattern.DashPx * scale),
+            InsetPx = Math.Max(0, pattern.InsetPx * scale),
         };
     }
 

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Binary1.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Binary1.cs
@@ -203,6 +203,8 @@ public static partial class QrPngRenderer {
         if (opts.ForegroundPattern is not null) return false;
         if (opts.ForegroundPaletteZones is not null) return false;
         if (opts.ModuleScaleMap is not null) return false;
+        if (opts.ModuleShapeMap is not null) return false;
+        if (opts.ModuleJitter is not null) return false;
         if (opts.Eyes is not null) return false;
         if (opts.Logo is not null) return false;
         if (opts.Canvas is not null) return false;

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
@@ -18,6 +18,8 @@ public static partial class QrPngRenderer {
             && opts.ForegroundPattern is null
             && opts.ForegroundPaletteZones is null
             && opts.ModuleScaleMap is null
+            && opts.ModuleShapeMap is null
+            && opts.ModuleJitter is null
             && opts.Eyes is null
             && opts.Logo is null
             && opts.Canvas is null

--- a/CodeGlyphX/Rendering/Png/RenderOptions.Fluent.cs
+++ b/CodeGlyphX/Rendering/Png/RenderOptions.Fluent.cs
@@ -122,6 +122,23 @@ public sealed partial class QrPngRenderOptions {
     }
 
     /// <summary>
+    /// Sets per-module shape mapping options.
+    /// </summary>
+    public QrPngRenderOptions WithModuleShapeMap(QrPngModuleShapeMapOptions? map) {
+        ModuleShapeMap = map;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets per-module jitter options.
+    /// </summary>
+    public QrPngRenderOptions WithModuleJitter(QrPngModuleJitterOptions? jitter) {
+        ModuleJitter = jitter;
+        return this;
+    }
+
+
+    /// <summary>
     /// Sets the module corner radius in pixels.
     /// </summary>
     public QrPngRenderOptions WithModuleCornerRadiusPx(int radiusPx) {

--- a/CodeGlyphX/Rendering/Vector/QrVectorLayout.cs
+++ b/CodeGlyphX/Rendering/Vector/QrVectorLayout.cs
@@ -90,6 +90,8 @@ internal static class QrVectorLayout {
         if (opts.ForegroundPalette is not null) return true;
         if (opts.ForegroundPaletteZones is not null) return true;
         if (opts.ModuleScaleMap is not null) return true;
+        if (opts.ModuleShapeMap is not null) return true;
+        if (opts.ModuleJitter is not null) return true;
         if (opts.Logo is not null) return true;
         if (opts.Canvas is not null) return true;
         if (opts.Debug is not null && opts.Debug.HasOverlay) return true;


### PR DESCRIPTION
## Summary
- add canvas band/edge patterns + gradients for frames/badges
- add foreground pattern mask blend mode for bead/cluster modules
- add module shape map + module jitter options for mixed/organic looks
- add art palettes/eye presets and expand style board presets

## Testing
- dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release -f net8.0
- dotnet run --project CodeGlyphX.Examples -c Release
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0