### PR TITLE
Add lossy WebP renderers

### DIFF
--- a/CodeGlyphX.Tests/WebpRendererTests.cs
+++ b/CodeGlyphX.Tests/WebpRendererTests.cs
@@ -1,0 +1,63 @@
+using CodeGlyphX;
+using CodeGlyphX.Code39;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class WebpRendererTests {
+    [Fact]
+    public void WebpRenderer_Qr_Lossy_Encodes() {
+        var qr = QrCodeEncoder.EncodeText("HELLO");
+        var opts = new QrPngRenderOptions {
+            ModuleSize = 4,
+            QuietZone = 2
+        };
+
+        var webp = QrWebpRenderer.Render(qr.Modules, opts, quality: 75);
+
+        Assert.True(WebpReader.IsWebp(webp));
+        Assert.True(WebpReader.TryReadDimensions(webp, out var width, out var height));
+        Assert.True(width > 0);
+        Assert.True(height > 0);
+    }
+
+    [Fact]
+    public void WebpRenderer_Matrix_Lossy_Encodes() {
+        var matrix = new BitMatrix(4, 4);
+        matrix[0, 0] = true;
+        matrix[1, 1] = true;
+        matrix[2, 2] = true;
+        matrix[3, 3] = true;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 4,
+            QuietZone = 2
+        };
+
+        var webp = MatrixWebpRenderer.Render(matrix, opts, quality: 80);
+
+        Assert.True(WebpReader.IsWebp(webp));
+        Assert.True(WebpReader.TryReadDimensions(webp, out var width, out var height));
+        Assert.True(width > 0);
+        Assert.True(height > 0);
+    }
+
+    [Fact]
+    public void WebpRenderer_Barcode_Lossy_Encodes() {
+        var barcode = Code39Encoder.Encode("ABC", includeChecksum: false, fullAsciiMode: false);
+        var opts = new BarcodePngRenderOptions {
+            ModuleSize = 2,
+            QuietZone = 2,
+            HeightModules = 30
+        };
+
+        var webp = BarcodeWebpRenderer.Render(barcode, opts, quality: 70);
+
+        Assert.True(WebpReader.IsWebp(webp));
+        Assert.True(WebpReader.TryReadDimensions(webp, out var width, out var height));
+        Assert.True(width > 0);
+        Assert.True(height > 0);
+    }
+}

--- a/CodeGlyphX/Rendering/Webp/BarcodeWebpRenderer.cs
+++ b/CodeGlyphX/Rendering/Webp/BarcodeWebpRenderer.cs
@@ -5,11 +5,11 @@ using CodeGlyphX.Rendering.Png;
 namespace CodeGlyphX.Rendering.Webp;
 
 /// <summary>
-/// Renders 1D barcodes to WebP images (lossless VP8L).
+/// Renders 1D barcodes to WebP images.
 /// </summary>
 public static class BarcodeWebpRenderer {
     /// <summary>
-    /// Renders the barcode to a WebP byte array.
+    /// Renders the barcode to a WebP byte array (lossless VP8L).
     /// </summary>
     public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
         var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
@@ -17,10 +17,33 @@ public static class BarcodeWebpRenderer {
     }
 
     /// <summary>
+    /// Renders the barcode to a WebP byte array (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="barcode">Barcode data.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts, int quality = 100) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        return WebpWriter.WriteRgba32Lossy(widthPx, heightPx, pixels, stride, quality);
+    }
+
+    /// <summary>
     /// Renders the barcode to a WebP stream.
     /// </summary>
     public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
         var webp = Render(barcode, opts);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a WebP stream (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="barcode">Barcode data.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="stream">Target stream.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream, int quality = 100) {
+        var webp = Render(barcode, opts, quality);
         RenderIO.WriteBinary(stream, webp);
     }
 
@@ -33,10 +56,37 @@ public static class BarcodeWebpRenderer {
     }
 
     /// <summary>
+    /// Renders the barcode to a WebP file (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="barcode">Barcode data.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path, int quality = 100) {
+        var webp = Render(barcode, opts, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
     /// Renders the barcode to a WebP file under the specified directory.
     /// </summary>
     public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
         var webp = Render(barcode, opts);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a WebP file under the specified directory (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="barcode">Barcode data.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="directory">Output directory.</param>
+    /// <param name="fileName">Output file name.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName, int quality = 100) {
+        var webp = Render(barcode, opts, quality);
         return RenderIO.WriteBinary(directory, fileName, webp);
     }
 }

