### PR TITLE
fix: harden canvas badge sizing and tails

### DIFF
--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1650,8 +1650,7 @@ public sealed class QrPngRendererTests {
         }
 
         Assert.True(maxX >= 0, "Expected badge pixels outside the QR bounds.");
-        Assert.True(maxX - minX == 0, "Expected no ribbon tails outside the badge bounds.");
-        Assert.True(maxY - minY == 0, "Expected no ribbon tails outside the badge bounds.");
+        Assert.True(maxX - minX == 0 && maxY - minY == 0, "Expected no ribbon tails outside the badge bounds.");
     }
 
     [Fact]

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1535,7 +1535,6 @@ public sealed class QrPngRendererTests {
         }
 
         Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
-        Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
     }
 
     [Fact]

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1535,6 +1535,123 @@ public sealed class QrPngRendererTests {
         }
 
         Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
+        Assert.True(foundBand, "Expected band pixels outside the QR bounds.");
+    }
+
+    [Fact]
+    public void Render_With_Zero_Size_Badge_Skips_Drawing() {
+        var matrix = new BitMatrix(21, 21);
+        var moduleSize = 6;
+        var quietZone = 4;
+        var padding = 20;
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = padding,
+                Background = Rgba32.White,
+                Badge = new QrPngCanvasBadgeOptions {
+                    Shape = QrPngCanvasBadgeShape.Badge,
+                    Position = QrPngCanvasBadgePosition.Top,
+                    WidthPx = 0,
+                    HeightPx = 24,
+                    GapPx = 8,
+                    Color = new Rgba32(200, 20, 60, 220),
+                },
+            },
+        };
+
+        var png = QrPngRenderer.Render(matrix, opts);
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var qrFullPx = (matrix.Width + quietZone * 2) * moduleSize;
+        var qrX0 = padding;
+        var qrY0 = padding;
+        var qrX1 = qrX0 + qrFullPx - 1;
+        var qrY1 = qrY0 + qrFullPx - 1;
+
+        var foundBadge = false;
+        for (var y = 0; y < height && !foundBadge; y++) {
+            for (var x = 0; x < width; x++) {
+                if (x >= qrX0 && x <= qrX1 && y >= qrY0 && y <= qrY1) continue;
+                var p = y * stride + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                if (r != 255 || g != 255 || b != 255) {
+                    foundBadge = true;
+                    break;
+                }
+            }
+        }
+
+        Assert.False(foundBadge, "Did not expect badge pixels outside the QR bounds.");
+    }
+
+    [Fact]
+    public void Render_With_Tiny_Ribbon_Badge_Skips_Tails() {
+        var matrix = new BitMatrix(21, 21);
+        var moduleSize = 5;
+        var quietZone = 4;
+        var padding = 12;
+
+        var opts = new QrPngRenderOptions {
+            ModuleSize = moduleSize,
+            QuietZone = quietZone,
+            Foreground = Rgba32.Black,
+            Background = Rgba32.White,
+            Canvas = new QrPngCanvasOptions {
+                PaddingPx = padding,
+                Background = Rgba32.White,
+                Badge = new QrPngCanvasBadgeOptions {
+                    Shape = QrPngCanvasBadgeShape.Ribbon,
+                    Position = QrPngCanvasBadgePosition.Top,
+                    WidthPx = 1,
+                    HeightPx = 1,
+                    GapPx = 6,
+                    TailPx = 20,
+                    CornerRadiusPx = 0,
+                    Color = new Rgba32(180, 30, 80, 220),
+                },
+            },
+        };
+
+        var png = QrPngRenderer.Render(matrix, opts);
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+
+        var qrFullPx = (matrix.Width + quietZone * 2) * moduleSize;
+        var qrX0 = padding;
+        var qrY0 = padding;
+        var qrX1 = qrX0 + qrFullPx - 1;
+        var qrY1 = qrY0 + qrFullPx - 1;
+
+        var minX = width;
+        var minY = height;
+        var maxX = -1;
+        var maxY = -1;
+
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                if (x >= qrX0 && x <= qrX1 && y >= qrY0 && y <= qrY1) continue;
+                var p = y * stride + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                if (r == 255 && g == 255 && b == 255) continue;
+
+                if (x < minX) minX = x;
+                if (y < minY) minY = y;
+                if (x > maxX) maxX = x;
+                if (y > maxY) maxY = y;
+            }
+        }
+
+        Assert.True(maxX >= 0, "Expected badge pixels outside the QR bounds.");
+        Assert.True(maxX - minX == 0, "Expected no ribbon tails outside the badge bounds.");
+        Assert.True(maxY - minY == 0, "Expected no ribbon tails outside the badge bounds.");
     }
 
     [Fact]

--- a/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngCanvasBadgeOptions.cs
@@ -17,12 +17,12 @@ public sealed class QrPngCanvasBadgeOptions {
     public QrPngCanvasBadgePosition Position { get; set; } = QrPngCanvasBadgePosition.Top;
 
     /// <summary>
-    /// Badge width in pixels.
+    /// Badge width in pixels (0 disables drawing).
     /// </summary>
     public int WidthPx { get; set; } = 120;
 
     /// <summary>
-    /// Badge height in pixels.
+    /// Badge height in pixels (0 disables drawing).
     /// </summary>
     public int HeightPx { get; set; } = 32;
 

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
@@ -2572,9 +2572,11 @@ public static partial class QrPngRenderer {
         var rightPad = innerCanvasX + innerCanvasW - (qrX + qrSize);
         var bottomPad = innerCanvasY + innerCanvasH - (qrY + qrSize);
 
+        if (badge.WidthPx <= 0 || badge.HeightPx <= 0) return;
+
         var gap = Math.Max(0, badge.GapPx);
-        var desiredW = Math.Max(1, badge.WidthPx);
-        var desiredH = Math.Max(1, badge.HeightPx);
+        var desiredW = badge.WidthPx;
+        var desiredH = badge.HeightPx;
         var offset = badge.OffsetPx;
 
         var x = 0;
@@ -2713,7 +2715,10 @@ public static partial class QrPngRenderer {
             tail = Math.Min(tail, tailMax);
             if (tail <= 0) return;
 
-            var tailWidth = Math.Max(6, Math.Min(w / 3, h * 2));
+            var tailBase = Math.Max(4, Math.Min(w / 3, h * 2));
+            var maxTailWidth = Math.Max(1, w / 2);
+            var tailWidth = Math.Min(maxTailWidth, tailBase);
+            if (tailWidth < 2) return;
             var leftBaseX0 = x;
             var leftBaseX1 = x + tailWidth;
             var rightBaseX0 = x + w - tailWidth;
@@ -2758,7 +2763,10 @@ public static partial class QrPngRenderer {
             tail = Math.Min(tail, tailMax);
             if (tail <= 0) return;
 
-            var tailHeight = Math.Max(6, Math.Min(h / 3, w * 2));
+            var tailBase = Math.Max(4, Math.Min(h / 3, w * 2));
+            var maxTailHeight = Math.Max(1, h / 2);
+            var tailHeight = Math.Min(maxTailHeight, tailBase);
+            if (tailHeight < 2) return;
             var topBaseY0 = y;
             var topBaseY1 = y + tailHeight;
             var bottomBaseY0 = y + h - tailHeight;


### PR DESCRIPTION
Summary:\n- Skip badge rendering when WidthPx/HeightPx <= 0\n- Clamp ribbon tail dimensions for tiny badges\n- Add regression tests for zero-size and tiny ribbon badges\n\nNotes:\n- Stacks on PR #42 (feature/art-enhancements-20260127)\n