### PR TITLE
Deduplicate save-by-extension logic

### DIFF
--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -349,56 +350,26 @@ public static partial class Barcode {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(type, content, path, options);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(type, content, path, options);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(type, content, path, options);
-            case ".webp":
-                return SaveWebp(type, content, path, options);
-            case ".svg":
-                return SaveSvg(type, content, path, options);
-            case ".html":
-            case ".htm":
-                return SaveHtml(type, content, path, options, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(type, content, path, options);
-            case ".bmp":
-                return SaveBmp(type, content, path, options);
-            case ".ppm":
-                return SavePpm(type, content, path, options);
-            case ".pbm":
-                return SavePbm(type, content, path, options);
-            case ".pgm":
-                return SavePgm(type, content, path, options);
-            case ".pam":
-                return SavePam(type, content, path, options);
-            case ".xbm":
-                return SaveXbm(type, content, path, options);
-            case ".xpm":
-                return SaveXpm(type, content, path, options);
-            case ".tga":
-                return SaveTga(type, content, path, options);
-            case ".ico":
-                return SaveIco(type, content, path, options);
-            case ".svgz":
-                return SaveSvgz(type, content, path, options);
-            case ".pdf":
-                return SavePdf(type, content, path, options);
-            case ".eps":
-            case ".ps":
-                return SaveEps(type, content, path, options);
-            default:
-                // Fallback to PNG for unknown extensions to keep the API forgiving.
-                return SavePng(type, content, path, options);
-        }
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => SavePng(type, content, path, options),
+            Png = () => SavePng(type, content, path, options),
+            Webp = () => SaveWebp(type, content, path, options),
+            Svg = () => SaveSvg(type, content, path, options),
+            Svgz = () => SaveSvgz(type, content, path, options),
+            Html = () => SaveHtml(type, content, path, options, title),
+            Jpeg = () => SaveJpeg(type, content, path, options),
+            Bmp = () => SaveBmp(type, content, path, options),
+            Ppm = () => SavePpm(type, content, path, options),
+            Pbm = () => SavePbm(type, content, path, options),
+            Pgm = () => SavePgm(type, content, path, options),
+            Pam = () => SavePam(type, content, path, options),
+            Xbm = () => SaveXbm(type, content, path, options),
+            Xpm = () => SaveXpm(type, content, path, options),
+            Tga = () => SaveTga(type, content, path, options),
+            Ico = () => SaveIco(type, content, path, options),
+            Pdf = () => SavePdf(type, content, path, options),
+            Eps = () => SaveEps(type, content, path, options)
+        });
     }
 
 

--- a/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -333,55 +334,26 @@ public static partial class DataMatrixCode {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(data, path, mode, options);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(data, path, mode, options);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(data, path, mode, options);
-            case ".webp":
-                return SaveWebp(data, path, mode, options);
-            case ".svg":
-                return SaveSvg(data, path, mode, options);
-            case ".html":
-            case ".htm":
-                return SaveHtml(data, path, mode, options, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(data, path, mode, options);
-            case ".bmp":
-                return SaveBmp(data, path, mode, options);
-            case ".ppm":
-                return SavePpm(data, path, mode, options);
-            case ".pbm":
-                return SavePbm(data, path, mode, options);
-            case ".pgm":
-                return SavePgm(data, path, mode, options);
-            case ".pam":
-                return SavePam(data, path, mode, options);
-            case ".xbm":
-                return SaveXbm(data, path, mode, options);
-            case ".xpm":
-                return SaveXpm(data, path, mode, options);
-            case ".tga":
-                return SaveTga(data, path, mode, options);
-            case ".ico":
-                return SaveIco(data, path, mode, options);
-            case ".svgz":
-                return SaveSvgz(data, path, mode, options);
-            case ".pdf":
-                return SavePdf(data, path, mode, options);
-            case ".eps":
-            case ".ps":
-                return SaveEps(data, path, mode, options);
-            default:
-                return SavePng(data, path, mode, options);
-        }
+        return SaveByExtensionHelper.Save(data, path, new SaveByExtensionSpanHandlers {
+            Default = d => SavePng(d, path, mode, options),
+            Png = d => SavePng(d, path, mode, options),
+            Webp = d => SaveWebp(d, path, mode, options),
+            Svg = d => SaveSvg(d, path, mode, options),
+            Svgz = d => SaveSvgz(d, path, mode, options),
+            Html = d => SaveHtml(d, path, mode, options, title),
+            Jpeg = d => SaveJpeg(d, path, mode, options),
+            Bmp = d => SaveBmp(d, path, mode, options),
+            Ppm = d => SavePpm(d, path, mode, options),
+            Pbm = d => SavePbm(d, path, mode, options),
+            Pgm = d => SavePgm(d, path, mode, options),
+            Pam = d => SavePam(d, path, mode, options),
+            Xbm = d => SaveXbm(d, path, mode, options),
+            Xpm = d => SaveXpm(d, path, mode, options),
+            Tga = d => SaveTga(d, path, mode, options),
+            Ico = d => SaveIco(d, path, mode, options),
+            Pdf = d => SavePdf(d, path, mode, options),
+            Eps = d => SaveEps(d, path, mode, options)
+        });
     }
 
 }

