### PR TITLE
fix: restore connected shapes and stabilize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Restore Tests
-        run: dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
+        run: dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0
 
       - name: Build Tests (net8.0)
         run: dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0 --no-restore

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -1363,6 +1363,8 @@ public sealed class QrPngRendererTests {
                 var r = rgba[p + 0];
                 var g = rgba[p + 1];
                 var b = rgba[p + 2];
+                var a = rgba[p + 3];
+                if (a == 0) continue;
                 if (r != 255 || g != 255 || b != 255) {
                     foundBadge = true;
                     break;
@@ -1639,6 +1641,8 @@ public sealed class QrPngRendererTests {
                 var r = rgba[p + 0];
                 var g = rgba[p + 1];
                 var b = rgba[p + 2];
+                var a = rgba[p + 3];
+                if (a == 0) continue;
                 if (r == 255 && g == 255 && b == 255) continue;
 
                 if (x < minX) minX = x;

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.A.cs
@@ -101,6 +101,7 @@ public static partial class QrPngRenderer {
         }
 
         var baseModuleShape = opts.ModuleShape;
+        var baseConnectedShape = baseModuleShape;
         var connectedMode = IsConnectedShape(baseModuleShape);
         if (connectedMode) {
             baseModuleShape = baseModuleShape == QrPngModuleShape.ConnectedRounded
@@ -223,8 +224,13 @@ public static partial class QrPngRenderer {
                 }
 
                 var useShape = baseModuleShape;
+                var shapeMapApplied = false;
                 if (applyShapeMap && !isEyeForShapeMap) {
                     useShape = GetShapeForModule(shapeMapInfo!.Value, mx, my, size);
+                    shapeMapApplied = true;
+                }
+                if (connectedMode && !shapeMapApplied) {
+                    useShape = baseConnectedShape;
                 }
 
                 var allowEyeOverride = eyeKind != EyeKind.None && (allowShapeMapOnEyes || allowEyeScaleMap);

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.B.cs
@@ -1,12 +1,19 @@
 using System;
 using System.Buffers;
 using System.IO;
+using CodeGlyphX.Qr;
 using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX.Rendering.Png;
 
 public static partial class QrPngRenderer {
     private static bool TryGetEye(int x, int y, int size, out int ex, out int ey, out EyeKind kind) {
+        if (!QrStructureAnalysis.TryGetVersionFromSize(size, out _)) {
+            ex = 0;
+            ey = 0;
+            kind = EyeKind.None;
+            return false;
+        }
         if (IsInEye(x, y, 0, 0)) {
             ex = 0;
             ey = 0;


### PR DESCRIPTION
Summary:\n- Restore connected module shapes when ModuleShape is connected\n- Prevent eye detection on non-QR-sized matrices\n- Ignore transparent pixels in badge/tail tests\n- Fix coverage job restore for net8.0\n\nNotes:\n- Targets failing tests in master and coverage job restore error\n