--- a/CodeGlyphX/Rendering/Webp/MatrixWebpRenderer.cs
+++ b/CodeGlyphX/Rendering/Webp/MatrixWebpRenderer.cs
@@ -5,11 +5,11 @@ using CodeGlyphX.Rendering.Png;
 namespace CodeGlyphX.Rendering.Webp;
 
 /// <summary>
-/// Renders generic 2D matrices to WebP images (lossless VP8L).
+/// Renders generic 2D matrices to WebP images.
 /// </summary>
 public static class MatrixWebpRenderer {
     /// <summary>
-    /// Renders the matrix to a WebP byte array.
+    /// Renders the matrix to a WebP byte array (lossless VP8L).
     /// </summary>
     public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts) {
         var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
@@ -17,10 +17,33 @@ public static class MatrixWebpRenderer {
     }
 
     /// <summary>
+    /// Renders the matrix to a WebP byte array (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts, int quality = 100) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return WebpWriter.WriteRgba32Lossy(widthPx, heightPx, pixels, stride, quality);
+    }
+
+    /// <summary>
     /// Renders the matrix to a WebP stream.
     /// </summary>
     public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
         var webp = Render(modules, opts);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a WebP stream (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="stream">Target stream.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream, int quality = 100) {
+        var webp = Render(modules, opts, quality);
         RenderIO.WriteBinary(stream, webp);
     }
 
@@ -33,10 +56,37 @@ public static class MatrixWebpRenderer {
     }
 
     /// <summary>
+    /// Renders the matrix to a WebP file (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path, int quality = 100) {
+        var webp = Render(modules, opts, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
     /// Renders the matrix to a WebP file under the specified directory.
     /// </summary>
     public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
         var webp = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a WebP file under the specified directory (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="directory">Output directory.</param>
+    /// <param name="fileName">Output file name.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName, int quality = 100) {
+        var webp = Render(modules, opts, quality);
         return RenderIO.WriteBinary(directory, fileName, webp);
     }
 }

--- a/CodeGlyphX/Rendering/Webp/QrWebpRenderer.cs
+++ b/CodeGlyphX/Rendering/Webp/QrWebpRenderer.cs
@@ -5,11 +5,11 @@ using CodeGlyphX.Rendering.Png;
 namespace CodeGlyphX.Rendering.Webp;
 
 /// <summary>
-/// Renders QR modules to WebP images (lossless VP8L).
+/// Renders QR modules to WebP images.
 /// </summary>
 public static class QrWebpRenderer {
     /// <summary>
-    /// Renders the QR module matrix to a WebP byte array.
+    /// Renders the QR module matrix to a WebP byte array (lossless VP8L).
     /// </summary>
     public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts) {
         var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
@@ -17,10 +17,33 @@ public static class QrWebpRenderer {
     }
 
     /// <summary>
+    /// Renders the QR module matrix to a WebP byte array (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts, int quality = 100) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return WebpWriter.WriteRgba32Lossy(widthPx, heightPx, pixels, stride, quality);
+    }
+
+    /// <summary>
     /// Renders the QR module matrix to a WebP stream.
     /// </summary>
     public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
         var webp = Render(modules, opts);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a WebP stream (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="stream">Target stream.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, int quality = 100) {
+        var webp = Render(modules, opts, quality);
         RenderIO.WriteBinary(stream, webp);
     }
 
@@ -33,10 +56,37 @@ public static class QrWebpRenderer {
     }
 
     /// <summary>
+    /// Renders the QR module matrix to a WebP file (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path, int quality = 100) {
+        var webp = Render(modules, opts, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
     /// Renders the QR module matrix to a WebP file under the specified directory.
     /// </summary>
     public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
         var webp = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a WebP file under the specified directory (lossy VP8 when possible).
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="directory">Output directory.</param>
+    /// <param name="fileName">Output file name.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName, int quality = 100) {
+        var webp = Render(modules, opts, quality);
         return RenderIO.WriteBinary(directory, fileName, webp);
     }
 }


### PR DESCRIPTION
## Summary\n- add lossy WebP overloads for QR, barcode, and matrix renderers (quality parameter)\n- keep existing lossless overloads intact\n- document quality behavior in XML comments\n\n## Testing\n- dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0\n- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0\n- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build\n- dotnet build CodeGlyphX.sln (fails on Linux: missing .NETFramework 4.7.2 targeting pack)