--- a/CodeGlyphX/DataMatrixCode.Save.Text.ByExtension.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.ByExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Internal;
 
 namespace CodeGlyphX;
 
@@ -10,55 +11,26 @@ public static partial class DataMatrixCode {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(text, path, mode, options);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(text, path, mode, options);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(text, path, mode, options);
-            case ".webp":
-                return SaveWebp(text, path, mode, options);
-            case ".svg":
-                return SaveSvg(text, path, mode, options);
-            case ".html":
-            case ".htm":
-                return SaveHtml(text, path, mode, options, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(text, path, mode, options);
-            case ".bmp":
-                return SaveBmp(text, path, mode, options);
-            case ".ppm":
-                return SavePpm(text, path, mode, options);
-            case ".pbm":
-                return SavePbm(text, path, mode, options);
-            case ".pgm":
-                return SavePgm(text, path, mode, options);
-            case ".pam":
-                return SavePam(text, path, mode, options);
-            case ".xbm":
-                return SaveXbm(text, path, mode, options);
-            case ".xpm":
-                return SaveXpm(text, path, mode, options);
-            case ".tga":
-                return SaveTga(text, path, mode, options);
-            case ".ico":
-                return SaveIco(text, path, mode, options);
-            case ".svgz":
-                return SaveSvgz(text, path, mode, options);
-            case ".pdf":
-                return SavePdf(text, path, mode, options);
-            case ".eps":
-            case ".ps":
-                return SaveEps(text, path, mode, options);
-            default:
-                return SavePng(text, path, mode, options);
-        }
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => SavePng(text, path, mode, options),
+            Png = () => SavePng(text, path, mode, options),
+            Webp = () => SaveWebp(text, path, mode, options),
+            Svg = () => SaveSvg(text, path, mode, options),
+            Svgz = () => SaveSvgz(text, path, mode, options),
+            Html = () => SaveHtml(text, path, mode, options, title),
+            Jpeg = () => SaveJpeg(text, path, mode, options),
+            Bmp = () => SaveBmp(text, path, mode, options),
+            Ppm = () => SavePpm(text, path, mode, options),
+            Pbm = () => SavePbm(text, path, mode, options),
+            Pgm = () => SavePgm(text, path, mode, options),
+            Pam = () => SavePam(text, path, mode, options),
+            Xbm = () => SaveXbm(text, path, mode, options),
+            Xpm = () => SaveXpm(text, path, mode, options),
+            Tga = () => SaveTga(text, path, mode, options),
+            Ico = () => SaveIco(text, path, mode, options),
+            Pdf = () => SavePdf(text, path, mode, options),
+            Eps = () => SaveEps(text, path, mode, options)
+        });
     }
 
     /// <summary>
