### PR TITLE
Deduplicate Aztec and macro save-by-extension

### DIFF
--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using CodeGlyphX.Aztec;
+using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -353,61 +354,31 @@ public static partial class AztecCode {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string Save(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return RenderIO.WriteBinary(path, Svgz(text, encodeOptions, renderOptions));
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions));
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions));
-            case ".svg":
-                return RenderIO.WriteText(path, Svg(text, encodeOptions, renderOptions));
-            case ".html":
-            case ".htm":
-            {
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions)),
+            Png = () => RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions)),
+            Webp = () => RenderIO.WriteBinary(path, Webp(text, encodeOptions, renderOptions)),
+            Svg = () => RenderIO.WriteText(path, Svg(text, encodeOptions, renderOptions)),
+            Svgz = () => RenderIO.WriteBinary(path, Svgz(text, encodeOptions, renderOptions)),
+            Html = () => {
                 var html = Html(text, encodeOptions, renderOptions);
                 if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
                 return RenderIO.WriteText(path, html);
-            }
-            case ".jpg":
-            case ".jpeg":
-                return RenderIO.WriteBinary(path, Jpeg(text, encodeOptions, renderOptions));
-            case ".webp":
-                return RenderIO.WriteBinary(path, Webp(text, encodeOptions, renderOptions));
-            case ".bmp":
-                return RenderIO.WriteBinary(path, Bmp(text, encodeOptions, renderOptions));
-            case ".ppm":
-                return RenderIO.WriteBinary(path, Ppm(text, encodeOptions, renderOptions));
-            case ".pbm":
-                return RenderIO.WriteBinary(path, Pbm(text, encodeOptions, renderOptions));
-            case ".pgm":
-                return RenderIO.WriteBinary(path, Pgm(text, encodeOptions, renderOptions));
-            case ".pam":
-                return RenderIO.WriteBinary(path, Pam(text, encodeOptions, renderOptions));
-            case ".xbm":
-                return RenderIO.WriteText(path, Xbm(text, encodeOptions, renderOptions));
-            case ".xpm":
-                return RenderIO.WriteText(path, Xpm(text, encodeOptions, renderOptions));
-            case ".tga":
-                return RenderIO.WriteBinary(path, Tga(text, encodeOptions, renderOptions));
-            case ".ico":
-                return RenderIO.WriteBinary(path, Ico(text, encodeOptions, renderOptions));
-            case ".svgz":
-                return RenderIO.WriteBinary(path, Svgz(text, encodeOptions, renderOptions));
-            case ".pdf":
-                return RenderIO.WriteBinary(path, Pdf(text, encodeOptions, renderOptions));
-            case ".eps":
-            case ".ps":
-                return RenderIO.WriteText(path, Eps(text, encodeOptions, renderOptions));
-            case ".txt":
-                return RenderIO.WriteText(path, Ascii(text, encodeOptions));
-            default:
-                return RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions));
-        }
+            },
+            Jpeg = () => RenderIO.WriteBinary(path, Jpeg(text, encodeOptions, renderOptions)),
+            Bmp = () => RenderIO.WriteBinary(path, Bmp(text, encodeOptions, renderOptions)),
+            Ppm = () => RenderIO.WriteBinary(path, Ppm(text, encodeOptions, renderOptions)),
+            Pbm = () => RenderIO.WriteBinary(path, Pbm(text, encodeOptions, renderOptions)),
+            Pgm = () => RenderIO.WriteBinary(path, Pgm(text, encodeOptions, renderOptions)),
+            Pam = () => RenderIO.WriteBinary(path, Pam(text, encodeOptions, renderOptions)),
+            Xbm = () => RenderIO.WriteText(path, Xbm(text, encodeOptions, renderOptions)),
+            Xpm = () => RenderIO.WriteText(path, Xpm(text, encodeOptions, renderOptions)),
+            Tga = () => RenderIO.WriteBinary(path, Tga(text, encodeOptions, renderOptions)),
+            Ico = () => RenderIO.WriteBinary(path, Ico(text, encodeOptions, renderOptions)),
+            Pdf = () => RenderIO.WriteBinary(path, Pdf(text, encodeOptions, renderOptions)),
+            Eps = () => RenderIO.WriteText(path, Eps(text, encodeOptions, renderOptions)),
+            Text = () => RenderIO.WriteText(path, Ascii(text, encodeOptions))
+        });
     }
 
     private static MatrixPngRenderOptions ToPngOptions(MatrixOptions? options) {

--- a/CodeGlyphX/Internal/SaveByExtensionHelper.cs
+++ b/CodeGlyphX/Internal/SaveByExtensionHelper.cs
@@ -22,6 +22,7 @@ internal readonly struct SaveByExtensionHandlers {
     internal Func<string> Ico { get; init; }
     internal Func<string> Pdf { get; init; }
     internal Func<string> Eps { get; init; }
+    internal Func<string>? Text { get; init; }
 }
 
 internal delegate string SaveByExtensionSpanHandler(ReadOnlySpan<byte> data);
@@ -95,6 +96,8 @@ internal static class SaveByExtensionHelper {
             case ".eps":
             case ".ps":
                 return handlers.Eps();
+            case ".txt":
+                return (handlers.Text ?? handlers.Default)();
             default:
                 return handlers.Default();
         }

--- a/CodeGlyphX/Pdf417Code.Macro.Save.cs
+++ b/CodeGlyphX/Pdf417Code.Macro.Save.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using CodeGlyphX.Pdf417;
+using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX;
@@ -11,54 +12,29 @@ public static partial class Pdf417Code {
     /// Defaults to PNG when no extension is provided.
     /// </summary>
     public static string SaveMacro(string text, Pdf417MacroOptions macro, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null, RenderMode renderMode = RenderMode.Vector) {
-        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
-            return SvgzMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-        }
-
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrWhiteSpace(ext)) return PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-
-        switch (ext.ToLowerInvariant()) {
-            case ".png":
-                return PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".svg":
-                return SvgMacro(text, macro, encodeOptions, renderOptions).WriteText(path);
-            case ".html":
-            case ".htm":
+        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
+            Default = () => PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Png = () => PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Webp = () => PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Svg = () => SvgMacro(text, macro, encodeOptions, renderOptions).WriteText(path),
+            Svgz = () => SvgzMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Html = () => {
                 var html = HtmlMacro(text, macro, encodeOptions, renderOptions);
                 if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
                 return html.WriteText(path);
-            case ".jpg":
-            case ".jpeg":
-                return JpegMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".bmp":
-                return BmpMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".ppm":
-                return PpmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".pbm":
-                return PbmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".pgm":
-                return PgmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".pam":
-                return PamMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".xbm":
-                return XbmMacro(text, macro, encodeOptions, renderOptions).WriteText(path);
-            case ".xpm":
-                return XpmMacro(text, macro, encodeOptions, renderOptions).WriteText(path);
-            case ".tga":
-                return TgaMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".ico":
-                return IcoMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".svgz":
-                return SvgzMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-            case ".pdf":
-                return PdfMacro(text, macro, encodeOptions, renderOptions, renderMode).WriteBinary(path);
-            case ".eps":
-            case ".ps":
-                return EpsMacro(text, macro, encodeOptions, renderOptions, renderMode).WriteText(path);
-            default:
-                return PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path);
-        }
+            },
+            Jpeg = () => JpegMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Bmp = () => BmpMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Ppm = () => PpmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Pbm = () => PbmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Pgm = () => PgmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Pam = () => PamMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Xbm = () => XbmMacro(text, macro, encodeOptions, renderOptions).WriteText(path),
+            Xpm = () => XpmMacro(text, macro, encodeOptions, renderOptions).WriteText(path),
+            Tga = () => TgaMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Ico = () => IcoMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
+            Pdf = () => PdfMacro(text, macro, encodeOptions, renderOptions, renderMode).WriteBinary(path),
+            Eps = () => EpsMacro(text, macro, encodeOptions, renderOptions, renderMode).WriteText(path)
+        });
     }
 }


### PR DESCRIPTION
## Summary
- extend save-by-extension helper to support .txt routing
- refactor Aztec and PDF417 macro save-by-extension to use the helper
- preserve existing behavior while reducing duplication

## Testing
- dotnet build CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -f net8.0 --no-build