### PR TITLE
Add WebP end-to-end output + docs

### DIFF
--- a/CodeGlyphX.Website/Pages/Docs.razor
+++ b/CodeGlyphX.Website/Pages/Docs.razor
@@ -601,6 +601,13 @@ QR.Save(QrPayloads.OneTimePassword(
                         <td style="padding: 0.75rem;">Baseline + progressive, EXIF, CMYK/YCCK</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem;">WebP</td>
+                        <td style="padding: 0.75rem;"><code>.webp</code></td>
+                        <td style="padding: 0.75rem;">Yes</td>
+                        <td style="padding: 0.75rem;">Yes</td>
+                        <td style="padding: 0.75rem;">Lossless VP8L + VP8 lossy intra, animation supported</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">BMP</td>
                         <td style="padding: 0.75rem;"><code>.bmp</code></td>
                         <td style="padding: 0.75rem;">Yes</td>
@@ -1002,7 +1009,7 @@ var decodeResult = QrImageDecoder.DecodeImage(stream);</pre>
 
             <h2>Supported Formats for Decoding</h2>
             <ul style="color: var(--text-muted); margin-left: 1.5rem;">
-                <li><strong>Images:</strong> PNG, JPEG, BMP, GIF, TIFF, PPM/PGM/PBM/PAM, TGA, ICO/CUR, XBM, XPM</li>
+                <li><strong>Images:</strong> PNG, JPEG, WebP, BMP, GIF, TIFF, PPM/PGM/PBM/PAM, TGA, ICO/CUR, XBM, XPM</li>
                 <li><strong>QR Codes:</strong> Standard QR, Micro QR</li>
                 <li><strong>1D Barcodes:</strong> Code 128, Code 39/93, EAN/UPC, ITF, Codabar, MSI, Telepen, Plessey, more</li>
                 <li><strong>2D Matrix:</strong> Data Matrix, PDF417, Aztec</li>
@@ -1010,7 +1017,7 @@ var decodeResult = QrImageDecoder.DecodeImage(stream);</pre>
 
             <h2>Known Gaps (Decoding)</h2>
             <ul style="color: var(--text-muted); margin-left: 1.5rem;">
-                <li>WebP, AVIF, HEIC, JPEG2000, PSD</li>
+                <li>AVIF, HEIC, JPEG2000, PSD</li>
                 <li>Animated GIF (first frame only)</li>
                 <li>Multi-page / tiled TIFF and mixed sample sizes</li>
                 <li>PDF/PS decode (rasterize first)</li>

--- a/CodeGlyphX/AztecCode.Save.cs
+++ b/CodeGlyphX/AztecCode.Save.cs
@@ -99,6 +99,20 @@ public static partial class AztecCode {
     }
 
     /// <summary>
+    /// Saves Aztec WebP to a file.
+    /// </summary>
+    public static string SaveWebp(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        return RenderIO.WriteBinary(path, Webp(text, encodeOptions, renderOptions));
+    }
+
+    /// <summary>
+    /// Saves Aztec WebP to a stream.
+    /// </summary>
+    public static void SaveWebp(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        RenderIO.WriteBinary(stream, Webp(text, encodeOptions, renderOptions));
+    }
+
+    /// <summary>
     /// Saves Aztec BMP to a file.
     /// </summary>
     public static string SaveBmp(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -310,6 +324,20 @@ public static partial class AztecCode {
     /// </summary>
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Jpeg(data, encodeOptions, renderOptions));
+    }
+
+    /// <summary>
+    /// Saves Aztec WebP to a file.
+    /// </summary>
+    public static string SaveWebp(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        return RenderIO.WriteBinary(path, Webp(data, encodeOptions, renderOptions));
+    }
+
+    /// <summary>
+    /// Saves Aztec WebP to a stream.
+    /// </summary>
+    public static void SaveWebp(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        RenderIO.WriteBinary(stream, Webp(data, encodeOptions, renderOptions));
     }
 
     /// <summary>

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -18,6 +18,7 @@ using CodeGlyphX.Rendering.Ppm;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -129,12 +130,30 @@ public static partial class AztecCode {
     }
 
     /// <summary>
+    /// Renders Aztec to WebP bytes.
+    /// </summary>
+    public static byte[] Webp(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        var opts = ToPngOptions(renderOptions);
+        return MatrixWebpRenderer.Render(modules, opts, renderOptions?.WebpQuality ?? 100);
+    }
+
+    /// <summary>
     /// Renders Aztec to JPEG bytes.
     /// </summary>
     public static byte[] Jpeg(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         var opts = ToPngOptions(renderOptions);
         return MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85);
+    }
+
+    /// <summary>
+    /// Renders Aztec to WebP bytes.
+    /// </summary>
+    public static byte[] Webp(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(data, encodeOptions);
+        var opts = ToPngOptions(renderOptions);
+        return MatrixWebpRenderer.Render(modules, opts, renderOptions?.WebpQuality ?? 100);
     }
 
     /// <summary>

--- a/CodeGlyphX/Barcode.Builder.cs
+++ b/CodeGlyphX/Barcode.Builder.cs
@@ -314,6 +314,16 @@ public static partial class Barcode {
         public void SaveJpeg(Stream stream) => Barcode.SaveJpeg(_type, _content, stream, Options);
 
         /// <summary>
+        /// Saves WebP to a file.
+        /// </summary>
+        public string SaveWebp(string path) => Barcode.SaveWebp(_type, _content, path, Options);
+
+        /// <summary>
+        /// Saves WebP to a stream.
+        /// </summary>
+        public void SaveWebp(Stream stream) => Barcode.SaveWebp(_type, _content, stream, Options);
+
+        /// <summary>
         /// Saves BMP to a file.
         /// </summary>
         public string SaveBmp(string path) => Barcode.SaveBmp(_type, _content, path, Options);

--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -17,6 +17,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -94,6 +95,24 @@ public static partial class Barcode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 90;
         BarcodeJpegRenderer.RenderToStream(barcode, opts, stream, quality);
+    }
+
+    /// <summary>
+    /// Renders a barcode as WebP and writes it to a file.
+    /// </summary>
+    public static string SaveWebp(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
+        var webp = Webp(type, content, options);
+        return webp.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Renders a barcode as WebP and writes it to a stream.
+    /// </summary>
+    public static void SaveWebp(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        BarcodeWebpRenderer.RenderToStream(barcode, opts, stream, quality);
     }
 
     /// <summary>
@@ -326,7 +345,7 @@ public static partial class Barcode {
     }
 
     /// <summary>
-    /// Saves a barcode to a file based on the file extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves a barcode to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
@@ -341,6 +360,8 @@ public static partial class Barcode {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(type, content, path, options);
+            case ".webp":
+                return SaveWebp(type, content, path, options);
             case ".svg":
                 return SaveSvg(type, content, path, options);
             case ".html":

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -17,6 +17,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -84,6 +85,16 @@ public static partial class Barcode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 90;
         return BarcodeJpegRenderer.Render(barcode, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders a barcode as WebP.
+    /// </summary>
+    public static byte[] Webp(BarcodeType type, string content, BarcodeOptions? options = null) {
+        var barcode = Encode(type, content);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        return BarcodeWebpRenderer.Render(barcode, opts, quality);
     }
 
     /// <summary>

--- a/CodeGlyphX/BarcodeEasy.cs
+++ b/CodeGlyphX/BarcodeEasy.cs
@@ -49,6 +49,12 @@ public static class BarcodeEasy {
         Barcode.Jpeg(type, content, options);
 
     /// <summary>
+    /// Renders a barcode as WebP.
+    /// </summary>
+    public static byte[] RenderWebp(BarcodeType type, string content, BarcodeOptions? options = null) =>
+        Barcode.Webp(type, content, options);
+
+    /// <summary>
     /// Renders a barcode as BMP.
     /// </summary>
     public static byte[] RenderBmp(BarcodeType type, string content, BarcodeOptions? options = null) =>
@@ -151,6 +157,12 @@ public static class BarcodeEasy {
         Barcode.SaveJpeg(type, content, stream, options);
 
     /// <summary>
+    /// Renders a barcode as WebP to a stream.
+    /// </summary>
+    public static void RenderWebpToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
+        Barcode.SaveWebp(type, content, stream, options);
+
+    /// <summary>
     /// Renders a barcode as BMP to a stream.
     /// </summary>
     public static void RenderBmpToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
@@ -245,6 +257,12 @@ public static class BarcodeEasy {
     /// </summary>
     public static string RenderJpegToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
         Barcode.SaveJpeg(type, content, path, options);
+
+    /// <summary>
+    /// Renders a barcode as WebP to a file.
+    /// </summary>
+    public static string RenderWebpToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
+        Barcode.SaveWebp(type, content, path, options);
 
     /// <summary>
     /// Renders a barcode as BMP to a file.

--- a/CodeGlyphX/BarcodeOptions.cs
+++ b/CodeGlyphX/BarcodeOptions.cs
@@ -38,6 +38,11 @@ public sealed class BarcodeOptions {
     public int JpegQuality { get; set; } = 90;
 
     /// <summary>
+    /// WebP quality (0..100). Values &gt;= 100 use lossless VP8L.
+    /// </summary>
+    public int WebpQuality { get; set; } = 100;
+
+    /// <summary>
     /// ICO output sizes in pixels (1..256). Defaults to common icon sizes.
     /// </summary>
     public int[]? IcoSizes { get; set; }

--- a/CodeGlyphX/DataMatrixCode.Builder.cs
+++ b/CodeGlyphX/DataMatrixCode.Builder.cs
@@ -221,6 +221,13 @@ public static partial class DataMatrixCode {
         }
 
         /// <summary>
+        /// Saves WebP to a file.
+        /// </summary>
+        public string SaveWebp(string path) {
+            return _text is not null ? DataMatrixCode.SaveWebp(_text, path, _mode, _options) : DataMatrixCode.SaveWebp(_bytes!, path, _mode, _options);
+        }
+
+        /// <summary>
         /// Saves BMP to a file.
         /// </summary>
         public string SaveBmp(string path) {

--- a/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
@@ -18,6 +18,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -85,6 +86,14 @@ public static partial class DataMatrixCode {
     public static string SaveJpeg(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var jpeg = Jpeg(data, mode, options);
         return jpeg.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix WebP to a file for byte payloads.
+    /// </summary>
+    public static string SaveWebp(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var webp = Webp(data, mode, options);
+        return webp.WriteBinary(path);
     }
 
     /// <summary>
@@ -204,6 +213,16 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix WebP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveWebp(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        MatrixWebpRenderer.RenderToStream(modules, opts, stream, quality);
+    }
+
+    /// <summary>
     /// Saves Data Matrix BMP to a stream for byte payloads.
     /// </summary>
     public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -310,7 +329,7 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -325,6 +344,8 @@ public static partial class DataMatrixCode {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(data, path, mode, options);
+            case ".webp":
+                return SaveWebp(data, path, mode, options);
             case ".svg":
                 return SaveSvg(data, path, mode, options);
             case ".html":

--- a/CodeGlyphX/DataMatrixCode.Save.Text.A.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.A.cs
@@ -173,6 +173,14 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix WebP to a file.
+    /// </summary>
+    public static string SaveWebp(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var webp = Webp(text, mode, options);
+        return webp.WriteBinary(path);
+    }
+
+    /// <summary>
     /// Saves Data Matrix BMP to a file.
     /// </summary>
     public static string SaveBmp(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -276,6 +284,14 @@ public static partial class DataMatrixCode {
     public static string SaveJpeg(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var jpeg = Jpeg(data, mode, options);
         return jpeg.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix WebP to a file for byte payloads.
+    /// </summary>
+    public static string SaveWebp(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var webp = Webp(data, mode, options);
+        return webp.WriteBinary(path);
     }
 
     /// <summary>

--- a/CodeGlyphX/DataMatrixCode.Save.Text.B.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.B.cs
@@ -18,6 +18,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -66,6 +67,16 @@ public static partial class DataMatrixCode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 85;
         MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix WebP to a stream.
+    /// </summary>
+    public static void SaveWebp(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        MatrixWebpRenderer.RenderToStream(modules, opts, stream, quality);
     }
 
     /// <summary>
@@ -177,6 +188,16 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
+    /// Saves Data Matrix WebP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveWebp(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        MatrixWebpRenderer.RenderToStream(modules, opts, stream, quality);
+    }
+
+    /// <summary>
     /// Saves Data Matrix BMP to a stream for byte payloads.
     /// </summary>
     public static void SaveBmp(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -275,7 +296,7 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Data Matrix to a file based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -290,6 +311,8 @@ public static partial class DataMatrixCode {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(text, path, mode, options);
+            case ".webp":
+                return SaveWebp(text, path, mode, options);
             case ".svg":
                 return SaveSvg(text, path, mode, options);
             case ".html":
@@ -329,7 +352,7 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -344,6 +367,8 @@ public static partial class DataMatrixCode {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(data, path, mode, options);
+            case ".webp":
+                return SaveWebp(data, path, mode, options);
             case ".svg":
                 return SaveSvg(data, path, mode, options);
             case ".html":

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -18,6 +18,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -109,6 +110,16 @@ public static partial class DataMatrixCode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 85;
         return MatrixJpegRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as WebP from bytes.
+    /// </summary>
+    public static byte[] Webp(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        return MatrixWebpRenderer.Render(modules, opts, quality);
     }
 
     /// <summary>
@@ -292,6 +303,16 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
+    /// Renders Data Matrix as WebP.
+    /// </summary>
+    public static byte[] Webp(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = Encode(text, mode);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        return MatrixWebpRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
     /// Renders Data Matrix as BMP.
     /// </summary>
     public static byte[] Bmp(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
@@ -403,6 +424,16 @@ public static partial class DataMatrixCode {
         var opts = BuildPngOptions(options);
         var quality = options?.JpegQuality ?? 85;
         return MatrixJpegRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders Data Matrix as WebP from bytes.
+    /// </summary>
+    public static byte[] Webp(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
+        var modules = EncodeBytes(data, mode);
+        var opts = BuildPngOptions(options);
+        var quality = options?.WebpQuality ?? 100;
+        return MatrixWebpRenderer.Render(modules, opts, quality);
     }
 
     /// <summary>

--- a/CodeGlyphX/MatrixOptions.cs
+++ b/CodeGlyphX/MatrixOptions.cs
@@ -33,6 +33,11 @@ public sealed class MatrixOptions {
     public int JpegQuality { get; set; } = 85;
 
     /// <summary>
+    /// WebP quality (0..100). Values &gt;= 100 use lossless VP8L.
+    /// </summary>
+    public int WebpQuality { get; set; } = 100;
+
+    /// <summary>
     /// ICO output sizes in pixels (1..256). Defaults to common icon sizes.
     /// </summary>
     public int[]? IcoSizes { get; set; }

--- a/CodeGlyphX/Otp.cs
+++ b/CodeGlyphX/Otp.cs
@@ -71,6 +71,14 @@ public static class Otp {
     }
 
     /// <summary>
+    /// Renders a TOTP QR as WebP from a Base32 secret.
+    /// </summary>
+    public static byte[] TotpWebp(string issuer, string account, string secretBase32, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        return QrEasy.RenderWebp(uri, options);
+    }
+
+    /// <summary>
     /// Renders a HOTP QR as PNG from a Base32 secret.
     /// </summary>
     public static byte[] HotpPng(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
@@ -100,6 +108,14 @@ public static class Otp {
     public static byte[] HotpJpeg(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
         return QrEasy.RenderJpeg(uri, options);
+    }
+
+    /// <summary>
+    /// Renders a HOTP QR as WebP from a Base32 secret.
+    /// </summary>
+    public static byte[] HotpWebp(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        return QrEasy.RenderWebp(uri, options);
     }
 
     /// <summary>
@@ -163,6 +179,20 @@ public static class Otp {
     }
 
     /// <summary>
+    /// Saves a TOTP WebP to a file.
+    /// </summary>
+    public static string SaveTotpWebp(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
+        return TotpWebp(issuer, account, secretBase32, options, alg, digits, period).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a TOTP WebP to a stream.
+    /// </summary>
+    public static void SaveTotpWebp(string issuer, string account, string secretBase32, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
+        QR.SaveWebp(TotpUri(issuer, account, secretBase32, alg, digits, period), stream, options);
+    }
+
+    /// <summary>
     /// Saves a HOTP PNG to a file.
     /// </summary>
     public static string SaveHotpPng(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
@@ -223,7 +253,21 @@ public static class Otp {
     }
 
     /// <summary>
-    /// Saves a TOTP QR based on file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
+    /// Saves a HOTP WebP to a file.
+    /// </summary>
+    public static string SaveHotpWebp(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
+        return HotpWebp(issuer, account, secretBase32, counter, options, alg, digits).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a HOTP WebP to a stream.
+    /// </summary>
+    public static void SaveHotpWebp(string issuer, string account, string secretBase32, long counter, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
+        QR.SaveWebp(HotpUri(issuer, account, secretBase32, counter, alg, digits), stream, options);
+    }
+
+    /// <summary>
+    /// Saves a TOTP QR based on file extension (.png/.webp/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveTotp(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30, string? title = null) {
@@ -232,7 +276,7 @@ public static class Otp {
     }
 
     /// <summary>
-    /// Saves a HOTP QR based on file extension (.png/.svg/.html/.jpg/.bmp/.pdf/.eps).
+    /// Saves a HOTP QR based on file extension (.png/.webp/.svg/.html/.jpg/.bmp/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveHotp(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, string? title = null) {
@@ -339,6 +383,11 @@ public static class Otp {
         public byte[] Jpeg() => QrEasy.RenderJpeg(Uri(), Options);
 
         /// <summary>
+        /// Renders WebP bytes.
+        /// </summary>
+        public byte[] Webp() => QrEasy.RenderWebp(Uri(), Options);
+
+        /// <summary>
         /// Saves PNG to a file.
         /// </summary>
         public string SavePng(string path) => Png().WriteBinary(path);
@@ -387,7 +436,17 @@ public static class Otp {
         public void SaveJpeg(Stream stream) => QR.SaveJpeg(Uri(), stream, Options);
 
         /// <summary>
-        /// Saves based on file extension (.png/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
+        /// Saves WebP to a file.
+        /// </summary>
+        public string SaveWebp(string path) => Webp().WriteBinary(path);
+
+        /// <summary>
+        /// Saves WebP to a stream.
+        /// </summary>
+        public void SaveWebp(Stream stream) => QR.SaveWebp(Uri(), stream, Options);
+
+        /// <summary>
+        /// Saves based on file extension (.png/.webp/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) => QR.Save(Uri(), path, Options, title);
     }
@@ -477,6 +536,11 @@ public static class Otp {
         public byte[] Jpeg() => QrEasy.RenderJpeg(Uri(), Options);
 
         /// <summary>
+        /// Renders WebP bytes.
+        /// </summary>
+        public byte[] Webp() => QrEasy.RenderWebp(Uri(), Options);
+
+        /// <summary>
         /// Saves PNG to a file.
         /// </summary>
         public string SavePng(string path) => Png().WriteBinary(path);
@@ -525,7 +589,17 @@ public static class Otp {
         public void SaveJpeg(Stream stream) => QR.SaveJpeg(Uri(), stream, Options);
 
         /// <summary>
-        /// Saves based on file extension (.png/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
+        /// Saves WebP to a file.
+        /// </summary>
+        public string SaveWebp(string path) => Webp().WriteBinary(path);
+
+        /// <summary>
+        /// Saves WebP to a stream.
+        /// </summary>
+        public void SaveWebp(Stream stream) => QR.SaveWebp(Uri(), stream, Options);
+
+        /// <summary>
+        /// Saves based on file extension (.png/.webp/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) => QR.Save(Uri(), path, Options, title);
     }

--- a/CodeGlyphX/Pdf417Code.Builder.cs
+++ b/CodeGlyphX/Pdf417Code.Builder.cs
@@ -281,6 +281,13 @@ public static partial class Pdf417Code {
         }
 
         /// <summary>
+        /// Saves WebP to a file.
+        /// </summary>
+        public string SaveWebp(string path) {
+            return _text is not null ? Pdf417Code.SaveWebp(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveWebp(_bytes!, path, _encodeOptions, _renderOptions);
+        }
+
+        /// <summary>
         /// Saves BMP to a file.
         /// </summary>
         public string SaveBmp(string path) {

--- a/CodeGlyphX/Pdf417Code.Save.Bytes.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Bytes.cs
@@ -19,6 +19,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -102,6 +103,14 @@ public static partial class Pdf417Code {
     public static string SaveJpeg(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var jpeg = Jpeg(data, encodeOptions, renderOptions);
         return jpeg.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 WebP to a file for byte payloads.
+    /// </summary>
+    public static string SaveWebp(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var webp = Webp(data, encodeOptions, renderOptions);
+        return webp.WriteBinary(path);
     }
 
     /// <summary>
@@ -213,6 +222,16 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 WebP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveWebp(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        var opts = BuildPngOptions(renderOptions);
+        var quality = renderOptions?.WebpQuality ?? 100;
+        MatrixWebpRenderer.RenderToStream(modules, opts, stream, quality);
+    }
+
+    /// <summary>
     /// Saves PDF417 BMP to a stream for byte payloads.
     /// </summary>
     public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -311,7 +330,7 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -326,6 +345,8 @@ public static partial class Pdf417Code {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(data, path, encodeOptions, renderOptions);
+            case ".webp":
+                return SaveWebp(data, path, encodeOptions, renderOptions);
             case ".svg":
                 return SaveSvg(data, path, encodeOptions, renderOptions);
             case ".html":

--- a/CodeGlyphX/Pdf417Code.Save.Text.A.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.A.cs
@@ -174,6 +174,14 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 WebP to a file.
+    /// </summary>
+    public static string SaveWebp(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var webp = Webp(text, encodeOptions, renderOptions);
+        return webp.WriteBinary(path);
+    }
+
+    /// <summary>
     /// Saves PDF417 BMP to a file.
     /// </summary>
     public static string SaveBmp(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -277,6 +285,14 @@ public static partial class Pdf417Code {
     public static string SaveJpeg(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var jpeg = Jpeg(data, encodeOptions, renderOptions);
         return jpeg.WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves PDF417 WebP to a file for byte payloads.
+    /// </summary>
+    public static string SaveWebp(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var webp = Webp(data, encodeOptions, renderOptions);
+        return webp.WriteBinary(path);
     }
 
     /// <summary>

--- a/CodeGlyphX/Pdf417Code.Save.Text.B.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.B.cs
@@ -19,6 +19,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -67,6 +68,16 @@ public static partial class Pdf417Code {
         var opts = BuildPngOptions(renderOptions);
         var quality = renderOptions?.JpegQuality ?? 85;
         MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+    }
+
+    /// <summary>
+    /// Saves PDF417 WebP to a stream.
+    /// </summary>
+    public static void SaveWebp(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        var opts = BuildPngOptions(renderOptions);
+        var quality = renderOptions?.WebpQuality ?? 100;
+        MatrixWebpRenderer.RenderToStream(modules, opts, stream, quality);
     }
 
     /// <summary>
@@ -178,6 +189,16 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
+    /// Saves PDF417 WebP to a stream for byte payloads.
+    /// </summary>
+    public static void SaveWebp(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        var opts = BuildPngOptions(renderOptions);
+        var quality = renderOptions?.WebpQuality ?? 100;
+        MatrixWebpRenderer.RenderToStream(modules, opts, stream, quality);
+    }
+
+    /// <summary>
     /// Saves PDF417 BMP to a stream for byte payloads.
     /// </summary>
     public static void SaveBmp(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -276,7 +297,7 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves PDF417 to a file based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -291,6 +312,8 @@ public static partial class Pdf417Code {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(text, path, encodeOptions, renderOptions);
+            case ".webp":
+                return SaveWebp(text, path, encodeOptions, renderOptions);
             case ".svg":
                 return SaveSvg(text, path, encodeOptions, renderOptions);
             case ".html":
@@ -330,7 +353,7 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -345,6 +368,8 @@ public static partial class Pdf417Code {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return SavePng(data, path, encodeOptions, renderOptions);
+            case ".webp":
+                return SaveWebp(data, path, encodeOptions, renderOptions);
             case ".svg":
                 return SaveSvg(data, path, encodeOptions, renderOptions);
             case ".html":

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -19,6 +19,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -117,6 +118,16 @@ public static partial class Pdf417Code {
         var opts = BuildPngOptions(renderOptions);
         var quality = renderOptions?.JpegQuality ?? 85;
         return MatrixJpegRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders PDF417 as WebP from bytes.
+    /// </summary>
+    public static byte[] Webp(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        var opts = BuildPngOptions(renderOptions);
+        var quality = renderOptions?.WebpQuality ?? 100;
+        return MatrixWebpRenderer.Render(modules, opts, quality);
     }
 
     /// <summary>
@@ -300,6 +311,16 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
+    /// Renders PDF417 as WebP.
+    /// </summary>
+    public static byte[] Webp(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = Encode(text, encodeOptions);
+        var opts = BuildPngOptions(renderOptions);
+        var quality = renderOptions?.WebpQuality ?? 100;
+        return MatrixWebpRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
     /// Renders PDF417 as BMP.
     /// </summary>
     public static byte[] Bmp(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
@@ -411,6 +432,16 @@ public static partial class Pdf417Code {
         var opts = BuildPngOptions(renderOptions);
         var quality = renderOptions?.JpegQuality ?? 85;
         return MatrixJpegRenderer.Render(modules, opts, quality);
+    }
+
+    /// <summary>
+    /// Renders PDF417 as WebP from bytes.
+    /// </summary>
+    public static byte[] Webp(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        var opts = BuildPngOptions(renderOptions);
+        var quality = renderOptions?.WebpQuality ?? 100;
+        return MatrixWebpRenderer.Render(modules, opts, quality);
     }
 
     /// <summary>

--- a/CodeGlyphX/QR.Builder.cs
+++ b/CodeGlyphX/QR.Builder.cs
@@ -452,6 +452,22 @@ public static partial class QR {
         }
 
         /// <summary>
+        /// Saves WebP to a file.
+        /// </summary>
+        public string SaveWebp(string path) => _payloadData is null ? QR.SaveWebp(_payload, path, Options) : QR.SaveWebp(_payloadData, path, Options);
+
+        /// <summary>
+        /// Saves WebP to a stream.
+        /// </summary>
+        public void SaveWebp(Stream stream) {
+            if (_payloadData is null) {
+                QR.SaveWebp(_payload, stream, Options);
+            } else {
+                QR.SaveWebp(_payloadData, stream, Options);
+            }
+        }
+
+        /// <summary>
         /// Saves BMP to a file.
         /// </summary>
         public string SaveBmp(string path) => _payloadData is null ? QR.SaveBmp(_payload, path, Options) : QR.SaveBmp(_payloadData, path, Options);

--- a/CodeGlyphX/QR.Save.cs
+++ b/CodeGlyphX/QR.Save.cs
@@ -131,6 +131,34 @@ public static partial class QR {
     }
 
     /// <summary>
+    /// Saves a WebP QR to a file.
+    /// </summary>
+    public static string SaveWebp(string payload, string path, QrEasyOptions? options = null) {
+        return Webp(payload, options).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a WebP QR to a file for a payload with embedded defaults.
+    /// </summary>
+    public static string SaveWebp(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        return Webp(payload, options).WriteBinary(path);
+    }
+
+    /// <summary>
+    /// Saves a WebP QR to a stream.
+    /// </summary>
+    public static void SaveWebp(string payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderWebpToStream(payload, stream, options);
+    }
+
+    /// <summary>
+    /// Saves a WebP QR to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void SaveWebp(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        QrEasy.RenderWebpToStream(payload, stream, options);
+    }
+
+    /// <summary>
     /// Saves a BMP QR to a file.
     /// </summary>
     public static string SaveBmp(string payload, string path, QrEasyOptions? options = null) {
@@ -517,7 +545,7 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -525,7 +553,7 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveAuto(string payload, string path, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, string? title = null) {
@@ -534,7 +562,7 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -556,6 +584,8 @@ public static partial class QR {
         switch (ext.ToLowerInvariant()) {
             case ".png":
                 return payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options);
+            case ".webp":
+                return payloadData is null ? SaveWebp(payload, path, options) : SaveWebp(payloadData, path, options);
             case ".svg":
                 return payloadData is null ? SaveSvg(payload, path, options) : SaveSvg(payloadData, path, options);
             case ".html":

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -110,6 +110,11 @@ public static partial class QR {
     public static byte[] Jpeg(string payload, QrEasyOptions? options = null) => QrEasy.RenderJpeg(payload, options);
 
     /// <summary>
+    /// Renders a QR code as WebP.
+    /// </summary>
+    public static byte[] Webp(string payload, QrEasyOptions? options = null) => QrEasy.RenderWebp(payload, options);
+
+    /// <summary>
     /// Detects a payload type and renders a QR code as JPEG.
     /// </summary>
     public static byte[] JpegAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
@@ -117,9 +122,21 @@ public static partial class QR {
     }
 
     /// <summary>
+    /// Detects a payload type and renders a QR code as WebP.
+    /// </summary>
+    public static byte[] WebpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.RenderWebpAuto(payload, detectOptions, options);
+    }
+
+    /// <summary>
     /// Renders a QR code as JPEG for a payload with embedded defaults.
     /// </summary>
     public static byte[] Jpeg(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderJpeg(payload, options);
+
+    /// <summary>
+    /// Renders a QR code as WebP for a payload with embedded defaults.
+    /// </summary>
+    public static byte[] Webp(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderWebp(payload, options);
 
     /// <summary>
     /// Renders a QR code as BMP.
@@ -366,4 +383,3 @@ public static partial class QR {
         return QrEasy.RenderAscii(payload, asciiOptions, options);
     }
 }
-

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -259,6 +259,7 @@ public static partial class QrEasy {
             LogoBackground = opts.LogoBackground,
             LogoCornerRadiusPx = opts.LogoCornerRadiusPx,
             JpegQuality = opts.JpegQuality,
+            WebpQuality = opts.WebpQuality,
             IcoSizes = opts.IcoSizes is null ? null : (int[])opts.IcoSizes.Clone(),
             IcoPreserveAspectRatio = opts.IcoPreserveAspectRatio,
             HtmlEmailSafeTable = opts.HtmlEmailSafeTable,

--- a/CodeGlyphX/QrEasy.Render.A.cs
+++ b/CodeGlyphX/QrEasy.Render.A.cs
@@ -18,6 +18,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 
@@ -268,12 +269,31 @@ public static partial class QrEasy {
     }
 
     /// <summary>
+    /// Renders a QR code as WebP.
+    /// </summary>
+    public static byte[] RenderWebp(string payload, QrEasyOptions? options = null) {
+        var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, qr);
+        return QrWebpRenderer.Render(qr.Modules, render, opts.WebpQuality);
+    }
+
+    /// <summary>
     /// Detects a payload type and renders a QR code as JPEG.
     /// </summary>
     public static byte[] RenderJpegAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
         return RenderJpeg(detected, options);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as WebP.
+    /// </summary>
+    public static byte[] RenderWebpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var detected = QrPayloads.Detect(payload, detectOptions);
+        return RenderWebp(detected, options);
     }
 
     /// <summary>
@@ -284,6 +304,16 @@ public static partial class QrEasy {
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, qr);
         QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+    }
+
+    /// <summary>
+    /// Renders a QR code as WebP to a stream.
+    /// </summary>
+    public static void RenderWebpToStream(string payload, Stream stream, QrEasyOptions? options = null) {
+        var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
+        var qr = Encode(payload, opts);
+        var render = BuildPngOptions(opts, qr);
+        QrWebpRenderer.RenderToStream(qr.Modules, render, stream, opts.WebpQuality);
     }
 
     /// <summary>
@@ -299,6 +329,18 @@ public static partial class QrEasy {
     }
 
     /// <summary>
+    /// Renders a QR code as WebP and writes it to a file.
+    /// </summary>
+    /// <param name="payload">Payload text.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderWebpToFile(string payload, string path, QrEasyOptions? options = null) {
+        var webp = RenderWebp(payload, options);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
     /// Renders a QR code as JPEG and writes it to a file for a payload with embedded defaults.
     /// </summary>
     /// <param name="payload">Payload with embedded defaults.</param>
@@ -308,6 +350,18 @@ public static partial class QrEasy {
     public static string RenderJpegToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var jpeg = RenderJpeg(payload, options);
         return RenderIO.WriteBinary(path, jpeg);
+    }
+
+    /// <summary>
+    /// Renders a QR code as WebP and writes it to a file for a payload with embedded defaults.
+    /// </summary>
+    /// <param name="payload">Payload with embedded defaults.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">Optional rendering options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderWebpToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
+        var webp = RenderWebp(payload, options);
+        return RenderIO.WriteBinary(path, webp);
     }
 
     /// <summary>
@@ -322,6 +376,17 @@ public static partial class QrEasy {
     }
 
     /// <summary>
+    /// Renders a QR code as WebP for a payload with embedded defaults.
+    /// </summary>
+    public static byte[] RenderWebp(QrPayloadData payload, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, qr);
+        return QrWebpRenderer.Render(qr.Modules, render, opts.WebpQuality);
+    }
+
+    /// <summary>
     /// Renders a QR code as JPEG to a stream for a payload with embedded defaults.
     /// </summary>
     public static void RenderJpegToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
@@ -330,6 +395,17 @@ public static partial class QrEasy {
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, qr);
         QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+    }
+
+    /// <summary>
+    /// Renders a QR code as WebP to a stream for a payload with embedded defaults.
+    /// </summary>
+    public static void RenderWebpToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var render = BuildPngOptions(opts, qr);
+        QrWebpRenderer.RenderToStream(qr.Modules, render, stream, opts.WebpQuality);
     }
 
     /// <summary>

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -230,6 +230,11 @@ public sealed class QrEasyOptions {
     public int JpegQuality { get; set; } = 85;
 
     /// <summary>
+    /// WebP quality (0..100). Values &gt;= 100 use lossless VP8L.
+    /// </summary>
+    public int WebpQuality { get; set; } = 100;
+
+    /// <summary>
     /// ICO output sizes in pixels (1..256). Defaults to common icon sizes.
     /// </summary>
     public int[]? IcoSizes { get; set; }

--- a/README.md
+++ b/README.md
@@ -374,12 +374,12 @@ Based on public docs as of 2026-01-18. Capabilities depend on optional renderer 
 - [x] Data Matrix + MicroPDF417 + PDF417 encode + decode
 - [x] Matrix barcode encoding (Data Matrix / MicroPDF417 / PDF417 / KIX / GS1 DataBar) with dedicated matrix renderers
 - [x] SVG / SVGZ / HTML / PNG / JPEG / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII renderers
-- [x] Image decode: PNG / JPEG / GIF / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / TIFF
+- [x] Image decode: PNG / JPEG / WebP / GIF / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / TIFF
 - [x] Base64 + data URI helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone, SMS, Contact, Calendar, OTP, Social)
 - [x] WPF controls and demo apps
 - [x] Aztec encode + decode (module matrix + pixel)
-- [x] Aztec render helpers (PNG/SVG/SVGZ/HTML/JPEG/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/PDF/EPS/ASCII + Save by extension)
+- [x] Aztec render helpers (PNG/SVG/SVGZ/HTML/JPEG/WebP/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/PDF/EPS/ASCII + Save by extension)
 
 ## AOT & trimming
 
@@ -395,6 +395,7 @@ For other matrix barcodes (e.g., KIX/Royal Mail 4‑State), use the `Matrix*` re
 | --- | --- | --- |
 | PNG | `.png` | Raster |
 | JPEG | `.jpg`, `.jpeg` | Raster, quality via options |
+| WebP | `.webp` | Raster, quality via options (lossless when quality &gt;= 100) |
 | BMP | `.bmp` | Raster |
 | PPM | `.ppm` | Raster (portable pixmap) |
 | PBM | `.pbm` | Raster (portable bitmap) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,6 +35,7 @@ This list is mostly **work we still want to do**. The "Recently completed" secti
 - Added stylized art decode pack to scenario runs with pass‑rate + timing summaries.
 - CI: PR website build check (static output) before merge.
 - Managed WebP VP8 lossy encode (intra), alpha (ALPH), segmentation, and skip-coefficient support. [formats][webp]
+- End-to-end WebP output across QR/Barcode/Matrix APIs (Save/Render + extension routing) + WebP quality options. [formats][webp][dx]
 
 ## Milestones (priority, no dates)
 ### P0 — Reliability & clarity
@@ -53,7 +54,6 @@ This list is mostly **work we still want to do**. The "Recently completed" secti
 - Preset schema + v1 packs/shape sets/palettes. [style]
 
 ### P2 — Platform breadth & UX
-- WebP decode + encode (lossless + VP8 lossy intra complete; remaining: VP8 inter if encountered). [formats][webp]
 - Expand format corpus (JPEG progressive/CMYK, GIF variants, BMP/ICO edge cases) and schedule periodic **local** full runs. [formats]
 - AOT evaluation + documentation of safe paths. [aot]
 - Add symbology packs + golden vectors (MaxiCode, rMQR, etc.). [symbology][tests]


### PR DESCRIPTION
## Summary\n- add WebP render/save across QR/Barcode/Aztec/DataMatrix/PDF417 with WebpQuality options + extension routing\n- update README/website docs/roadmap for WebP output and decoding\n\n## Testing\n- dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0\n- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0\n- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build