@@ -66,55 +38,26 @@ public static partial class DataMatrixCode {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(data, path, mode, options);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(data, path, mode, options);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(data, path, mode, options);
-            case ".webp":
-                return SaveWebp(data, path, mode, options);
-            case ".svg":
-                return SaveSvg(data, path, mode, options);
-            case ".html":
-            case ".htm":
-                return SaveHtml(data, path, mode, options, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(data, path, mode, options);
-            case ".bmp":
-                return SaveBmp(data, path, mode, options);
-            case ".ppm":
-                return SavePpm(data, path, mode, options);
-            case ".pbm":
-                return SavePbm(data, path, mode, options);
-            case ".pgm":
-                return SavePgm(data, path, mode, options);
-            case ".pam":
-                return SavePam(data, path, mode, options);
-            case ".xbm":
-                return SaveXbm(data, path, mode, options);
-            case ".xpm":
-                return SaveXpm(data, path, mode, options);
-            case ".tga":
-                return SaveTga(data, path, mode, options);
-            case ".ico":
-                return SaveIco(data, path, mode, options);
-            case ".svgz":
-                return SaveSvgz(data, path, mode, options);
-            case ".pdf":
-                return SavePdf(data, path, mode, options);
-            case ".eps":
-            case ".ps":
-                return SaveEps(data, path, mode, options);
-            default:
-                return SavePng(data, path, mode, options);
-        }
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => SavePng(data, path, mode, options),
+            Png = () => SavePng(data, path, mode, options),
+            Webp = () => SaveWebp(data, path, mode, options),
+            Svg = () => SaveSvg(data, path, mode, options),
+            Svgz = () => SaveSvgz(data, path, mode, options),
+            Html = () => SaveHtml(data, path, mode, options, title),
+            Jpeg = () => SaveJpeg(data, path, mode, options),
+            Bmp = () => SaveBmp(data, path, mode, options),
+            Ppm = () => SavePpm(data, path, mode, options),
+            Pbm = () => SavePbm(data, path, mode, options),
+            Pgm = () => SavePgm(data, path, mode, options),
+            Pam = () => SavePam(data, path, mode, options),
+            Xbm = () => SaveXbm(data, path, mode, options),
+            Xpm = () => SaveXpm(data, path, mode, options),
+            Tga = () => SaveTga(data, path, mode, options),
+            Ico = () => SaveIco(data, path, mode, options),
+            Pdf = () => SavePdf(data, path, mode, options),
+            Eps = () => SaveEps(data, path, mode, options)
+        });
     }
 
 }

