### PR TITLE
Add lossy WebP animation encode (managed VP8)

### DIFF
--- a/CodeGlyphX.Tests/WebpAnimationDecodeTests.cs
+++ b/CodeGlyphX.Tests/WebpAnimationDecodeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Webp;
 using Xunit;
 
 namespace CodeGlyphX.Tests;
@@ -31,6 +32,62 @@ public sealed class WebpAnimationDecodeTests {
         Assert.Equal(0, rgba[5]);
         Assert.Equal(0, rgba[6]);
         Assert.Equal(0, rgba[7]);
+    }
+
+    [Fact]
+    public void Webp_ManagedDecode_AnimatedWebp_DecodesFrames() {
+        var frame1 = new AnimationFrameSpec(
+            BuildLiteralOnlyVp8lPayload(width: 1, height: 1, r: 10, g: 20, b: 30, a: 128),
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            durationMs: 120,
+            blend: true,
+            disposeToBackground: false);
+        var frame2 = new AnimationFrameSpec(
+            BuildLiteralOnlyVp8lPayload(width: 1, height: 1, r: 5, g: 6, b: 7, a: 255),
+            x: 2,
+            y: 2,
+            width: 1,
+            height: 1,
+            durationMs: 80,
+            blend: false,
+            disposeToBackground: true);
+
+        var webp = BuildAnimatedWebp(
+            new[] { frame1, frame2 },
+            canvasWidth: 3,
+            canvasHeight: 3,
+            bgraBackground: 0x11223344,
+            loopCount: 3);
+
+        Assert.True(WebpReader.TryDecodeAnimationFrames(webp, out var frames, out var canvasWidth, out var canvasHeight, out var options));
+        Assert.Equal(3, canvasWidth);
+        Assert.Equal(3, canvasHeight);
+        Assert.Equal(3, options.LoopCount);
+        Assert.Equal(0x11223344u, options.BackgroundBgra);
+        Assert.Equal(2, frames.Length);
+
+        Assert.Equal(1, frames[0].Width);
+        Assert.Equal(1, frames[0].Height);
+        Assert.Equal(4, frames[0].Stride);
+        Assert.Equal(120, frames[0].DurationMs);
+        Assert.True(frames[0].Blend);
+        Assert.False(frames[0].DisposeToBackground);
+        Assert.Equal(0, frames[0].X);
+        Assert.Equal(0, frames[0].Y);
+        Assert.Equal(new byte[] { 10, 20, 30, 128 }, frames[0].Rgba.AsSpan(0, 4).ToArray());
+
+        Assert.Equal(1, frames[1].Width);
+        Assert.Equal(1, frames[1].Height);
+        Assert.Equal(4, frames[1].Stride);
+        Assert.Equal(80, frames[1].DurationMs);
+        Assert.False(frames[1].Blend);
+        Assert.True(frames[1].DisposeToBackground);
+        Assert.Equal(2, frames[1].X);
+        Assert.Equal(2, frames[1].Y);
+        Assert.Equal(new byte[] { 5, 6, 7, 255 }, frames[1].Rgba.AsSpan(0, 4).ToArray());
     }
 
     private static byte[] BuildLiteralOnlyVp8lPayload(int width, int height, int r, int g, int b, int a) {
@@ -72,6 +129,24 @@ public sealed class WebpAnimationDecodeTests {
         int frameHeight,
         bool blend,
         uint bgraBackground) {
+        var frame = new AnimationFrameSpec(
+            vp8lPayload,
+            frameX,
+            frameY,
+            frameWidth,
+            frameHeight,
+            durationMs: 0,
+            blend,
+            disposeToBackground: false);
+        return BuildAnimatedWebp(new[] { frame }, canvasWidth, canvasHeight, bgraBackground, loopCount: 0);
+    }
+
+    private static byte[] BuildAnimatedWebp(
+        AnimationFrameSpec[] frames,
+        int canvasWidth,
+        int canvasHeight,
+        uint bgraBackground,
+        int loopCount) {
         using var ms = new MemoryStream();
 
         WriteAscii(ms, "RIFF");
@@ -79,7 +154,7 @@ public sealed class WebpAnimationDecodeTests {
         WriteAscii(ms, "WEBP");
 
         var flags = (byte)0x02; // animation
-        if (vp8lPayload.Length > 0) {
+        if (UsesAlpha(frames)) {
             flags |= 0x10; // alpha flag
         }
 
@@ -95,30 +170,82 @@ public sealed class WebpAnimationDecodeTests {
 
         using (var anim = new MemoryStream()) {
             WriteU32LE(anim, bgraBackground);
-            WriteU16LE(anim, 0); // loop count
+            WriteU16LE(anim, (ushort)loopCount); // loop count
             WriteChunk(ms, "ANIM", anim.ToArray());
         }
 
-        using (var frame = new MemoryStream()) {
-            WriteU24LE(frame, frameX / 2);
-            WriteU24LE(frame, frameY / 2);
-            WriteU24LE(frame, frameWidth - 1);
-            WriteU24LE(frame, frameHeight - 1);
-            WriteU24LE(frame, 0); // duration
-            frame.WriteByte((byte)(blend ? 0x00 : 0x02));
+        foreach (var frame in frames) {
+            using var framePayload = new MemoryStream();
+            WriteU24LE(framePayload, frame.X / 2);
+            WriteU24LE(framePayload, frame.Y / 2);
+            WriteU24LE(framePayload, frame.Width - 1);
+            WriteU24LE(framePayload, frame.Height - 1);
+            WriteU24LE(framePayload, frame.DurationMs);
+            var frameFlags = 0;
+            if (frame.DisposeToBackground) frameFlags |= 0x01;
+            if (!frame.Blend) frameFlags |= 0x02;
+            framePayload.WriteByte((byte)frameFlags);
 
             using (var vp8l = new MemoryStream()) {
-                vp8l.Write(vp8lPayload, 0, vp8lPayload.Length);
-                WriteChunk(frame, "VP8L", vp8l.ToArray());
+                vp8l.Write(frame.Vp8lPayload, 0, frame.Vp8lPayload.Length);
+                WriteChunk(framePayload, "VP8L", vp8l.ToArray());
             }
 
-            WriteChunk(ms, "ANMF", frame.ToArray());
+            WriteChunk(ms, "ANMF", framePayload.ToArray());
         }
 
         var bytes = ms.ToArray();
         var riffSize = checked((uint)(bytes.Length - 8));
         WriteU32LE(bytes, 4, riffSize);
         return bytes;
+    }
+
+    private readonly struct AnimationFrameSpec {
+        public AnimationFrameSpec(
+            byte[] vp8lPayload,
+            int x,
+            int y,
+            int width,
+            int height,
+            int durationMs,
+            bool blend,
+            bool disposeToBackground) {
+            Vp8lPayload = vp8lPayload;
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+            DurationMs = durationMs;
+            Blend = blend;
+            DisposeToBackground = disposeToBackground;
+        }
+
+        public byte[] Vp8lPayload { get; }
+        public int X { get; }
+        public int Y { get; }
+        public int Width { get; }
+        public int Height { get; }
+        public int DurationMs { get; }
+        public bool Blend { get; }
+        public bool DisposeToBackground { get; }
+    }
+
+    private static bool UsesAlpha(AnimationFrameSpec[] frames) {
+        for (var i = 0; i < frames.Length; i++) {
+            var payload = frames[i].Vp8lPayload;
+            if (payload.Length < 5) continue;
+            var bits = ReadU32LE(payload, 1);
+            if (((bits >> 28) & 1) != 0) return true;
+        }
+        return false;
+    }
+
+    private static uint ReadU32LE(byte[] buffer, int offset) {
+        if (offset < 0 || offset + 4 > buffer.Length) return 0;
+        return (uint)(buffer[offset]
+            | (buffer[offset + 1] << 8)
+            | (buffer[offset + 2] << 16)
+            | (buffer[offset + 3] << 24));
     }
 
     private static void WriteChunk(Stream stream, string fourCc, byte[] payload) {

--- a/CodeGlyphX.Tests/WebpAnimationEncodeTests.cs
+++ b/CodeGlyphX.Tests/WebpAnimationEncodeTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using CodeGlyphX.Rendering.Webp;
 using Xunit;
 
@@ -71,6 +73,8 @@ public sealed class WebpAnimationEncodeTests {
         Assert.Equal(height, decodedHeight);
         Assert.Equal(width * height * 4, decoded.Length);
         AssertAllAlpha(decoded, 180);
+        Assert.True(ContainsAnimationFrameChunk(webp, "VP8 "));
+        Assert.True(ContainsAnimationFrameChunk(webp, "ALPH"));
     }
 
     private static byte[] CreateSolidRgba(int width, int height, byte r, byte g, byte b, byte a) {
@@ -97,5 +101,62 @@ public sealed class WebpAnimationEncodeTests {
         for (var i = 0; i < rgba.Length; i += 4) {
             Assert.Equal(a, rgba[i + 3]);
         }
+    }
+
+    private static bool ContainsAnimationFrameChunk(byte[] webp, string fourCc) {
+        var target = Encoding.ASCII.GetBytes(fourCc);
+        if (target.Length != 4) throw new ArgumentException("FourCC must be 4 characters.", nameof(fourCc));
+        if (webp.Length < 12) return false;
+        if (!Matches(webp, 0, "RIFF") || !Matches(webp, 8, "WEBP")) return false;
+
+        var offset = 12;
+        while (offset + 8 <= webp.Length) {
+            var chunkSize = ReadU32LE(webp, offset + 4);
+            var dataOffset = offset + 8;
+            if (dataOffset + chunkSize > webp.Length) break;
+
+            if (Matches(webp, offset, "ANMF")) {
+                var payload = new ReadOnlySpan<byte>(webp, dataOffset, (int)chunkSize);
+                if (ContainsFrameChunk(payload, target)) return true;
+            }
+
+            offset = dataOffset + (int)chunkSize + ((int)chunkSize & 1);
+        }
+
+        return false;
+    }
+
+    private static bool ContainsFrameChunk(ReadOnlySpan<byte> anmfPayload, byte[] target) {
+        if (anmfPayload.Length < 16 + 8) return false;
+        var offset = 16;
+        while (offset + 8 <= anmfPayload.Length) {
+            var chunkSize = ReadU32LE(anmfPayload, offset + 4);
+            var dataOffset = offset + 8;
+            if (dataOffset + chunkSize > anmfPayload.Length) break;
+            if (Matches(anmfPayload, offset, target)) return true;
+            offset = dataOffset + (int)chunkSize + ((int)chunkSize & 1);
+        }
+        return false;
+    }
+
+    private static bool Matches(byte[] data, int offset, string text) {
+        var bytes = Encoding.ASCII.GetBytes(text);
+        return Matches(new ReadOnlySpan<byte>(data), offset, bytes);
+    }
+
+    private static bool Matches(ReadOnlySpan<byte> data, int offset, byte[] bytes) {
+        if (offset < 0 || offset + bytes.Length > data.Length) return false;
+        for (var i = 0; i < bytes.Length; i++) {
+            if (data[offset + i] != bytes[i]) return false;
+        }
+        return true;
+    }
+
+    private static uint ReadU32LE(ReadOnlySpan<byte> data, int offset) {
+        if (offset < 0 || offset + 4 > data.Length) return 0;
+        return (uint)(data[offset]
+            | (data[offset + 1] << 8)
+            | (data[offset + 2] << 16)
+            | (data[offset + 3] << 24));
     }
 }

--- a/CodeGlyphX/Rendering/Webp/WebpReader.cs
+++ b/CodeGlyphX/Rendering/Webp/WebpReader.cs
@@ -109,6 +109,38 @@ public static class WebpReader {
         return frames;
     }
 
+    /// <summary>
+    /// Attempts to decode animated WebP frames composited onto the full canvas (managed).
+    /// </summary>
+    public static bool TryDecodeAnimationCanvasFrames(
+        ReadOnlySpan<byte> data,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        frames = Array.Empty<WebpAnimationFrame>();
+        canvasWidth = 0;
+        canvasHeight = 0;
+        options = default;
+        if (!IsWebp(data)) return false;
+        if (data.Length > MaxWebpBytes) return false;
+        return WebpManagedDecoder.TryDecodeAnimationCanvasFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes animated WebP frames composited onto the full canvas (managed).
+    /// </summary>
+    public static WebpAnimationFrame[] DecodeAnimationCanvasFrames(
+        ReadOnlySpan<byte> data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (!TryDecodeAnimationCanvasFrames(data, out var frames, out canvasWidth, out canvasHeight, out options)) {
+            throw new FormatException("Unsupported or invalid animated WebP.");
+        }
+        return frames;
+    }
+
     private static bool TryReadVp8XSize(ReadOnlySpan<byte> chunk, out int width, out int height) {
         width = 0;
         height = 0;

--- a/CodeGlyphX/Rendering/Webp/WebpReader.cs
+++ b/CodeGlyphX/Rendering/Webp/WebpReader.cs
@@ -77,6 +77,38 @@ public static class WebpReader {
         throw new FormatException("Unsupported or invalid WebP. Managed decode supports VP8/VP8L still images and animated WebP (first frame).");
     }
 
+    /// <summary>
+    /// Attempts to decode animated WebP frames into RGBA32 buffers (managed).
+    /// </summary>
+    public static bool TryDecodeAnimationFrames(
+        ReadOnlySpan<byte> data,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        frames = Array.Empty<WebpAnimationFrame>();
+        canvasWidth = 0;
+        canvasHeight = 0;
+        options = default;
+        if (!IsWebp(data)) return false;
+        if (data.Length > MaxWebpBytes) return false;
+        return WebpManagedDecoder.TryDecodeAnimationFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes animated WebP frames into RGBA32 buffers (managed).
+    /// </summary>
+    public static WebpAnimationFrame[] DecodeAnimationFrames(
+        ReadOnlySpan<byte> data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (!TryDecodeAnimationFrames(data, out var frames, out canvasWidth, out canvasHeight, out options)) {
+            throw new FormatException("Unsupported or invalid animated WebP.");
+        }
+        return frames;
+    }
+
     private static bool TryReadVp8XSize(ReadOnlySpan<byte> chunk, out int width, out int height) {
         width = 0;
         height = 0;

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 | --- | --- | --- | --- |
 | PNG | ✅ | ✅ | Color types 0/2/3/4/6, bit depths 1/2/4/8/16, tRNS, Adam7 |
 | JPEG | ✅ | ✅ | Baseline + progressive (8-bit, Huffman), EXIF orientation, CMYK/YCCK |
-| WebP | ✅ | ✅ | Decode: managed VP8L/VP8 + VP8+ALPH (external corpus validation in progress). Animated WebP decodes first frame only. Encode: VP8L lossless subset + animated VP8L; lossy uses managed VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure). Managed decode enforces a size cap. |
+| WebP | ✅ | ✅ | Decode: managed VP8L/VP8 + VP8+ALPH (external corpus validation in progress). Animated WebP decodes first frame only. Encode: VP8L lossless subset + animated VP8L/VP8 (lossy intra-only); lossy uses managed VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure). Managed decode enforces a size cap. |
 | BMP | ✅ | ✅ | 1/4/8/16/24/32-bit, RLE4/RLE8, bitfields |
 | GIF | No | ✅ | First frame only, transparency via GCE |
 | TIFF | No | ✅ | Baseline, strips, uncompressed/PackBits/LZW/Deflate, 8/16-bit, predictor 2 |
@@ -470,6 +470,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 
 - Animated WebP returns the first frame only (no multi-frame output)
 - Managed lossy WebP encode uses VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure)
+- VP8 inter (lossy) frames are not supported yet
 - Managed WebP decode enforces a size limit (256 MB).
 - AVIF, HEIC, JPEG2000, PSD
 - Animated GIF (first frame only)

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 | --- | --- | --- | --- |
 | PNG | ✅ | ✅ | Color types 0/2/3/4/6, bit depths 1/2/4/8/16, tRNS, Adam7 |
 | JPEG | ✅ | ✅ | Baseline + progressive (8-bit, Huffman), EXIF orientation, CMYK/YCCK |
-| WebP | ✅ | ✅ | Decode: managed VP8L/VP8 + VP8+ALPH (external corpus validation in progress). ImageReader returns the first animation frame; WebpReader can decode all frames. Encode: VP8L lossless subset + animated VP8L/VP8 (lossy intra-only); lossy uses managed VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure). Managed decode enforces a size cap. |
+| WebP | ✅ | ✅ | Decode: managed VP8L/VP8 + VP8+ALPH (external corpus validation in progress). ImageReader returns the first animation frame; WebpReader can decode raw frames or composited canvas frames. Encode: VP8L lossless subset + animated VP8L/VP8 (lossy intra-only); lossy uses managed VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure). Managed decode enforces a size cap. |
 | BMP | ✅ | ✅ | 1/4/8/16/24/32-bit, RLE4/RLE8, bitfields |
 | GIF | No | ✅ | First frame only, transparency via GCE |
 | TIFF | No | ✅ | Baseline, strips, uncompressed/PackBits/LZW/Deflate, 8/16-bit, predictor 2 |
@@ -468,7 +468,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 
 ### Known gaps / not supported (decode)
 
-- ImageReader returns the first animation frame only; use WebpReader.DecodeAnimationFrames for per-frame output
+- ImageReader returns the first animation frame only; use WebpReader.DecodeAnimationFrames for raw frames or WebpReader.DecodeAnimationCanvasFrames for composited frames
 - Managed lossy WebP encode uses VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure)
 - VP8 inter (lossy) frames are not supported yet
 - Managed WebP decode enforces a size limit (256 MB).

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 | --- | --- | --- | --- |
 | PNG | ✅ | ✅ | Color types 0/2/3/4/6, bit depths 1/2/4/8/16, tRNS, Adam7 |
 | JPEG | ✅ | ✅ | Baseline + progressive (8-bit, Huffman), EXIF orientation, CMYK/YCCK |
-| WebP | ✅ | ✅ | Decode: managed VP8L/VP8 + VP8+ALPH (external corpus validation in progress). Animated WebP decodes first frame only. Encode: VP8L lossless subset + animated VP8L/VP8 (lossy intra-only); lossy uses managed VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure). Managed decode enforces a size cap. |
+| WebP | ✅ | ✅ | Decode: managed VP8L/VP8 + VP8+ALPH (external corpus validation in progress). ImageReader returns the first animation frame; WebpReader can decode all frames. Encode: VP8L lossless subset + animated VP8L/VP8 (lossy intra-only); lossy uses managed VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure). Managed decode enforces a size cap. |
 | BMP | ✅ | ✅ | 1/4/8/16/24/32-bit, RLE4/RLE8, bitfields |
 | GIF | No | ✅ | First frame only, transparency via GCE |
 | TIFF | No | ✅ | Baseline, strips, uncompressed/PackBits/LZW/Deflate, 8/16-bit, predictor 2 |
@@ -468,7 +468,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 
 ### Known gaps / not supported (decode)
 
-- Animated WebP returns the first frame only (no multi-frame output)
+- ImageReader returns the first animation frame only; use WebpReader.DecodeAnimationFrames for per-frame output
 - Managed lossy WebP encode uses VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure)
 - VP8 inter (lossy) frames are not supported yet
 - Managed WebP decode enforces a size limit (256 MB).

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ QR payload helpers generate well-known structured strings so scanners can trigge
 
 - ImageReader returns the first animation frame only; use WebpReader.DecodeAnimationFrames for raw frames or WebpReader.DecodeAnimationCanvasFrames for composited frames
 - Managed lossy WebP encode uses VP8 intra-only (4x4/16x16) with ALPH for alpha (VP8L fallback on failure)
-- VP8 inter (lossy) frames are not supported yet
+- Managed VP8 decode supports keyframes only; interframes (if present) are not supported
 - Managed WebP decode enforces a size limit (256 MB).
 - AVIF, HEIC, JPEG2000, PSD
 - Animated GIF (first frame only)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ This list is mostly **work we still want to do**. The "Recently completed" secti
 - Preset schema + v1 packs/shape sets/palettes. [style]
 
 ### P2 — Platform breadth & UX
-- WebP decode + encode (lossless + VP8 lossy intra complete; remaining: VP8 inter + lossy animation). [formats][webp]
+- WebP decode + encode (lossless + VP8 lossy intra complete; remaining: VP8 inter). [formats][webp]
 - Expand format corpus (JPEG progressive/CMYK, GIF variants, BMP/ICO edge cases) and schedule periodic **local** full runs. [formats]
 - AOT evaluation + documentation of safe paths. [aot]
 - Add symbology packs + golden vectors (MaxiCode, rMQR, etc.). [symbology][tests]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ This list is mostly **work we still want to do**. The "Recently completed" secti
 - Preset schema + v1 packs/shape sets/palettes. [style]
 
 ### P2 — Platform breadth & UX
-- WebP decode + encode (lossless + VP8 lossy intra complete; remaining: VP8 inter). [formats][webp]
+- WebP decode + encode (lossless + VP8 lossy intra complete; remaining: VP8 inter if encountered). [formats][webp]
 - Expand format corpus (JPEG progressive/CMYK, GIF variants, BMP/ICO edge cases) and schedule periodic **local** full runs. [formats]
 - AOT evaluation + documentation of safe paths. [aot]
 - Add symbology packs + golden vectors (MaxiCode, rMQR, etc.). [symbology][tests]
@@ -107,7 +107,7 @@ This list is mostly **work we still want to do**. The "Recently completed" secti
 - Website: add marketing gallery + download links (use generated assets, not manual images). [style][ux]
 
 ## Backlog — Image formats
-- WebP: finish managed coverage (VP8 inter, lossy animation frames, broader VP8L features). [formats][webp]
+- WebP: finish managed coverage (VP8 inter if encountered, broader VP8L features). [formats][webp]
 - Expand format corpus (JPEG progressive/CMYK, GIF variants, BMP/ICO edge cases) and schedule periodic **local** full runs. [formats]
 
 ## Backlog — Platform & runtime


### PR DESCRIPTION
## Summary\n- add managed lossy animation encode using VP8 intra with ALPH support\n- fall back to VP8L + quantization when VP8 encode fails\n- update WebP animation tests and docs/roadmap\n\n## Testing\n- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0\n- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build\n\n## Notes\n- full solution build on Linux still requires .NET Framework 4.7.2 targeting pack