### PR TITLE
Deduplicate WebP quality clamping

### DIFF
--- a/CodeGlyphX.Tests/SaveByExtensionWebpTests.cs
+++ b/CodeGlyphX.Tests/SaveByExtensionWebpTests.cs
@@ -9,55 +9,29 @@ namespace CodeGlyphX.Tests;
 public sealed class SaveByExtensionWebpTests {
     [Fact]
     public void Qr_Save_ByExtension_WritesWebp() {
-        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
-
-        try {
-            QR.Save("QR-WEBP", path);
-            var bytes = File.ReadAllBytes(path);
-            Assert.True(WebpReader.IsWebp(bytes));
-        } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
-            }
-        }
+        AssertWebpSaved(path => QR.Save("QR-WEBP", path));
     }
 
     [Fact]
     public void Barcode_Save_ByExtension_WritesWebp() {
-        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
-
-        try {
-            Barcode.Save(BarcodeType.Code128, "CODE128-WEBP", path);
-            var bytes = File.ReadAllBytes(path);
-            Assert.True(WebpReader.IsWebp(bytes));
-        } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
-            }
-        }
+        AssertWebpSaved(path => Barcode.Save(BarcodeType.Code128, "CODE128-WEBP", path));
     }
 
     [Fact]
     public void DataMatrix_Save_ByExtension_WritesWebp() {
-        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
-
-        try {
-            DataMatrixCode.Save("DM-WEBP", path);
-            var bytes = File.ReadAllBytes(path);
-            Assert.True(WebpReader.IsWebp(bytes));
-        } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
-            }
-        }
+        AssertWebpSaved(path => DataMatrixCode.Save("DM-WEBP", path));
     }
 
     [Fact]
     public void Pdf417_Save_ByExtension_WritesWebp() {
+        AssertWebpSaved(path => Pdf417Code.Save("PDF417-WEBP", path));
+    }
+
+    private static void AssertWebpSaved(Action<string> saveAction) {
         var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.webp");
 
         try {
-            Pdf417Code.Save("PDF417-WEBP", path);
+            saveAction(path);
             var bytes = File.ReadAllBytes(path);
             Assert.True(WebpReader.IsWebp(bytes));
         } finally {

--- a/CodeGlyphX.Tests/WebpQualityClampTests.cs
+++ b/CodeGlyphX.Tests/WebpQualityClampTests.cs
@@ -10,30 +10,9 @@ public sealed class WebpQualityClampTests {
     [InlineData(25, 25)]
     [InlineData(100, 100)]
     [InlineData(150, 100)]
-    public void QrEasyOptions_WebpQuality_Clamps(int input, int expected) {
-        var options = new QrEasyOptions { WebpQuality = input };
-        Assert.Equal(expected, options.WebpQuality);
-    }
-
-    [Theory]
-    [InlineData(-5, 0)]
-    [InlineData(0, 0)]
-    [InlineData(25, 25)]
-    [InlineData(100, 100)]
-    [InlineData(150, 100)]
-    public void MatrixOptions_WebpQuality_Clamps(int input, int expected) {
-        var options = new MatrixOptions { WebpQuality = input };
-        Assert.Equal(expected, options.WebpQuality);
-    }
-
-    [Theory]
-    [InlineData(-5, 0)]
-    [InlineData(0, 0)]
-    [InlineData(25, 25)]
-    [InlineData(100, 100)]
-    [InlineData(150, 100)]
-    public void BarcodeOptions_WebpQuality_Clamps(int input, int expected) {
-        var options = new BarcodeOptions { WebpQuality = input };
-        Assert.Equal(expected, options.WebpQuality);
+    public void WebpQuality_Clamps_For_All_Options(int input, int expected) {
+        Assert.Equal(expected, new QrEasyOptions { WebpQuality = input }.WebpQuality);
+        Assert.Equal(expected, new MatrixOptions { WebpQuality = input }.WebpQuality);
+        Assert.Equal(expected, new BarcodeOptions { WebpQuality = input }.WebpQuality);
     }
 }

--- a/CodeGlyphX/BarcodeOptions.cs
+++ b/CodeGlyphX/BarcodeOptions.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX;
 
@@ -42,7 +43,7 @@ public sealed class BarcodeOptions {
     /// </summary>
     public int WebpQuality {
         get => _webpQuality;
-        set => _webpQuality = ClampWebpQuality(value);
+        set => _webpQuality = WebpQualityClamp.Clamp(value);
     }
 
     private int _webpQuality = 100;
@@ -87,9 +88,4 @@ public sealed class BarcodeOptions {
     /// </summary>
     public string LabelFontFamily { get; set; } = RenderDefaults.BarcodeLabelFontFamily;
 
-    private static int ClampWebpQuality(int value) {
-        if (value < 0) return 0;
-        if (value > 100) return 100;
-        return value;
-    }
 }

--- a/CodeGlyphX/MatrixOptions.cs
+++ b/CodeGlyphX/MatrixOptions.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX;
 
@@ -37,7 +38,7 @@ public sealed class MatrixOptions {
     /// </summary>
     public int WebpQuality {
         get => _webpQuality;
-        set => _webpQuality = ClampWebpQuality(value);
+        set => _webpQuality = WebpQualityClamp.Clamp(value);
     }
 
     private int _webpQuality = 100;
@@ -57,9 +58,4 @@ public sealed class MatrixOptions {
     /// </summary>
     public bool HtmlEmailSafeTable { get; set; }
 
-    private static int ClampWebpQuality(int value) {
-        if (value < 0) return 0;
-        if (value > 100) return 100;
-        return value;
-    }
 }

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX;
 
@@ -234,7 +235,7 @@ public sealed class QrEasyOptions {
     /// </summary>
     public int WebpQuality {
         get => _webpQuality;
-        set => _webpQuality = ClampWebpQuality(value);
+        set => _webpQuality = WebpQualityClamp.Clamp(value);
     }
 
     private int _webpQuality = 100;
@@ -254,9 +255,4 @@ public sealed class QrEasyOptions {
     /// </summary>
     public bool HtmlEmailSafeTable { get; set; }
 
-    private static int ClampWebpQuality(int value) {
-        if (value < 0) return 0;
-        if (value > 100) return 100;
-        return value;
-    }
 }

--- a/CodeGlyphX/Rendering/Webp/WebpQualityClamp.cs
+++ b/CodeGlyphX/Rendering/Webp/WebpQualityClamp.cs
@@ -1,0 +1,9 @@
+namespace CodeGlyphX.Rendering.Webp;
+
+internal static class WebpQualityClamp {
+    internal static int Clamp(int value) {
+        if (value < 0) return 0;
+        if (value > 100) return 100;
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize WebP quality clamping in a shared helper
- reuse helper in QrEasyOptions/MatrixOptions/BarcodeOptions
- simplify WebP save-by-extension and clamping tests to reduce duplication

## Testing
- dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0
- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build