--- a/CodeGlyphX/Internal/SaveByExtensionHelper.cs
+++ b/CodeGlyphX/Internal/SaveByExtensionHelper.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+
+namespace CodeGlyphX.Internal;
+
+internal readonly struct SaveByExtensionHandlers {
+    internal Func<string> Default { get; init; }
+    internal Func<string> Png { get; init; }
+    internal Func<string> Webp { get; init; }
+    internal Func<string> Svg { get; init; }
+    internal Func<string> Svgz { get; init; }
+    internal Func<string> Html { get; init; }
+    internal Func<string> Jpeg { get; init; }
+    internal Func<string> Bmp { get; init; }
+    internal Func<string> Ppm { get; init; }
+    internal Func<string> Pbm { get; init; }
+    internal Func<string> Pgm { get; init; }
+    internal Func<string> Pam { get; init; }
+    internal Func<string> Xbm { get; init; }
+    internal Func<string> Xpm { get; init; }
+    internal Func<string> Tga { get; init; }
+    internal Func<string> Ico { get; init; }
+    internal Func<string> Pdf { get; init; }
+    internal Func<string> Eps { get; init; }
+}
+
+internal delegate string SaveByExtensionSpanHandler(ReadOnlySpan<byte> data);
+
+internal readonly struct SaveByExtensionSpanHandlers {
+    internal SaveByExtensionSpanHandler Default { get; init; }
+    internal SaveByExtensionSpanHandler Png { get; init; }
+    internal SaveByExtensionSpanHandler Webp { get; init; }
+    internal SaveByExtensionSpanHandler Svg { get; init; }
+    internal SaveByExtensionSpanHandler Svgz { get; init; }
+    internal SaveByExtensionSpanHandler Html { get; init; }
+    internal SaveByExtensionSpanHandler Jpeg { get; init; }
+    internal SaveByExtensionSpanHandler Bmp { get; init; }
+    internal SaveByExtensionSpanHandler Ppm { get; init; }
+    internal SaveByExtensionSpanHandler Pbm { get; init; }
+    internal SaveByExtensionSpanHandler Pgm { get; init; }
+    internal SaveByExtensionSpanHandler Pam { get; init; }
+    internal SaveByExtensionSpanHandler Xbm { get; init; }
+    internal SaveByExtensionSpanHandler Xpm { get; init; }
+    internal SaveByExtensionSpanHandler Tga { get; init; }
+    internal SaveByExtensionSpanHandler Ico { get; init; }
+    internal SaveByExtensionSpanHandler Pdf { get; init; }
+    internal SaveByExtensionSpanHandler Eps { get; init; }
+}
+
+internal static class SaveByExtensionHelper {
+    internal static string Save(string path, in SaveByExtensionHandlers handlers) {
+        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
+            return handlers.Svgz();
+        }
+
+        var ext = Path.GetExtension(path);
+        if (string.IsNullOrWhiteSpace(ext)) return handlers.Default();
+
+        switch (ext.ToLowerInvariant()) {
+            case ".png":
+                return handlers.Png();
+            case ".webp":
+                return handlers.Webp();
+            case ".svg":
+                return handlers.Svg();
+            case ".html":
+            case ".htm":
+                return handlers.Html();
+            case ".jpg":
+            case ".jpeg":
+                return handlers.Jpeg();
+            case ".bmp":
+                return handlers.Bmp();
+            case ".ppm":
+                return handlers.Ppm();
+            case ".pbm":
+                return handlers.Pbm();
+            case ".pgm":
+                return handlers.Pgm();
+            case ".pam":
+                return handlers.Pam();
+            case ".xbm":
+                return handlers.Xbm();
+            case ".xpm":
+                return handlers.Xpm();
+            case ".tga":
+                return handlers.Tga();
+            case ".ico":
+                return handlers.Ico();
+            case ".svgz":
+                return handlers.Svgz();
+            case ".pdf":
+                return handlers.Pdf();
+            case ".eps":
+            case ".ps":
+                return handlers.Eps();
+            default:
+                return handlers.Default();
+        }
+    }
+
+    internal static string Save(ReadOnlySpan<byte> data, string path, in SaveByExtensionSpanHandlers handlers) {
+        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
+            return handlers.Svgz(data);
+        }
+
+        var ext = Path.GetExtension(path);
+        if (string.IsNullOrWhiteSpace(ext)) return handlers.Default(data);
+
+        switch (ext.ToLowerInvariant()) {
+            case ".png":
+                return handlers.Png(data);
+            case ".webp":
+                return handlers.Webp(data);
+            case ".svg":
+                return handlers.Svg(data);
+            case ".html":
+            case ".htm":
+                return handlers.Html(data);
+            case ".jpg":
+            case ".jpeg":
+                return handlers.Jpeg(data);
+            case ".bmp":
+                return handlers.Bmp(data);
+            case ".ppm":
+                return handlers.Ppm(data);
+            case ".pbm":
+                return handlers.Pbm(data);
+            case ".pgm":
+                return handlers.Pgm(data);
+            case ".pam":
+                return handlers.Pam(data);
+            case ".xbm":
+                return handlers.Xbm(data);
+            case ".xpm":
+                return handlers.Xpm(data);
+            case ".tga":
+                return handlers.Tga(data);
+            case ".ico":
+                return handlers.Ico(data);
+            case ".svgz":
+                return handlers.Svgz(data);
+            case ".pdf":
+                return handlers.Pdf(data);
+            case ".eps":
+            case ".ps":
+                return handlers.Eps(data);
+            default:
+                return handlers.Default(data);
+        }
+    }
+}

