### PR TITLE
Add WebP follow-up coverage and quality clamping

### DIFF
--- a/CodeGlyphX.Tests/SaveByExtensionWebpTests.cs
+++ b/CodeGlyphX.Tests/SaveByExtensionWebpTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using CodeGlyphX;
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class SaveByExtensionWebpTests {
+    [Fact]
+    public void Qr_Save_ByExtension_WritesWebp() {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
+
+        try {
+            QR.Save("QR-WEBP", path);
+            var bytes = File.ReadAllBytes(path);
+            Assert.True(WebpReader.IsWebp(bytes));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Barcode_Save_ByExtension_WritesWebp() {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
+
+        try {
+            Barcode.Save(BarcodeType.Code128, "CODE128-WEBP", path);
+            var bytes = File.ReadAllBytes(path);
+            Assert.True(WebpReader.IsWebp(bytes));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void DataMatrix_Save_ByExtension_WritesWebp() {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
+
+        try {
+            DataMatrixCode.Save("DM-WEBP", path);
+            var bytes = File.ReadAllBytes(path);
+            Assert.True(WebpReader.IsWebp(bytes));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Pdf417_Save_ByExtension_WritesWebp() {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
+
+        try {
+            Pdf417Code.Save("PDF417-WEBP", path);
+            var bytes = File.ReadAllBytes(path);
+            Assert.True(WebpReader.IsWebp(bytes));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/CodeGlyphX.Tests/WebpQualityClampTests.cs
+++ b/CodeGlyphX.Tests/WebpQualityClampTests.cs
@@ -1,0 +1,39 @@
+using CodeGlyphX;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class WebpQualityClampTests {
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(25, 25)]
+    [InlineData(100, 100)]
+    [InlineData(150, 100)]
+    public void QrEasyOptions_WebpQuality_Clamps(int input, int expected) {
+        var options = new QrEasyOptions { WebpQuality = input };
+        Assert.Equal(expected, options.WebpQuality);
+    }
+
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(25, 25)]
+    [InlineData(100, 100)]
+    [InlineData(150, 100)]
+    public void MatrixOptions_WebpQuality_Clamps(int input, int expected) {
+        var options = new MatrixOptions { WebpQuality = input };
+        Assert.Equal(expected, options.WebpQuality);
+    }
+
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(25, 25)]
+    [InlineData(100, 100)]
+    [InlineData(150, 100)]
+    public void BarcodeOptions_WebpQuality_Clamps(int input, int expected) {
+        var options = new BarcodeOptions { WebpQuality = input };
+        Assert.Equal(expected, options.WebpQuality);
+    }
+}

--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -345,7 +345,7 @@ public static partial class Barcode {
     }
 
     /// <summary>
-    /// Saves a barcode to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves a barcode to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {

--- a/CodeGlyphX/BarcodeOptions.cs
+++ b/CodeGlyphX/BarcodeOptions.cs
@@ -40,7 +40,12 @@ public sealed class BarcodeOptions {
     /// <summary>
     /// WebP quality (0..100). A value of 100 uses lossless VP8L.
     /// </summary>
-    public int WebpQuality { get; set; } = 100;
+    public int WebpQuality {
+        get => _webpQuality;
+        set => _webpQuality = ClampWebpQuality(value);
+    }
+
+    private int _webpQuality = 100;
 
     /// <summary>
     /// ICO output sizes in pixels (1..256). Defaults to common icon sizes.
@@ -81,4 +86,10 @@ public sealed class BarcodeOptions {
     /// Label font family (SVG/HTML).
     /// </summary>
     public string LabelFontFamily { get; set; } = RenderDefaults.BarcodeLabelFontFamily;
+
+    private static int ClampWebpQuality(int value) {
+        if (value < 0) return 0;
+        if (value > 100) return 100;
+        return value;
+    }
 }

--- a/CodeGlyphX/DataMatrixCode.Save.Text.B.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.B.cs
@@ -296,7 +296,7 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Data Matrix to a file based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
@@ -352,7 +352,7 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {

--- a/CodeGlyphX/MatrixOptions.cs
+++ b/CodeGlyphX/MatrixOptions.cs
@@ -35,7 +35,12 @@ public sealed class MatrixOptions {
     /// <summary>
     /// WebP quality (0..100). A value of 100 uses lossless VP8L.
     /// </summary>
-    public int WebpQuality { get; set; } = 100;
+    public int WebpQuality {
+        get => _webpQuality;
+        set => _webpQuality = ClampWebpQuality(value);
+    }
+
+    private int _webpQuality = 100;
 
     /// <summary>
     /// ICO output sizes in pixels (1..256). Defaults to common icon sizes.
@@ -51,4 +56,10 @@ public sealed class MatrixOptions {
     /// When true, renders HTML using email-safe tables.
     /// </summary>
     public bool HtmlEmailSafeTable { get; set; }
+
+    private static int ClampWebpQuality(int value) {
+        if (value < 0) return 0;
+        if (value > 100) return 100;
+        return value;
+    }
 }

--- a/CodeGlyphX/Pdf417Code.Save.Text.B.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.B.cs
@@ -297,7 +297,7 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves PDF417 to a file based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
@@ -353,7 +353,7 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves PDF417 to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {

--- a/CodeGlyphX/QR.Save.cs
+++ b/CodeGlyphX/QR.Save.cs
@@ -545,7 +545,7 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string payload, string path, QrEasyOptions? options = null, string? title = null) {
@@ -553,7 +553,7 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveAuto(string payload, string path, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, string? title = null) {
@@ -562,7 +562,7 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, string? title = null) {

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -232,7 +232,12 @@ public sealed class QrEasyOptions {
     /// <summary>
     /// WebP quality (0..100). A value of 100 uses lossless VP8L.
     /// </summary>
-    public int WebpQuality { get; set; } = 100;
+    public int WebpQuality {
+        get => _webpQuality;
+        set => _webpQuality = ClampWebpQuality(value);
+    }
+
+    private int _webpQuality = 100;
 
     /// <summary>
     /// ICO output sizes in pixels (1..256). Defaults to common icon sizes.
@@ -248,4 +253,10 @@ public sealed class QrEasyOptions {
     /// When true, renders HTML using email-safe tables.
     /// </summary>
     public bool HtmlEmailSafeTable { get; set; }
+
+    private static int ClampWebpQuality(int value) {
+        if (value < 0) return 0;
+        if (value > 100) return 100;
+        return value;
+    }
 }


### PR DESCRIPTION
## Summary
- update Save-by-extension docs for QR/Barcode/DataMatrix/PDF417 to include svg.gz/htm/jpeg/ps
- clamp WebpQuality to the 0..100 range in option models
- add WebP save-by-extension and WebpQuality clamp tests

## Testing
- dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0
- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build