### PR TITLE
Fix Aztec .webp save routing

### DIFF
--- a/CodeGlyphX.Tests/AztecTests.cs
+++ b/CodeGlyphX.Tests/AztecTests.cs
@@ -1,7 +1,10 @@
+using System;
+using System.IO;
 using System.Threading;
 using CodeGlyphX;
 using CodeGlyphX.Aztec;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
 using Xunit;
 
 namespace CodeGlyphX.Tests;
@@ -49,6 +52,21 @@ public sealed class AztecTests {
         cts.Cancel();
 
         Assert.False(AztecCode.TryDecode(pixels, width, height, width * 4, PixelFormat.Rgba32, cts.Token, out _));
+    }
+
+    [Fact]
+    public void Aztec_Save_ByExtension_WritesWebp() {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
+
+        try {
+            AztecCode.Save("AZTEC-WEBP", path);
+            var bytes = File.ReadAllBytes(path);
+            Assert.True(WebpReader.IsWebp(bytes));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
     }
 
     private static byte[] Rotate90Rgba(byte[] pixels, int width, int height, out int outWidth, out int outHeight) {

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -349,7 +349,7 @@ public static partial class AztecCode {
     }
 
     /// <summary>
-    /// Saves Aztec to a file based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Aztec to a file based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -376,6 +376,8 @@ public static partial class AztecCode {
             case ".jpg":
             case ".jpeg":
                 return RenderIO.WriteBinary(path, Jpeg(text, encodeOptions, renderOptions));
+            case ".webp":
+                return RenderIO.WriteBinary(path, Webp(text, encodeOptions, renderOptions));
             case ".bmp":
                 return RenderIO.WriteBinary(path, Bmp(text, encodeOptions, renderOptions));
             case ".ppm":

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -349,7 +349,7 @@ public static partial class AztecCode {
     }
 
     /// <summary>
-    /// Saves Aztec to a file based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Aztec to a file based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps/.txt).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {

--- a/CodeGlyphX/BarcodeOptions.cs
+++ b/CodeGlyphX/BarcodeOptions.cs
@@ -38,7 +38,7 @@ public sealed class BarcodeOptions {
     public int JpegQuality { get; set; } = 90;
 
     /// <summary>
-    /// WebP quality (0..100). Values &gt;= 100 use lossless VP8L.
+    /// WebP quality (0..100). A value of 100 uses lossless VP8L.
     /// </summary>
     public int WebpQuality { get; set; } = 100;
 

--- a/CodeGlyphX/MatrixOptions.cs
+++ b/CodeGlyphX/MatrixOptions.cs
@@ -33,7 +33,7 @@ public sealed class MatrixOptions {
     public int JpegQuality { get; set; } = 85;
 
     /// <summary>
-    /// WebP quality (0..100). Values &gt;= 100 use lossless VP8L.
+    /// WebP quality (0..100). A value of 100 uses lossless VP8L.
     /// </summary>
     public int WebpQuality { get; set; } = 100;
 

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -230,7 +230,7 @@ public sealed class QrEasyOptions {
     public int JpegQuality { get; set; } = 85;
 
     /// <summary>
-    /// WebP quality (0..100). Values &gt;= 100 use lossless VP8L.
+    /// WebP quality (0..100). A value of 100 uses lossless VP8L.
     /// </summary>
     public int WebpQuality { get; set; } = 100;
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Based on public docs as of 2026-01-18. Capabilities depend on optional renderer 
 - [x] 1D barcode encode + decode
 - [x] Data Matrix + MicroPDF417 + PDF417 encode + decode
 - [x] Matrix barcode encoding (Data Matrix / MicroPDF417 / PDF417 / KIX / GS1 DataBar) with dedicated matrix renderers
-- [x] SVG / SVGZ / HTML / PNG / JPEG / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII renderers
+- [x] SVG / SVGZ / HTML / PNG / JPEG / WebP / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII renderers
 - [x] Image decode: PNG / JPEG / WebP / GIF / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / TIFF
 - [x] Base64 + data URI helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone, SMS, Contact, Calendar, OTP, Social)
@@ -395,7 +395,7 @@ For other matrix barcodes (e.g., KIX/Royal Mail 4‑State), use the `Matrix*` re
 | --- | --- | --- |
 | PNG | `.png` | Raster |
 | JPEG | `.jpg`, `.jpeg` | Raster, quality via options |
-| WebP | `.webp` | Raster, quality via options (lossless when quality &gt;= 100) |
+| WebP | `.webp` | Raster, quality via options (lossless at quality 100) |
 | BMP | `.bmp` | Raster |
 | PPM | `.ppm` | Raster (portable pixmap) |
 | PBM | `.pbm` | Raster (portable bitmap) |


### PR DESCRIPTION
## Summary\n- add .webp extension routing to AztecCode.Save(...) and update extension list\n- align WebP quality docs to lossless at quality 100\n- include WebP in renderer feature list\n\n## Testing\n- dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0\n- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0\n- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build