--- a/CodeGlyphX/Pdf417Code.Save.Bytes.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Bytes.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Text;
 using CodeGlyphX.Pdf417;
+using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -334,55 +335,26 @@ public static partial class Pdf417Code {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(data, path, encodeOptions, renderOptions);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(data, path, encodeOptions, renderOptions);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(data, path, encodeOptions, renderOptions);
-            case ".webp":
-                return SaveWebp(data, path, encodeOptions, renderOptions);
-            case ".svg":
-                return SaveSvg(data, path, encodeOptions, renderOptions);
-            case ".html":
-            case ".htm":
-                return SaveHtml(data, path, encodeOptions, renderOptions, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(data, path, encodeOptions, renderOptions);
-            case ".bmp":
-                return SaveBmp(data, path, encodeOptions, renderOptions);
-            case ".ppm":
-                return SavePpm(data, path, encodeOptions, renderOptions);
-            case ".pbm":
-                return SavePbm(data, path, encodeOptions, renderOptions);
-            case ".pgm":
-                return SavePgm(data, path, encodeOptions, renderOptions);
-            case ".pam":
-                return SavePam(data, path, encodeOptions, renderOptions);
-            case ".xbm":
-                return SaveXbm(data, path, encodeOptions, renderOptions);
-            case ".xpm":
-                return SaveXpm(data, path, encodeOptions, renderOptions);
-            case ".tga":
-                return SaveTga(data, path, encodeOptions, renderOptions);
-            case ".ico":
-                return SaveIco(data, path, encodeOptions, renderOptions);
-            case ".svgz":
-                return SaveSvgz(data, path, encodeOptions, renderOptions);
-            case ".pdf":
-                return SavePdf(data, path, encodeOptions, renderOptions);
-            case ".eps":
-            case ".ps":
-                return SaveEps(data, path, encodeOptions, renderOptions);
-            default:
-                return SavePng(data, path, encodeOptions, renderOptions);
-        }
+        return SaveByExtensionHelper.Save(data, path, new SaveByExtensionSpanHandlers {
+            Default = d => SavePng(d, path, encodeOptions, renderOptions),
+            Png = d => SavePng(d, path, encodeOptions, renderOptions),
+            Webp = d => SaveWebp(d, path, encodeOptions, renderOptions),
+            Svg = d => SaveSvg(d, path, encodeOptions, renderOptions),
+            Svgz = d => SaveSvgz(d, path, encodeOptions, renderOptions),
+            Html = d => SaveHtml(d, path, encodeOptions, renderOptions, title),
+            Jpeg = d => SaveJpeg(d, path, encodeOptions, renderOptions),
+            Bmp = d => SaveBmp(d, path, encodeOptions, renderOptions),
+            Ppm = d => SavePpm(d, path, encodeOptions, renderOptions),
+            Pbm = d => SavePbm(d, path, encodeOptions, renderOptions),
+            Pgm = d => SavePgm(d, path, encodeOptions, renderOptions),
+            Pam = d => SavePam(d, path, encodeOptions, renderOptions),
+            Xbm = d => SaveXbm(d, path, encodeOptions, renderOptions),
+            Xpm = d => SaveXpm(d, path, encodeOptions, renderOptions),
+            Tga = d => SaveTga(d, path, encodeOptions, renderOptions),
+            Ico = d => SaveIco(d, path, encodeOptions, renderOptions),
+            Pdf = d => SavePdf(d, path, encodeOptions, renderOptions),
+            Eps = d => SaveEps(d, path, encodeOptions, renderOptions)
+        });
     }
 
 }

--- a/CodeGlyphX/Pdf417Code.Save.Text.ByExtension.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.ByExtension.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using CodeGlyphX.Pdf417;
+using CodeGlyphX.Internal;
 
 namespace CodeGlyphX;
 
@@ -10,55 +11,26 @@ public static partial class Pdf417Code {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(text, path, encodeOptions, renderOptions);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(text, path, encodeOptions, renderOptions);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(text, path, encodeOptions, renderOptions);
-            case ".webp":
-                return SaveWebp(text, path, encodeOptions, renderOptions);
-            case ".svg":
-                return SaveSvg(text, path, encodeOptions, renderOptions);
-            case ".html":
-            case ".htm":
-                return SaveHtml(text, path, encodeOptions, renderOptions, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(text, path, encodeOptions, renderOptions);
-            case ".bmp":
-                return SaveBmp(text, path, encodeOptions, renderOptions);
-            case ".ppm":
-                return SavePpm(text, path, encodeOptions, renderOptions);
-            case ".pbm":
-                return SavePbm(text, path, encodeOptions, renderOptions);
-            case ".pgm":
-                return SavePgm(text, path, encodeOptions, renderOptions);
-            case ".pam":
-                return SavePam(text, path, encodeOptions, renderOptions);
-            case ".xbm":
-                return SaveXbm(text, path, encodeOptions, renderOptions);
-            case ".xpm":
-                return SaveXpm(text, path, encodeOptions, renderOptions);
-            case ".tga":
-                return SaveTga(text, path, encodeOptions, renderOptions);
-            case ".ico":
-                return SaveIco(text, path, encodeOptions, renderOptions);
-            case ".svgz":
-                return SaveSvgz(text, path, encodeOptions, renderOptions);
-            case ".pdf":
-                return SavePdf(text, path, encodeOptions, renderOptions);
-            case ".eps":
-            case ".ps":
-                return SaveEps(text, path, encodeOptions, renderOptions);
-            default:
-                return SavePng(text, path, encodeOptions, renderOptions);
-        }
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => SavePng(text, path, encodeOptions, renderOptions),
+            Png = () => SavePng(text, path, encodeOptions, renderOptions),
+            Webp = () => SaveWebp(text, path, encodeOptions, renderOptions),
+            Svg = () => SaveSvg(text, path, encodeOptions, renderOptions),
+            Svgz = () => SaveSvgz(text, path, encodeOptions, renderOptions),
+            Html = () => SaveHtml(text, path, encodeOptions, renderOptions, title),
+            Jpeg = () => SaveJpeg(text, path, encodeOptions, renderOptions),
+            Bmp = () => SaveBmp(text, path, encodeOptions, renderOptions),
+            Ppm = () => SavePpm(text, path, encodeOptions, renderOptions),
+            Pbm = () => SavePbm(text, path, encodeOptions, renderOptions),
+            Pgm = () => SavePgm(text, path, encodeOptions, renderOptions),
+            Pam = () => SavePam(text, path, encodeOptions, renderOptions),
+            Xbm = () => SaveXbm(text, path, encodeOptions, renderOptions),
+            Xpm = () => SaveXpm(text, path, encodeOptions, renderOptions),
+            Tga = () => SaveTga(text, path, encodeOptions, renderOptions),
+            Ico = () => SaveIco(text, path, encodeOptions, renderOptions),
+            Pdf = () => SavePdf(text, path, encodeOptions, renderOptions),
+            Eps = () => SaveEps(text, path, encodeOptions, renderOptions)
+        });
     }
 
     /// <summary>
@@ -66,55 +38,26 @@ public static partial class Pdf417Code {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SaveSvgz(data, path, encodeOptions, renderOptions);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return SavePng(data, path, encodeOptions, renderOptions);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return SavePng(data, path, encodeOptions, renderOptions);
-            case ".webp":
-                return SaveWebp(data, path, encodeOptions, renderOptions);
-            case ".svg":
-                return SaveSvg(data, path, encodeOptions, renderOptions);
-            case ".html":
-            case ".htm":
-                return SaveHtml(data, path, encodeOptions, renderOptions, title);
-            case ".jpg":
-            case ".jpeg":
-                return SaveJpeg(data, path, encodeOptions, renderOptions);
-            case ".bmp":
-                return SaveBmp(data, path, encodeOptions, renderOptions);
-            case ".ppm":
-                return SavePpm(data, path, encodeOptions, renderOptions);
-            case ".pbm":
-                return SavePbm(data, path, encodeOptions, renderOptions);
-            case ".pgm":
-                return SavePgm(data, path, encodeOptions, renderOptions);
-            case ".pam":
-                return SavePam(data, path, encodeOptions, renderOptions);
-            case ".xbm":
-                return SaveXbm(data, path, encodeOptions, renderOptions);
-            case ".xpm":
-                return SaveXpm(data, path, encodeOptions, renderOptions);
-            case ".tga":
-                return SaveTga(data, path, encodeOptions, renderOptions);
-            case ".ico":
-                return SaveIco(data, path, encodeOptions, renderOptions);
-            case ".svgz":
-                return SaveSvgz(data, path, encodeOptions, renderOptions);
-            case ".pdf":
-                return SavePdf(data, path, encodeOptions, renderOptions);
-            case ".eps":
-            case ".ps":
-                return SaveEps(data, path, encodeOptions, renderOptions);
-            default:
-                return SavePng(data, path, encodeOptions, renderOptions);
-        }
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => SavePng(data, path, encodeOptions, renderOptions),
+            Png = () => SavePng(data, path, encodeOptions, renderOptions),
+            Webp = () => SaveWebp(data, path, encodeOptions, renderOptions),
+            Svg = () => SaveSvg(data, path, encodeOptions, renderOptions),
+            Svgz = () => SaveSvgz(data, path, encodeOptions, renderOptions),
+            Html = () => SaveHtml(data, path, encodeOptions, renderOptions, title),
+            Jpeg = () => SaveJpeg(data, path, encodeOptions, renderOptions),
+            Bmp = () => SaveBmp(data, path, encodeOptions, renderOptions),
+            Ppm = () => SavePpm(data, path, encodeOptions, renderOptions),
+            Pbm = () => SavePbm(data, path, encodeOptions, renderOptions),
+            Pgm = () => SavePgm(data, path, encodeOptions, renderOptions),
+            Pam = () => SavePam(data, path, encodeOptions, renderOptions),
+            Xbm = () => SaveXbm(data, path, encodeOptions, renderOptions),
+            Xpm = () => SaveXpm(data, path, encodeOptions, renderOptions),
+            Tga = () => SaveTga(data, path, encodeOptions, renderOptions),
+            Ico = () => SaveIco(data, path, encodeOptions, renderOptions),
+            Pdf = () => SavePdf(data, path, encodeOptions, renderOptions),
+            Eps = () => SaveEps(data, path, encodeOptions, renderOptions)
+        });
     }
 
 }

--- a/CodeGlyphX/QR.Save.cs
+++ b/CodeGlyphX/QR.Save.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using CodeGlyphX.Internal;
 using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
@@ -571,57 +572,25 @@ public static partial class QR {
     }
 
     private static string SaveByExtension(string path, string payload, QrPayloadData? payloadData, QrEasyOptions? options, string? title) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return payloadData is null ? SaveSvgz(payload, path, options) : SaveSvgz(payloadData, path, options);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) {
-            return payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options);
-        }
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options);
-            case ".webp":
-                return payloadData is null ? SaveWebp(payload, path, options) : SaveWebp(payloadData, path, options);
-            case ".svg":
-                return payloadData is null ? SaveSvg(payload, path, options) : SaveSvg(payloadData, path, options);
-            case ".html":
-            case ".htm":
-                return payloadData is null ? SaveHtml(payload, path, options, title) : SaveHtml(payloadData, path, options, title);
-            case ".jpg":
-            case ".jpeg":
-                return payloadData is null ? SaveJpeg(payload, path, options) : SaveJpeg(payloadData, path, options);
-            case ".bmp":
-                return payloadData is null ? SaveBmp(payload, path, options) : SaveBmp(payloadData, path, options);
-            case ".ppm":
-                return payloadData is null ? SavePpm(payload, path, options) : SavePpm(payloadData, path, options);
-            case ".pbm":
-                return payloadData is null ? SavePbm(payload, path, options) : SavePbm(payloadData, path, options);
-            case ".pgm":
-                return payloadData is null ? SavePgm(payload, path, options) : SavePgm(payloadData, path, options);
-            case ".pam":
-                return payloadData is null ? SavePam(payload, path, options) : SavePam(payloadData, path, options);
-            case ".xbm":
-                return payloadData is null ? SaveXbm(payload, path, options) : SaveXbm(payloadData, path, options);
-            case ".xpm":
-                return payloadData is null ? SaveXpm(payload, path, options) : SaveXpm(payloadData, path, options);
-            case ".tga":
-                return payloadData is null ? SaveTga(payload, path, options) : SaveTga(payloadData, path, options);
-            case ".ico":
-                return payloadData is null ? SaveIco(payload, path, options) : SaveIco(payloadData, path, options);
-            case ".svgz":
-                return payloadData is null ? SaveSvgz(payload, path, options) : SaveSvgz(payloadData, path, options);
-            case ".pdf":
-                return payloadData is null ? SavePdf(payload, path, options) : SavePdf(payloadData, path, options);
-            case ".eps":
-            case ".ps":
-                return payloadData is null ? SaveEps(payload, path, options) : SaveEps(payloadData, path, options);
-            default:
-                // Fallback to PNG for unknown extensions to keep the API forgiving.
-                return payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options);
-        }
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options),
+            Png = () => payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options),
+            Webp = () => payloadData is null ? SaveWebp(payload, path, options) : SaveWebp(payloadData, path, options),
+            Svg = () => payloadData is null ? SaveSvg(payload, path, options) : SaveSvg(payloadData, path, options),
+            Svgz = () => payloadData is null ? SaveSvgz(payload, path, options) : SaveSvgz(payloadData, path, options),
+            Html = () => payloadData is null ? SaveHtml(payload, path, options, title) : SaveHtml(payloadData, path, options, title),
+            Jpeg = () => payloadData is null ? SaveJpeg(payload, path, options) : SaveJpeg(payloadData, path, options),
+            Bmp = () => payloadData is null ? SaveBmp(payload, path, options) : SaveBmp(payloadData, path, options),
+            Ppm = () => payloadData is null ? SavePpm(payload, path, options) : SavePpm(payloadData, path, options),
+            Pbm = () => payloadData is null ? SavePbm(payload, path, options) : SavePbm(payloadData, path, options),
+            Pgm = () => payloadData is null ? SavePgm(payload, path, options) : SavePgm(payloadData, path, options),
+            Pam = () => payloadData is null ? SavePam(payload, path, options) : SavePam(payloadData, path, options),
+            Xbm = () => payloadData is null ? SaveXbm(payload, path, options) : SaveXbm(payloadData, path, options),
+            Xpm = () => payloadData is null ? SaveXpm(payload, path, options) : SaveXpm(payloadData, path, options),
+            Tga = () => payloadData is null ? SaveTga(payload, path, options) : SaveTga(payloadData, path, options),
+            Ico = () => payloadData is null ? SaveIco(payload, path, options) : SaveIco(payloadData, path, options),
+            Pdf = () => payloadData is null ? SavePdf(payload, path, options) : SavePdf(payloadData, path, options),
+            Eps = () => payloadData is null ? SaveEps(payload, path, options) : SaveEps(payloadData, path, options)
+        });
     }
 }


### PR DESCRIPTION
## Summary
- centralize save-by-extension switching in an internal helper
- reuse helper for QR/Barcode/DataMatrix/PDF417 save-by-extension paths
- keep behavior unchanged

## Testing
- dotnet restore CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -p:TargetFramework=net8.0
- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build