### PR TITLE
Refactor legacy format helpers to render pipeline

### DIFF
--- a/Assets/Templates/pages/docs.html
+++ b/Assets/Templates/pages/docs.html
@@ -217,6 +217,17 @@ QR.Save("Hello, World!", "hello.png");
 QR.Save("Hello, World!", "hello.svg");  // Vector SVG
 QR.Save("Hello, World!", "hello.pdf");  // PDF document</pre>
 
+            <h3>Render In-Memory</h3>
+            <pre class="code-block">using CodeGlyphX;
+using CodeGlyphX.Rendering;
+
+var svg = Barcode.Render(BarcodeType.Code128, "PRODUCT-12345", OutputFormat.Svg).GetText();
+var png = QrCode.Render("Hello, World!", OutputFormat.Png).Data;
+
+// HTML title + raster PDF/EPS
+var extras = new RenderExtras { HtmlTitle = "My Code", VectorMode = RenderMode.Raster };
+QR.Save("Hello, World!", "hello.html", extras: extras);</pre>
+
             <h2>3. Generate Barcodes</h2>
             <pre class="code-block">using CodeGlyphX;
 

--- a/CodeGlyphX.Benchmarks/BarcodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/BarcodeBenchmarks.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX.Benchmarks;
 
@@ -19,36 +20,36 @@ public class BarcodeBenchmarks
     [Benchmark(Description = "Code 128 PNG")]
     public byte[] Code128_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.Code128, Code128Text);
+        return Barcode.Render(BarcodeType.Code128, Code128Text, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "Code 128 SVG")]
     public string Code128_Svg()
     {
-        return BarcodeEasy.RenderSvg(BarcodeType.Code128, Code128Text);
+        return Barcode.Render(BarcodeType.Code128, Code128Text, OutputFormat.Svg).GetText();
     }
 
     [Benchmark(Description = "EAN PNG")]
     public byte[] Ean_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.EAN, EanText);
+        return Barcode.Render(BarcodeType.EAN, EanText, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "Code 39 PNG")]
     public byte[] Code39_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.Code39, Code39Text);
+        return Barcode.Render(BarcodeType.Code39, Code39Text, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "Code 93 PNG")]
     public byte[] Code93_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.Code93, Code39Text);
+        return Barcode.Render(BarcodeType.Code93, Code39Text, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "UPC-A PNG")]
     public byte[] UpcA_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.UPCA, "012345678905");
+        return Barcode.Render(BarcodeType.UPCA, "012345678905", OutputFormat.Png).Data;
     }
 }

--- a/CodeGlyphX.Benchmarks/Compare/AztecCompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/AztecCompareBenchmarks.cs
@@ -64,7 +64,7 @@ public class AztecCompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX Aztec PNG")]
     public byte[] CodeGlyphX_Aztec_Png()
     {
-        return AztecCode.Png(MediumText, renderOptions: _options);
+        return AztecCode.Render(MediumText, OutputFormat.Png, renderOptions: _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/Code128CompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/Code128CompareBenchmarks.cs
@@ -55,7 +55,7 @@ public class Code128CompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX Code128 PNG")]
     public byte[] CodeGlyphX_Code128_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.Code128, Code128Text, _options);
+        return Barcode.Render(BarcodeType.Code128, Code128Text, OutputFormat.Png, _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/Code39CompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/Code39CompareBenchmarks.cs
@@ -55,7 +55,7 @@ public class Code39CompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX Code39 PNG")]
     public byte[] CodeGlyphX_Code39_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.Code39, Code39Text, _options);
+        return Barcode.Render(BarcodeType.Code39, Code39Text, OutputFormat.Png, _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/Code93CompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/Code93CompareBenchmarks.cs
@@ -55,7 +55,7 @@ public class Code93CompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX Code93 PNG")]
     public byte[] CodeGlyphX_Code93_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.Code93, Code93Text, _options);
+        return Barcode.Render(BarcodeType.Code93, Code93Text, OutputFormat.Png, _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/DataMatrixCompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/DataMatrixCompareBenchmarks.cs
@@ -63,7 +63,7 @@ public class DataMatrixCompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX Data Matrix PNG (medium)")]
     public byte[] CodeGlyphX_DataMatrix_Png()
     {
-        return DataMatrixCode.Png(MediumText, options: _options);
+        return DataMatrixCode.Render(MediumText, OutputFormat.Png, options: _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/EanCompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/EanCompareBenchmarks.cs
@@ -55,7 +55,7 @@ public class EanCompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX EAN-13 PNG")]
     public byte[] CodeGlyphX_Ean_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.EAN, EanText, _options);
+        return Barcode.Render(BarcodeType.EAN, EanText, OutputFormat.Png, _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/Pdf417CompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/Pdf417CompareBenchmarks.cs
@@ -63,7 +63,7 @@ public class Pdf417CompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX PDF417 PNG")]
     public byte[] CodeGlyphX_Pdf417_Png()
     {
-        return Pdf417Code.Png(LongText, renderOptions: _options);
+        return Pdf417Code.Render(LongText, OutputFormat.Png, renderOptions: _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/QrCompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/QrCompareBenchmarks.cs
@@ -74,7 +74,7 @@ public class QrCompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX QR PNG (medium)")]
     public byte[] CodeGlyphX_QrPng()
     {
-        return QrEasy.RenderPng(MediumText, _options);
+        return QrCode.Render(MediumText, OutputFormat.Png, _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/Compare/QrDecodeStressCompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/QrDecodeStressCompareBenchmarks.cs
@@ -135,7 +135,7 @@ public class QrDecodeStressCompareBenchmarks
             out _,
             out _);
         var options = QrPresets.Logo(logo);
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out rgba, out width, out height);
     }
 #endif
@@ -143,14 +143,14 @@ public class QrDecodeStressCompareBenchmarks
     private static void BuildFancySample(out byte[] rgba, out int width, out int height)
     {
         var options = new QrEasyOptions { Style = QrRenderStyle.Fancy };
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out rgba, out width, out height);
     }
 
     private static void BuildResampledSample(out byte[] rgba, out int width, out int height)
     {
         var options = new QrEasyOptions { ModuleSize = 8 };
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out var baseRgba, out var baseWidth, out var baseHeight);
 
         var downW = Math.Max(1, (int)Math.Round(baseWidth * 0.62));
@@ -169,7 +169,7 @@ public class QrDecodeStressCompareBenchmarks
     private static void BuildNoQuietSample(out byte[] rgba, out int width, out int height)
     {
         var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out rgba, out width, out height);
     }
 

--- a/CodeGlyphX.Benchmarks/Compare/UpcACompareBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/Compare/UpcACompareBenchmarks.cs
@@ -55,7 +55,7 @@ public class UpcACompareBenchmarks
     [Benchmark(Baseline = true, Description = "CodeGlyphX UPC-A PNG")]
     public byte[] CodeGlyphX_UpcA_Png()
     {
-        return BarcodeEasy.RenderPng(BarcodeType.UPCA, UpcAText, _options);
+        return Barcode.Render(BarcodeType.UPCA, UpcAText, OutputFormat.Png, _options).Data;
     }
 
 #if COMPARE_ZXING

--- a/CodeGlyphX.Benchmarks/MatrixCodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/MatrixCodeBenchmarks.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX.Benchmarks;
 
@@ -28,19 +29,19 @@ public class MatrixCodeBenchmarks
     [Benchmark(Description = "Data Matrix PNG (medium)")]
     public byte[] DataMatrix_Png_Medium()
     {
-        return DataMatrixCode.Png(_mediumBytes);
+        return DataMatrixCode.Render(_mediumBytes, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "Data Matrix PNG (long)")]
     public byte[] DataMatrix_Png_Long()
     {
-        return DataMatrixCode.Png(_longBytes);
+        return DataMatrixCode.Render(_longBytes, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "Data Matrix SVG")]
     public string DataMatrix_Svg()
     {
-        return DataMatrixCode.Svg(_mediumBytes);
+        return DataMatrixCode.Render(_mediumBytes, OutputFormat.Svg).GetText();
     }
 
     [Benchmark(Description = "PDF417 PNG")]
@@ -58,12 +59,12 @@ public class MatrixCodeBenchmarks
     [Benchmark(Description = "Aztec PNG")]
     public byte[] Aztec_Png()
     {
-        return AztecCode.Png(MediumText);
+        return AztecCode.Render(MediumText, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "Aztec SVG")]
     public string Aztec_Svg()
     {
-        return AztecCode.Svg(MediumText);
+        return AztecCode.Render(MediumText, OutputFormat.Svg).GetText();
     }
 }

--- a/CodeGlyphX.Benchmarks/PreflightChecks.cs
+++ b/CodeGlyphX.Benchmarks/PreflightChecks.cs
@@ -42,13 +42,13 @@ internal static class PreflightChecks
 
         Check("CodeGlyphX QR PNG", () =>
         {
-            var png = QrEasy.RenderPng(QrText);
+            var png = QrCode.Render(QrText, OutputFormat.Png).Data;
             if (png.Length == 0) throw new InvalidOperationException("Empty PNG output.");
         });
 
         Check("CodeGlyphX Barcode PNG", () =>
         {
-            var png = BarcodeEasy.RenderPng(BarcodeType.EAN, EanText, new BarcodeOptions());
+            var png = Barcode.Render(BarcodeType.EAN, EanText, OutputFormat.Png, new BarcodeOptions()).Data;
             if (png.Length == 0) throw new InvalidOperationException("Empty PNG output.");
         });
 

--- a/CodeGlyphX.Benchmarks/QrCodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/QrCodeBenchmarks.cs
@@ -23,49 +23,49 @@ public class QrCodeBenchmarks
     [Benchmark(Description = "QR PNG (short text)")]
     public byte[] QrPng_ShortText()
     {
-        return QrEasy.RenderPng(ShortText);
+        return QrCode.Render(ShortText, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "QR PNG (medium text)")]
     public byte[] QrPng_MediumText()
     {
-        return QrEasy.RenderPng(MediumText);
+        return QrCode.Render(MediumText, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "QR PNG (long text)")]
     public byte[] QrPng_LongText()
     {
-        return QrEasy.RenderPng(LongText);
+        return QrCode.Render(LongText, OutputFormat.Png).Data;
     }
 
     [Benchmark(Description = "QR SVG (medium text)")]
     public string QrSvg_MediumText()
     {
-        return QrEasy.RenderSvg(MediumText);
+        return QrCode.Render(MediumText, OutputFormat.Svg).GetText();
     }
 
     [Benchmark(Description = "QR PNG High Error Correction")]
     public byte[] QrPng_HighEC()
     {
-        return QrEasy.RenderPng(MediumText, new QrEasyOptions { ErrorCorrectionLevel = QrErrorCorrectionLevel.H });
+        return QrCode.Render(MediumText, OutputFormat.Png, new QrEasyOptions { ErrorCorrectionLevel = QrErrorCorrectionLevel.H }).Data;
     }
 
     [Benchmark(Description = "QR PNG (medium text, logo)")]
     public byte[] QrPng_MediumText_Logo()
     {
-        return QrEasy.RenderPng(MediumText, LogoOptions);
+        return QrCode.Render(MediumText, OutputFormat.Png, LogoOptions).Data;
     }
 
     [Benchmark(Description = "QR PNG (medium text, fancy)")]
     public byte[] QrPng_MediumText_Fancy()
     {
-        return QrEasy.RenderPng(MediumText, FancyOptions);
+        return QrCode.Render(MediumText, OutputFormat.Png, FancyOptions).Data;
     }
 
     [Benchmark(Description = "QR HTML (medium text)")]
     public string QrHtml_MediumText()
     {
-        return QrEasy.RenderHtml(MediumText);
+        return QrCode.Render(MediumText, OutputFormat.Html).GetText();
     }
 
     private static QrEasyOptions CreateLogoOptions()

--- a/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
@@ -153,7 +153,7 @@ public class QrDecodeBenchmarks
             out _,
             out _);
         var options = QrPresets.Logo(logo);
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out rgba, out width, out height);
     }
 #endif
@@ -161,14 +161,14 @@ public class QrDecodeBenchmarks
     private static void BuildFancySample(out byte[] rgba, out int width, out int height)
     {
         var options = new QrEasyOptions { Style = QrRenderStyle.Fancy };
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out rgba, out width, out height);
     }
 
     private static void BuildResampledSample(out byte[] rgba, out int width, out int height)
     {
         var options = new QrEasyOptions { ModuleSize = 8 };
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out var baseRgba, out var baseWidth, out var baseHeight);
 
         var downW = Math.Max(1, (int)Math.Round(baseWidth * 0.62));
@@ -187,7 +187,7 @@ public class QrDecodeBenchmarks
     private static void BuildNoQuietSample(out byte[] rgba, out int width, out int height)
     {
         var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
-        var png = QrEasy.RenderPng(SampleText, options);
+        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
         DecodePng(png, out rgba, out width, out height);
     }
 

--- a/CodeGlyphX.Benchmarks/QrDecodeScenarioPacks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeScenarioPacks.cs
@@ -208,7 +208,7 @@ internal static class QrDecodeScenarioPacks {
 
     private static QrDecodeScenarioData BuildResampledGenerated() {
         var options = new QrEasyOptions { ModuleSize = 8 };
-        var png = QrEasy.RenderPng(GeneratedPayload, options);
+        var png = QrCode.Render(GeneratedPayload, OutputFormat.Png, options).Data;
         if (!ImageReader.TryDecodeRgba32(png, out var baseRgba, out var baseWidth, out var baseHeight)) {
             throw new InvalidOperationException("Failed to decode generated resample PNG.");
         }
@@ -226,7 +226,7 @@ internal static class QrDecodeScenarioPacks {
 
     private static QrDecodeScenarioData BuildNoQuietGenerated() {
         var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
-        var png = QrEasy.RenderPng(GeneratedPayload, options);
+        var png = QrCode.Render(GeneratedPayload, OutputFormat.Png, options).Data;
         if (!ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height)) {
             throw new InvalidOperationException("Failed to decode generated no-quiet PNG.");
         }
@@ -241,7 +241,7 @@ internal static class QrDecodeScenarioPacks {
             TargetSizeIncludesQuietZone = true,
             QuietZone = 4
         };
-        var png = QrEasy.RenderPng(LongPayload, options);
+        var png = QrCode.Render(LongPayload, OutputFormat.Png, options).Data;
         if (!ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height)) {
             throw new InvalidOperationException("Failed to decode generated long-payload PNG.");
         }

--- a/CodeGlyphX.Examples/BarcodeExample.cs
+++ b/CodeGlyphX.Examples/BarcodeExample.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using CodeGlyphX;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX.Examples;
@@ -16,7 +17,7 @@ internal static class BarcodeExample {
 
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.png"), options);
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.svg"), options);
-        Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.html"), options, title: "Code128");
+        Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.html"), options, new RenderExtras { HtmlTitle = "Code128" });
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.jpg"), options);
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.pdf"), options);
         Barcode.Save(BarcodeType.Code128, "CODEGLYPHX-123456", Path.Combine(outputDir, "barcode-code128.eps"), options);

--- a/CodeGlyphX.Examples/CodeGlyphDecodeExample.cs
+++ b/CodeGlyphX.Examples/CodeGlyphDecodeExample.cs
@@ -6,7 +6,7 @@ namespace CodeGlyphX.Examples;
 
 internal static class CodeGlyphDecodeExample {
     public static void Run(string outputDir) {
-        var qrPng = QR.Png("Auto decode QR");
+        var qrPng = QrCode.Render("Auto decode QR", OutputFormat.Png).Data;
         if (CodeGlyph.TryDecodePng(qrPng, out var qrDecoded)) {
             qrDecoded.Text.WriteText(outputDir, "decode-any-qr.txt");
         }
@@ -26,11 +26,11 @@ internal static class CodeGlyphDecodeExample {
             }
         }
 
-        var barcodePng = Barcode.Png(BarcodeType.Code128, "CODE128-ANY", new BarcodeOptions {
+        var barcodePng = Barcode.Render(BarcodeType.Code128, "CODE128-ANY", OutputFormat.Png, new BarcodeOptions {
             ModuleSize = 3,
             QuietZone = 10,
             HeightModules = 40
-        });
+        }).Data;
         if (CodeGlyph.TryDecodePng(barcodePng, out var barcodeDecoded, expectedBarcode: BarcodeType.Code128, preferBarcode: true)) {
             barcodeDecoded.Text.WriteText(outputDir, "decode-any-barcode.txt");
         }

--- a/CodeGlyphX.Examples/EvotecExamples.cs
+++ b/CodeGlyphX.Examples/EvotecExamples.cs
@@ -28,6 +28,6 @@ internal static class EvotecExamples {
 
         QR.Save(url, Path.Combine(outputDir, "qr-evotec-logo.png"), withLogo);
         QR.Save(url, Path.Combine(outputDir, "qr-evotec-logo.svg"), withLogo);
-        QR.Save(url, Path.Combine(outputDir, "qr-evotec-logo.html"), withLogo, title: "Evotec QR");
+        QR.Save(url, Path.Combine(outputDir, "qr-evotec-logo.html"), withLogo, new RenderExtras { HtmlTitle = "Evotec QR" });
     }
 }

--- a/CodeGlyphX.Examples/QrAsciiExample.cs
+++ b/CodeGlyphX.Examples/QrAsciiExample.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using CodeGlyphX;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Png;
 
@@ -26,7 +27,11 @@ internal static class QrAsciiExample {
         if (scaleFit < 1) scaleFit = 1;
         if (scaleFit > 3) scaleFit = 3;
 
-        var ascii = QR.Ascii(payload, AsciiPresets.Console(scale: scaleFit, darkColor: new Rgba32(12, 12, 12)));
+        var ascii = QrCode.Render(
+            payload,
+            OutputFormat.Ascii,
+            extras: new RenderExtras { MatrixAscii = AsciiPresets.Console(scale: scaleFit, darkColor: new Rgba32(12, 12, 12)) }
+        ).GetText();
 
         var pngPath = Path.Combine(outputDir, "qr-ascii-console.png");
         var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {

--- a/CodeGlyphX.Examples/QrConnectedExample.cs
+++ b/CodeGlyphX.Examples/QrConnectedExample.cs
@@ -61,8 +61,13 @@ internal static class QrConnectedExample {
         };
 
         QR.Save(payload, Path.Combine(outputDir, "qr-connected-rounded.png"), options);
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-connected-rounded.pdf"), options, RenderMode.Raster);
-        QR.SaveEps(payload, Path.Combine(outputDir, "qr-connected-rounded.eps"), options, RenderMode.Raster);
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-connected-rounded.pdf"),
+            QrCode.Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-connected-rounded.eps"),
+            QrCode.Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
     }
 }
-

--- a/CodeGlyphX.Examples/QrDecodeExample.cs
+++ b/CodeGlyphX.Examples/QrDecodeExample.cs
@@ -8,7 +8,7 @@ namespace CodeGlyphX.Examples;
 internal static class QrDecodeExample {
     public static void Run(string outputDir) {
         var payload = "Decode me with CodeGlyphX 1234";
-        var png = QR.Png(payload);
+        var png = QrCode.Render(payload, OutputFormat.Png).Data;
         if (QR.TryDecodePng(png, out var decoded)) {
             decoded.Text.WriteText(outputDir, "qr-decode.txt");
         }

--- a/CodeGlyphX.Examples/QrFancyExample.cs
+++ b/CodeGlyphX.Examples/QrFancyExample.cs
@@ -24,7 +24,13 @@ internal static class QrFancyExample {
         };
 
         QR.Save(payload, Path.Combine(outputDir, "qr-fancy.png"), options);
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-fancy.pdf"), options, RenderMode.Raster);
-        QR.SaveEps(payload, Path.Combine(outputDir, "qr-fancy.eps"), options, RenderMode.Raster);
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-fancy.pdf"),
+            QrCode.Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-fancy.eps"),
+            QrCode.Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
     }
 }

--- a/CodeGlyphX.Examples/QrGenerationExample.cs
+++ b/CodeGlyphX.Examples/QrGenerationExample.cs
@@ -9,10 +9,19 @@ internal static class QrGenerationExample {
         var payload = "https://example.com/codeglyphx?from=examples";
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.png"));
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.svg"));
-        QR.Save(payload, Path.Combine(outputDir, "qr-basic.html"), title: "CodeGlyphX QR");
+        QR.Save(payload, Path.Combine(outputDir, "qr-basic.html"), null, new RenderExtras { HtmlTitle = "CodeGlyphX QR" });
         QR.Save(payload, Path.Combine(outputDir, "qr-basic.jpg"));
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic.pdf"));
-        QR.SaveEps(payload, Path.Combine(outputDir, "qr-basic.eps"));
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-basic-raster.pdf"), mode: RenderMode.Raster);
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-basic.pdf"),
+            QrCode.Render(payload, OutputFormat.Pdf)
+        );
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-basic.eps"),
+            QrCode.Render(payload, OutputFormat.Eps)
+        );
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-basic-raster.pdf"),
+            QrCode.Render(payload, OutputFormat.Pdf, null, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
     }
 }

--- a/CodeGlyphX.Examples/QrGlowExample.cs
+++ b/CodeGlyphX.Examples/QrGlowExample.cs
@@ -64,8 +64,13 @@ internal static class QrGlowExample {
         };
 
         QR.Save(payload, Path.Combine(outputDir, "qr-glow.png"), options);
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-glow.pdf"), options, RenderMode.Raster);
-        QR.SaveEps(payload, Path.Combine(outputDir, "qr-glow.eps"), options, RenderMode.Raster);
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-glow.pdf"),
+            QrCode.Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-glow.eps"),
+            QrCode.Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
     }
 }
-

--- a/CodeGlyphX.Examples/QrPrintExample.cs
+++ b/CodeGlyphX.Examples/QrPrintExample.cs
@@ -18,6 +18,9 @@ internal static class QrPrintExample {
 
         opts.TargetSizePx = 8000;
         QR.Save(payload, Path.Combine(outputDir, "qr-print-8k.png"), opts);
-        QR.SavePdf(payload, Path.Combine(outputDir, "qr-print-8k.pdf"), opts, mode: RenderMode.Raster);
+        OutputWriter.Write(
+            Path.Combine(outputDir, "qr-print-8k.pdf"),
+            QrCode.Render(payload, OutputFormat.Pdf, opts, new RenderExtras { VectorMode = RenderMode.Raster })
+        );
     }
 }

--- a/CodeGlyphX.Playground/Playground.Generate.cs
+++ b/CodeGlyphX.Playground/Playground.Generate.cs
@@ -9,6 +9,7 @@ using CodeGlyphX.DataMatrix;
 using CodeGlyphX.Pdf417;
 using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -246,8 +247,8 @@ public partial class Playground {
                 }
 
                 SafetyReport = QrEasy.EvaluateSafety(Content, options);
-                pngBytes = QrEasy.RenderPng(Content, options);
-                svg = QrEasy.RenderSvg(Content, options);
+                pngBytes = QrCode.Render(Content, OutputFormat.Png, options).Data;
+                svg = QrCode.Render(Content, OutputFormat.Svg, options).GetText();
             }
             else if (SelectedCategory == "SpecialQR")
             {
@@ -255,8 +256,8 @@ public partial class Playground {
                 if (payloadData == null || string.IsNullOrWhiteSpace(payloadData.Text))
                     return;
 
-                pngBytes = QrEasy.RenderPng(payloadData);
-                svg = QrEasy.RenderSvg(payloadData);
+                pngBytes = QrCode.Render(payloadData, OutputFormat.Png).Data;
+                svg = QrCode.Render(payloadData, OutputFormat.Svg).GetText();
             }
             else if (SelectedCategory == "Barcode")
             {
@@ -342,8 +343,8 @@ public partial class Playground {
                     content = NormalizeDigits(content);
                 }
 
-                pngBytes = BarcodeEasy.RenderPng(barcodeType, content);
-                svg = BarcodeEasy.RenderSvg(barcodeType, content);
+                pngBytes = Barcode.Render(barcodeType, content, OutputFormat.Png).Data;
+                svg = Barcode.Render(barcodeType, content, OutputFormat.Svg).GetText();
             }
             else if (SelectedCategory == "Matrix")
             {
@@ -358,8 +359,8 @@ public partial class Playground {
                             ErrorCorrectionLevel = Pdf417EccLevel,
                             Compact = Pdf417Compact
                         };
-                        pngBytes = Pdf417Code.Png(MatrixContent, pdf417Options);
-                        svg = Pdf417Code.Svg(MatrixContent, pdf417Options);
+                        pngBytes = Pdf417Code.Render(MatrixContent, OutputFormat.Png, pdf417Options).Data;
+                        svg = Pdf417Code.Render(MatrixContent, OutputFormat.Svg, pdf417Options).GetText();
                         break;
                     case "Aztec":
                         var aztecOptions = new AztecEncodeOptions
@@ -367,13 +368,13 @@ public partial class Playground {
                             ErrorCorrectionPercent = AztecAutoEcc ? null : AztecEccPercent,
                             Layers = AztecLayers > 0 ? AztecLayers : null
                         };
-                        pngBytes = AztecCode.Png(MatrixContent, aztecOptions);
-                        svg = AztecCode.Svg(MatrixContent, aztecOptions);
+                        pngBytes = AztecCode.Render(MatrixContent, OutputFormat.Png, aztecOptions).Data;
+                        svg = AztecCode.Render(MatrixContent, OutputFormat.Svg, aztecOptions).GetText();
                         break;
                     default:
                         var dmMode = ParseDataMatrixMode(SelectedDataMatrixMode);
-                        pngBytes = DataMatrixCode.Png(MatrixContent, dmMode);
-                        svg = DataMatrixCode.Svg(MatrixContent, dmMode);
+                        pngBytes = DataMatrixCode.Render(MatrixContent, OutputFormat.Png, dmMode).Data;
+                        svg = DataMatrixCode.Render(MatrixContent, OutputFormat.Svg, dmMode).GetText();
                         break;
                 }
             }

--- a/CodeGlyphX.Playground/Playground.Generate.cs
+++ b/CodeGlyphX.Playground/Playground.Generate.cs
@@ -9,7 +9,6 @@ using CodeGlyphX.DataMatrix;
 using CodeGlyphX.Pdf417;
 using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
-using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;

--- a/CodeGlyphX.Tests/AztecTests.cs
+++ b/CodeGlyphX.Tests/AztecTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using CodeGlyphX;
 using CodeGlyphX.Aztec;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Webp;
 using Xunit;
@@ -35,7 +36,7 @@ public sealed class AztecTests {
 
     [Fact]
     public void Aztec_Image_RoundTrip() {
-        var png = AztecCode.Png("AZTEC-IMG");
+        var png = AztecCode.Render("AZTEC-IMG", OutputFormat.Png).Data;
         Assert.True(AztecCode.TryDecodeImage(png, out var text));
         Assert.Equal("AZTEC-IMG", text);
     }

--- a/CodeGlyphX.Tests/BarcodeDecoderTests.cs
+++ b/CodeGlyphX.Tests/BarcodeDecoderTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using Xunit;
 
@@ -53,11 +54,11 @@ public sealed class BarcodeDecoderTests {
 
     [Fact]
     public void Decode_Code128_FromPng() {
-        var png = Barcode.Png(BarcodeType.Code128, "CODEMATRIX-123", new BarcodeOptions {
+        var png = Barcode.Render(BarcodeType.Code128, "CODEMATRIX-123", OutputFormat.Png, new BarcodeOptions {
             ModuleSize = 3,
             QuietZone = 10,
             HeightModules = 40
-        });
+        }).Data;
 
         Assert.True(Barcode.TryDecodePng(png, out var decoded));
         Assert.Equal(BarcodeType.Code128, decoded.Type);
@@ -66,11 +67,11 @@ public sealed class BarcodeDecoderTests {
 
     [Fact]
     public void Decode_Code128_FromPng_Cancelled_ReturnsFalse() {
-        var png = Barcode.Png(BarcodeType.Code128, "CANCEL-PNG", new BarcodeOptions {
+        var png = Barcode.Render(BarcodeType.Code128, "CANCEL-PNG", OutputFormat.Png, new BarcodeOptions {
             ModuleSize = 3,
             QuietZone = 10,
             HeightModules = 40
-        });
+        }).Data;
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/CodeGlyphX.Tests/CodeGlyphDecodeTests.cs
+++ b/CodeGlyphX.Tests/CodeGlyphDecodeTests.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.DataMatrix;
 using CodeGlyphX.Pdf417;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using Xunit;
 
@@ -8,7 +9,7 @@ namespace CodeGlyphX.Tests;
 public sealed class CodeGlyphDecodeTests {
     [Fact]
     public void Decode_Qr_FromPng() {
-        var png = QR.Png("HELLO");
+        var png = QrCode.Render("HELLO", OutputFormat.Png).Data;
 
         Assert.True(CodeGlyph.TryDecodePng(png, out var decoded));
         Assert.Equal(CodeGlyphKind.Qr, decoded.Kind);
@@ -17,11 +18,11 @@ public sealed class CodeGlyphDecodeTests {
 
     [Fact]
     public void Decode_Barcode_FromPng() {
-        var png = Barcode.Png(BarcodeType.Code128, "CODE128-12345", new BarcodeOptions {
+        var png = Barcode.Render(BarcodeType.Code128, "CODE128-12345", OutputFormat.Png, new BarcodeOptions {
             ModuleSize = 3,
             QuietZone = 10,
             HeightModules = 40
-        });
+        }).Data;
 
         Assert.True(CodeGlyph.TryDecodePng(png, out var decoded));
         Assert.Equal(CodeGlyphKind.Barcode1D, decoded.Kind);
@@ -69,7 +70,7 @@ public sealed class CodeGlyphDecodeTests {
 
     [Fact]
     public void DecodeAll_Qr_FromPng() {
-        var png = QR.Png("HELLO-ALL");
+        var png = QrCode.Render("HELLO-ALL", OutputFormat.Png).Data;
 
         Assert.True(CodeGlyph.TryDecodeAllPng(png, out var decoded, includeBarcode: false));
         Assert.Single(decoded);
@@ -79,11 +80,11 @@ public sealed class CodeGlyphDecodeTests {
 
     [Fact]
     public void DecodeAll_Barcode_FromPng() {
-        var png = Barcode.Png(BarcodeType.Code128, "CODE128-ALL", new BarcodeOptions {
+        var png = Barcode.Render(BarcodeType.Code128, "CODE128-ALL", OutputFormat.Png, new BarcodeOptions {
             ModuleSize = 3,
             QuietZone = 10,
             HeightModules = 40
-        });
+        }).Data;
 
         Assert.True(CodeGlyph.TryDecodeAllPng(png, out var decoded, expectedBarcode: BarcodeType.Code128, includeBarcode: true, preferBarcode: true));
         Assert.Single(decoded);

--- a/CodeGlyphX.Tests/ImageDecodeOptionsTests.cs
+++ b/CodeGlyphX.Tests/ImageDecodeOptionsTests.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX;
 using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using Xunit;
 
@@ -42,7 +43,7 @@ public sealed class ImageDecodeOptionsTests {
 
     [Fact]
     public void Qr_Downscales_WithImageOptions() {
-        var png = QR.Png("HELLO-WORLD", new QrEasyOptions { ModuleSize = 18, QuietZone = 4 });
+        var png = QrCode.Render("HELLO-WORLD", OutputFormat.Png, new QrEasyOptions { ModuleSize = 18, QuietZone = 4 }).Data;
         var imageOptions = new ImageDecodeOptions { MaxDimension = 200 };
 
         Assert.True(QR.TryDecodePng(png, imageOptions, options: null, out var decoded));

--- a/CodeGlyphX.Tests/MatrixApiTests.cs
+++ b/CodeGlyphX.Tests/MatrixApiTests.cs
@@ -1,4 +1,5 @@
 using CodeGlyphX.Pdf417;
+using CodeGlyphX.Rendering;
 using Xunit;
 
 namespace CodeGlyphX.Tests;
@@ -6,14 +7,14 @@ namespace CodeGlyphX.Tests;
 public sealed class MatrixApiTests {
     [Fact]
     public void DataMatrixCode_Png_RoundTrip() {
-        var png = DataMatrixCode.Png("DM-HELLO");
+        var png = DataMatrixCode.Render("DM-HELLO", OutputFormat.Png).Data;
         Assert.True(DataMatrixCode.TryDecodePng(png, out var text));
         Assert.Equal("DM-HELLO", text);
     }
 
     [Fact]
     public void DataMatrixCode_Image_RoundTrip() {
-        var png = DataMatrixCode.Png("DM-IMG");
+        var png = DataMatrixCode.Render("DM-IMG", OutputFormat.Png).Data;
         Assert.True(DataMatrixCode.TryDecodeImage(png, out var text));
         Assert.Equal("DM-IMG", text);
     }
@@ -21,7 +22,7 @@ public sealed class MatrixApiTests {
     [Fact]
     public void Pdf417Code_Png_RoundTrip() {
         var options = new Pdf417EncodeOptions { ErrorCorrectionLevel = 2 };
-        var png = Pdf417Code.Png("PDF-HELLO", options);
+        var png = Pdf417Code.Render("PDF-HELLO", OutputFormat.Png, options).Data;
         Assert.True(Pdf417Code.TryDecodePng(png, out string text));
         Assert.Equal("PDF-HELLO", text);
     }
@@ -29,7 +30,7 @@ public sealed class MatrixApiTests {
     [Fact]
     public void Pdf417Code_Image_RoundTrip() {
         var options = new Pdf417EncodeOptions { ErrorCorrectionLevel = 2 };
-        var png = Pdf417Code.Png("PDF-IMG", options);
+        var png = Pdf417Code.Render("PDF-IMG", OutputFormat.Png, options).Data;
         Assert.True(Pdf417Code.TryDecodeImage(png, out string text));
         Assert.Equal("PDF-IMG", text);
     }
@@ -42,7 +43,7 @@ public sealed class MatrixApiTests {
             IsLastSegment = true,
             FileName = "macro.txt"
         };
-        var png = Pdf417Code.PngMacro("PDF-MACRO", macro);
+        var png = Pdf417Code.RenderMacro("PDF-MACRO", macro, OutputFormat.Png).Data;
 
         Assert.True(Pdf417Code.TryDecodePng(png, out Pdf417Decoded decoded));
         Assert.Equal("PDF-MACRO", decoded.Text);

--- a/CodeGlyphX.Tests/QrArtAutoTuneTests.cs
+++ b/CodeGlyphX.Tests/QrArtAutoTuneTests.cs
@@ -130,7 +130,7 @@ public sealed class QrArtAutoTuneTests {
         var originalAccentRayCount = options.Eyes.AccentRayCount;
         var originalAccentStripeCount = options.Eyes.AccentStripeCount;
 
-        _ = QR.Png(payload, options);
+        _ = QrCode.Render(payload, OutputFormat.Png, options).Data;
 
         Assert.Equal(originalMinScale, options.ModuleScaleMap.MinScale);
         Assert.Equal(originalMaxScale, options.ModuleScaleMap.MaxScale);

--- a/CodeGlyphX.Tests/QrStylizedRoundTripTests.cs
+++ b/CodeGlyphX.Tests/QrStylizedRoundTripTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Threading;
 using CodeGlyphX;
 using CodeGlyphX.Rendering;
@@ -84,9 +83,7 @@ public sealed class QrStylizedRoundTripTests {
     }
 
     private static byte[] RenderPng(string payload, QrEasyOptions options) {
-        using var stream = new MemoryStream();
-        QR.SavePng(payload, stream, options);
-        return stream.ToArray();
+        return QrCode.Render(payload, OutputFormat.Png, options).Data;
     }
 
     private static QrEasyOptions CreateNeonDotOptions(int targetSizePx) {

--- a/CodeGlyphX.Tests/RenderOutputTests.cs
+++ b/CodeGlyphX.Tests/RenderOutputTests.cs
@@ -1,0 +1,48 @@
+using System;
+using CodeGlyphX.Rendering;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public class RenderOutputTests {
+    [Fact]
+    public void RenderBarcodeSvgReturnsText() {
+        var output = Barcode.Render(BarcodeType.Code128, "CODE128-12345", OutputFormat.Svg);
+
+        Assert.Equal(OutputFormat.Svg, output.Format);
+        Assert.True(output.IsText);
+
+        var text = output.GetText();
+        Assert.Contains("<svg", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RenderQrPngReturnsBinary() {
+        var output = QrCode.Render("HELLO-QR", OutputFormat.Png);
+
+        Assert.Equal(OutputFormat.Png, output.Format);
+        Assert.False(output.IsText);
+        Assert.True(output.Data.Length > 8);
+
+        // PNG signature (89 50 4E 47 0D 0A 1A 0A)
+        Assert.Equal(0x89, output.Data[0]);
+        Assert.Equal(0x50, output.Data[1]);
+        Assert.Equal(0x4E, output.Data[2]);
+        Assert.Equal(0x47, output.Data[3]);
+    }
+
+    [Fact]
+    public void RenderHtmlHonorsTitleExtras() {
+        var extras = new RenderExtras { HtmlTitle = "Render Output Test" };
+        var output = Barcode.Render(BarcodeType.Code128, "CODE128-HTML", OutputFormat.Html, extras: extras);
+
+        var text = output.GetText();
+        Assert.Contains("<title>Render Output Test</title>", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OutputFormatInfoDetectsSvgzAndSvgGz() {
+        Assert.Equal(OutputFormat.Svgz, OutputFormatInfo.FromPath("code.svgz"));
+        Assert.Equal(OutputFormat.Svgz, OutputFormatInfo.FromPath("code.svg.gz"));
+    }
+}

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -23,58 +23,60 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_Renderers_Produce_Expected_Formats() {
         var payload = "https://example.com";
-        var png = QrEasy.RenderPng(payload);
+        var png = QrCode.Render(payload, OutputFormat.Png).Data;
         Assert.True(IsPng(png));
 
-        var svg = QrEasy.RenderSvg(payload);
+        var svg = QrCode.Render(payload, OutputFormat.Svg).GetText();
         Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
 
-        var html = QrEasy.RenderHtml(payload);
+        var html = QrCode.Render(payload, OutputFormat.Html).GetText();
         Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
 
-        var bmp = QrEasy.RenderBmp(payload);
+        var bmp = QrCode.Render(payload, OutputFormat.Bmp).Data;
         Assert.True(IsBmp(bmp));
 
-        var ppm = QrEasy.RenderPpm(payload);
+        var ppm = QrCode.Render(payload, OutputFormat.Ppm).Data;
         Assert.True(IsPpm(ppm));
 
-        var pbm = QrEasy.RenderPbm(payload);
+        var pbm = QrCode.Render(payload, OutputFormat.Pbm).Data;
         Assert.True(IsPbm(pbm));
 
-        var pgm = QrEasy.RenderPgm(payload);
+        var pgm = QrCode.Render(payload, OutputFormat.Pgm).Data;
         Assert.True(IsPgm(pgm));
 
-        var pam = QrEasy.RenderPam(payload);
+        var pam = QrCode.Render(payload, OutputFormat.Pam).Data;
         Assert.True(IsPam(pam));
 
-        var xbm = QrEasy.RenderXbm(payload);
+        var xbm = QrCode.Render(payload, OutputFormat.Xbm).GetText();
         Assert.StartsWith("#define", xbm, StringComparison.Ordinal);
 
-        var xpm = QrEasy.RenderXpm(payload);
+        var xpm = QrCode.Render(payload, OutputFormat.Xpm).GetText();
         Assert.Contains("XPM", xpm, StringComparison.Ordinal);
 
-        var tga = QrEasy.RenderTga(payload);
+        var tga = QrCode.Render(payload, OutputFormat.Tga).Data;
         Assert.True(IsTga(tga));
 
-        var ico = QrEasy.RenderIco(payload);
+        var ico = QrCode.Render(payload, OutputFormat.Ico).Data;
         Assert.True(IsIco(ico));
 
-        var svgz = QrEasy.RenderSvgz(payload);
+        var svgz = QrCode.Render(payload, OutputFormat.Svgz).Data;
         Assert.True(IsGzip(svgz));
 
-        var pdf = QrEasy.RenderPdf(payload);
+        var pdf = QrCode.Render(payload, OutputFormat.Pdf).Data;
         Assert.True(IsPdf(pdf));
 
-        var eps = QrEasy.RenderEps(payload);
+        var eps = QrCode.Render(payload, OutputFormat.Eps).GetText();
         Assert.True(IsEps(eps));
 
-        var pdfRaster = QrEasy.RenderPdf(payload, mode: RenderMode.Raster);
+        var pdfRaster = QrCode.Render(payload, OutputFormat.Pdf, extras: new RenderExtras { VectorMode = RenderMode.Raster }).Data;
         Assert.True(IsPdf(pdfRaster));
 
-        var epsRaster = QrEasy.RenderEps(payload, mode: RenderMode.Raster);
+        var epsRaster = QrCode.Render(payload, OutputFormat.Eps, extras: new RenderExtras { VectorMode = RenderMode.Raster }).GetText();
         Assert.True(IsEps(epsRaster));
 
-        var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions { QuietZone = 1 });
+        var ascii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = new MatrixAsciiRenderOptions { QuietZone = 1 }
+        }).GetText();
         Assert.Contains("#", ascii, StringComparison.Ordinal);
     }
 
@@ -95,7 +97,7 @@ public sealed class RendererFormatTests {
 #pragma warning restore CS0618
 
         foreach (var preset in presets) {
-            var png = QrEasy.RenderPng(payload, preset);
+            var png = QrCode.Render(payload, OutputFormat.Png, preset).Data;
             Assert.True(ImageReader.TryDetectFormat(png, out var format));
             Assert.Equal(ImageFormat.Png, format);
         }
@@ -111,7 +113,7 @@ public sealed class RendererFormatTests {
         };
 
         foreach (var art in arts) {
-            var png = QrEasy.RenderPng(payload, new QrEasyOptions { Art = art });
+            var png = QrCode.Render(payload, OutputFormat.Png, new QrEasyOptions { Art = art }).Data;
             Assert.True(ImageReader.TryDetectFormat(png, out var format));
             Assert.Equal(ImageFormat.Png, format);
         }
@@ -120,10 +122,12 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_Ascii_UnicodeBlocks_Uses_Block_Glyphs() {
         var payload = "https://example.com";
-        var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
-            QuietZone = 1,
-            UseUnicodeBlocks = true
-        });
+        var ascii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = new MatrixAsciiRenderOptions {
+                QuietZone = 1,
+                UseUnicodeBlocks = true
+            }
+        }).GetText();
 
         Assert.Contains("█", ascii, StringComparison.Ordinal);
     }
@@ -131,12 +135,14 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_Ascii_AnsiColors_Emits_Escape_Codes() {
         var payload = "https://example.com";
-        var ascii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
-            QuietZone = 1,
-            UseUnicodeBlocks = true,
-            UseAnsiColors = true,
-            UseAnsiTrueColor = false
-        });
+        var ascii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = new MatrixAsciiRenderOptions {
+                QuietZone = 1,
+                UseUnicodeBlocks = true,
+                UseAnsiColors = true,
+                UseAnsiTrueColor = false
+            }
+        }).GetText();
 
         Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
     }
@@ -144,7 +150,9 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_Ascii_ConsolePreset_Is_Scan_Friendly() {
         var payload = "https://example.com";
-        var ascii = QrEasy.RenderAscii(payload, AsciiPresets.Console(scale: 3));
+        var ascii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = AsciiPresets.Console(scale: 3)
+        }).GetText();
 
         Assert.Contains("█", ascii, StringComparison.Ordinal);
         Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
@@ -153,7 +161,9 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_Ascii_ConsoleWrapper_Uses_Preset() {
         var payload = "https://example.com";
-        var ascii = QrEasy.RenderAsciiConsole(payload, scale: 3);
+        var ascii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = AsciiPresets.Console(scale: 3)
+        }).GetText();
 
         Assert.Contains("█", ascii, StringComparison.Ordinal);
         Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
@@ -162,18 +172,22 @@ public sealed class RendererFormatTests {
     [Fact]
     public void Qr_Ascii_Scale_Increases_Output_Size() {
         var payload = "https://example.com";
-        var baseAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
-            QuietZone = 1,
-            ModuleWidth = 1,
-            ModuleHeight = 1,
-            Scale = 1
-        });
-        var scaledAscii = QrEasy.RenderAscii(payload, new MatrixAsciiRenderOptions {
-            QuietZone = 1,
-            ModuleWidth = 1,
-            ModuleHeight = 1,
-            Scale = 2
-        });
+        var baseAscii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = new MatrixAsciiRenderOptions {
+                QuietZone = 1,
+                ModuleWidth = 1,
+                ModuleHeight = 1,
+                Scale = 1
+            }
+        }).GetText();
+        var scaledAscii = QrCode.Render(payload, OutputFormat.Ascii, extras: new RenderExtras {
+            MatrixAscii = new MatrixAsciiRenderOptions {
+                QuietZone = 1,
+                ModuleWidth = 1,
+                ModuleHeight = 1,
+                Scale = 2
+            }
+        }).GetText();
 
         Assert.True(scaledAscii.Length > baseAscii.Length);
     }
@@ -185,7 +199,7 @@ public sealed class RendererFormatTests {
             IcoSizes = new[] { 32, 64, 128 }
         };
 
-        var ico = QrEasy.RenderIco(payload, opts);
+        var ico = QrCode.Render(payload, OutputFormat.Ico, opts).Data;
         Assert.True(IsIco(ico));
         Assert.Equal(3, GetIcoCount(ico));
     }
@@ -232,16 +246,16 @@ public sealed class RendererFormatTests {
         var svgz = BarcodeSvgzRenderer.Render(barcode, new BarcodeSvgRenderOptions());
         Assert.True(IsGzip(svgz));
 
-        var pdf = Barcode.Pdf(BarcodeType.Code128, "CODEGLYPH-123");
+        var pdf = Barcode.Render(BarcodeType.Code128, "CODEGLYPH-123", OutputFormat.Pdf).Data;
         Assert.True(IsPdf(pdf));
 
-        var eps = Barcode.Eps(BarcodeType.Code128, "CODEGLYPH-123");
+        var eps = Barcode.Render(BarcodeType.Code128, "CODEGLYPH-123", OutputFormat.Eps).GetText();
         Assert.True(IsEps(eps));
 
-        var pdfRaster = Barcode.Pdf(BarcodeType.Code128, "CODEGLYPH-123", mode: RenderMode.Raster);
+        var pdfRaster = Barcode.Render(BarcodeType.Code128, "CODEGLYPH-123", OutputFormat.Pdf, extras: new RenderExtras { VectorMode = RenderMode.Raster }).Data;
         Assert.True(IsPdf(pdfRaster));
 
-        var epsRaster = Barcode.Eps(BarcodeType.Code128, "CODEGLYPH-123", mode: RenderMode.Raster);
+        var epsRaster = Barcode.Render(BarcodeType.Code128, "CODEGLYPH-123", OutputFormat.Eps, extras: new RenderExtras { VectorMode = RenderMode.Raster }).GetText();
         Assert.True(IsEps(epsRaster));
 
         var ascii = BarcodeAsciiRenderer.Render(barcode, new BarcodeAsciiRenderOptions { QuietZone = 1, Height = 2 });
@@ -255,12 +269,12 @@ public sealed class RendererFormatTests {
             ModuleCornerRadiusPx = 2,
         };
 
-        var pdf = QrEasy.RenderPdf("https://example.com", opts, RenderMode.Vector);
+        var pdf = QrCode.Render("https://example.com", OutputFormat.Pdf, opts, new RenderExtras { VectorMode = RenderMode.Vector }).Data;
         var pdfText = Encoding.ASCII.GetString(pdf);
         Assert.Contains(" c\n", pdfText, StringComparison.Ordinal);
         Assert.DoesNotContain("/Subtype /Image", pdfText, StringComparison.Ordinal);
 
-        var eps = QrEasy.RenderEps("https://example.com", opts, RenderMode.Vector);
+        var eps = QrCode.Render("https://example.com", OutputFormat.Eps, opts, new RenderExtras { VectorMode = RenderMode.Vector }).GetText();
         Assert.Contains("curveto", eps, StringComparison.Ordinal);
         Assert.DoesNotContain("colorimage", eps, StringComparison.OrdinalIgnoreCase);
     }
@@ -275,11 +289,11 @@ public sealed class RendererFormatTests {
             },
         };
 
-        var pdf = QrEasy.RenderPdf("https://example.com", opts, RenderMode.Vector);
+        var pdf = QrCode.Render("https://example.com", OutputFormat.Pdf, opts, new RenderExtras { VectorMode = RenderMode.Vector }).Data;
         var pdfText = Encoding.ASCII.GetString(pdf);
         Assert.Contains("/Subtype /Image", pdfText, StringComparison.Ordinal);
 
-        var eps = QrEasy.RenderEps("https://example.com", opts, RenderMode.Vector);
+        var eps = QrCode.Render("https://example.com", OutputFormat.Eps, opts, new RenderExtras { VectorMode = RenderMode.Vector }).GetText();
         Assert.Contains("colorimage", eps, StringComparison.Ordinal);
     }
 
@@ -299,11 +313,11 @@ public sealed class RendererFormatTests {
             LogoPng = logoPng,
         };
 
-        var pdf = QrEasy.RenderPdf("https://example.com", opts, RenderMode.Vector);
+        var pdf = QrCode.Render("https://example.com", OutputFormat.Pdf, opts, new RenderExtras { VectorMode = RenderMode.Vector }).Data;
         var pdfText = Encoding.ASCII.GetString(pdf);
         Assert.Contains("/Subtype /Image", pdfText, StringComparison.Ordinal);
 
-        var eps = QrEasy.RenderEps("https://example.com", opts, RenderMode.Vector);
+        var eps = QrCode.Render("https://example.com", OutputFormat.Eps, opts, new RenderExtras { VectorMode = RenderMode.Vector }).GetText();
         Assert.Contains("colorimage", eps, StringComparison.Ordinal);
     }
 

--- a/CodeGlyphX.Tests/RoundTripTests.cs
+++ b/CodeGlyphX.Tests/RoundTripTests.cs
@@ -178,7 +178,7 @@ public sealed class RoundTripTests {
         opts.LogoScale = 0.10;
         opts.LogoDrawBackground = false;
         var expectedModules = QrEasy.Encode(text, opts).Modules.Width;
-        var png = QrEasy.RenderPng(text, opts);
+        var png = QrCode.Render(text, OutputFormat.Png, opts).Data;
 
         Assert.True(ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height));
         var stride = width * 4;
@@ -198,7 +198,7 @@ public sealed class RoundTripTests {
     public void DecodePixels_CanDecodeFancyQr_Robust() {
         var text = "Fancy QR";
         var opts = new QrEasyOptions { Style = QrRenderStyle.Fancy, ModuleSize = 8, QuietZone = 4 };
-        var png = QrEasy.RenderPng(text, opts);
+        var png = QrCode.Render(text, OutputFormat.Png, opts).Data;
 
         var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
         var options = new QrPixelDecodeOptions { Profile = QrDecodeProfile.Robust, AggressiveSampling = true };
@@ -210,7 +210,7 @@ public sealed class RoundTripTests {
     public void DecodePixels_CanDecodeNoQuietZone_Robust() {
         var text = "No quiet zone";
         var opts = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H, ModuleSize = 8 };
-        var png = QrEasy.RenderPng(text, opts);
+        var png = QrCode.Render(text, OutputFormat.Png, opts).Data;
 
         var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
         var options = new QrPixelDecodeOptions { Profile = QrDecodeProfile.Robust, AggressiveSampling = true };

--- a/CodeGlyphX.Website/Pages/Docs.razor
+++ b/CodeGlyphX.Website/Pages/Docs.razor
@@ -220,6 +220,17 @@ QR.Save("Hello, World!", "hello.png");
 QR.Save("Hello, World!", "hello.svg");  // Vector SVG
 QR.Save("Hello, World!", "hello.pdf");  // PDF document</pre>
 
+            <h3>Render In-Memory</h3>
+            <pre class="code-block">using CodeGlyphX;
+using CodeGlyphX.Rendering;
+
+var svg = Barcode.Render(BarcodeType.Code128, "PRODUCT-12345", OutputFormat.Svg).GetText();
+var png = QrCode.Render("Hello, World!", OutputFormat.Png).Data;
+
+// HTML title + raster PDF/EPS
+var extras = new RenderExtras { HtmlTitle = "My Code", VectorMode = RenderMode.Raster };
+QR.Save("Hello, World!", "hello.html", extras: extras);</pre>
+
             <h2>3. Generate Barcodes</h2>
             <pre class="code-block">using CodeGlyphX;
 

--- a/CodeGlyphX/AztecCode.Render.cs
+++ b/CodeGlyphX/AztecCode.Render.cs
@@ -1,0 +1,85 @@
+using System;
+using CodeGlyphX.Aztec;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pam;
+using CodeGlyphX.Rendering.Pbm;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Pgm;
+using CodeGlyphX.Rendering.Ppm;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+using CodeGlyphX.Rendering.Svgz;
+using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
+using CodeGlyphX.Rendering.Xbm;
+using CodeGlyphX.Rendering.Xpm;
+
+namespace CodeGlyphX;
+
+public static partial class AztecCode {
+    /// <summary>
+    /// Renders an Aztec payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(string text, OutputFormat format, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var modules = Encode(text, encodeOptions);
+        return Render(modules, format, renderOptions, extras);
+    }
+
+    private static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? renderOptions, RenderExtras? extras) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
+
+        var pngOptions = ToPngOptions(renderOptions);
+        switch (format) {
+            case OutputFormat.Png:
+                return RenderedOutput.FromBinary(format, MatrixPngRenderer.Render(modules, pngOptions));
+            case OutputFormat.Svg:
+                return RenderedOutput.FromText(format, MatrixSvgRenderer.Render(modules, ToSvgOptions(renderOptions)));
+            case OutputFormat.Svgz:
+                return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, ToSvgOptions(renderOptions)));
+            case OutputFormat.Html: {
+                var html = MatrixHtmlRenderer.Render(modules, ToHtmlOptions(renderOptions));
+                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
+                    html = html.WrapHtml(extras.HtmlTitle);
+                }
+                return RenderedOutput.FromText(format, html);
+            }
+            case OutputFormat.Jpeg:
+                return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
+            case OutputFormat.Webp:
+                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, renderOptions?.WebpQuality ?? 100));
+            case OutputFormat.Bmp:
+                return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
+            case OutputFormat.Ppm:
+                return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pbm:
+                return RenderedOutput.FromBinary(format, MatrixPbmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pgm:
+                return RenderedOutput.FromBinary(format, MatrixPgmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pam:
+                return RenderedOutput.FromBinary(format, MatrixPamRenderer.Render(modules, pngOptions));
+            case OutputFormat.Xbm:
+                return RenderedOutput.FromText(format, MatrixXbmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Xpm:
+                return RenderedOutput.FromText(format, MatrixXpmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Tga:
+                return RenderedOutput.FromBinary(format, MatrixTgaRenderer.Render(modules, pngOptions));
+            case OutputFormat.Ico:
+                return RenderedOutput.FromBinary(format, MatrixIcoRenderer.Render(modules, pngOptions, ToIcoOptions(renderOptions)));
+            case OutputFormat.Pdf:
+                return RenderedOutput.FromBinary(format, MatrixPdfRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Eps:
+                return RenderedOutput.FromText(format, MatrixEpsRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Ascii:
+                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(modules, extras?.MatrixAscii ?? new MatrixAsciiRenderOptions()));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
+        }
+    }
+}

--- a/CodeGlyphX/AztecCode.Render.cs
+++ b/CodeGlyphX/AztecCode.Render.cs
@@ -45,8 +45,9 @@ public static partial class AztecCode {
                 return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, ToSvgOptions(renderOptions)));
             case OutputFormat.Html: {
                 var html = MatrixHtmlRenderer.Render(modules, ToHtmlOptions(renderOptions));
-                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
-                    html = html.WrapHtml(extras.HtmlTitle);
+                var title = extras?.HtmlTitle;
+                if (!string.IsNullOrEmpty(title)) {
+                    html = html.WrapHtml(title);
                 }
                 return RenderedOutput.FromText(format, html);
             }

--- a/CodeGlyphX/AztecCode.Save.cs
+++ b/CodeGlyphX/AztecCode.Save.cs
@@ -27,6 +27,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PNG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions));
     }
@@ -34,6 +35,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PNG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Png(text, encodeOptions, renderOptions));
     }
@@ -41,6 +43,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteText(path, Svg(text, encodeOptions, renderOptions));
     }
@@ -48,6 +51,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVGZ to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Svgz(text, encodeOptions, renderOptions));
     }
@@ -55,6 +59,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteText(stream, Svg(text, encodeOptions, renderOptions));
     }
@@ -62,6 +67,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVGZ to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Svgz(text, encodeOptions, renderOptions));
     }
@@ -69,6 +75,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec HTML to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(text, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
@@ -78,6 +85,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec HTML to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(text, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
@@ -87,6 +95,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec JPEG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Jpeg(text, encodeOptions, renderOptions));
     }
@@ -94,6 +103,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec JPEG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Jpeg(text, encodeOptions, renderOptions));
     }
@@ -101,6 +111,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec WebP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Webp(text, encodeOptions, renderOptions));
     }
@@ -108,6 +119,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec WebP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Webp(text, encodeOptions, renderOptions));
     }
@@ -115,6 +127,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec BMP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Bmp(text, encodeOptions, renderOptions));
     }
@@ -122,6 +135,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec BMP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Bmp(text, encodeOptions, renderOptions));
     }
@@ -129,6 +143,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Ppm(text, encodeOptions, renderOptions));
     }
@@ -136,6 +151,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Ppm(text, encodeOptions, renderOptions));
     }
@@ -143,6 +159,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Pbm(text, encodeOptions, renderOptions));
     }
@@ -150,6 +167,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Pbm(text, encodeOptions, renderOptions));
     }
@@ -157,6 +175,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PGM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Pgm(text, encodeOptions, renderOptions));
     }
@@ -164,6 +183,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PGM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Pgm(text, encodeOptions, renderOptions));
     }
@@ -171,6 +191,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PAM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Pam(text, encodeOptions, renderOptions));
     }
@@ -178,6 +199,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PAM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Pam(text, encodeOptions, renderOptions));
     }
@@ -185,6 +207,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteText(path, Xbm(text, encodeOptions, renderOptions));
     }
@@ -192,6 +215,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteText(stream, Xbm(text, encodeOptions, renderOptions));
     }
@@ -199,6 +223,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteText(path, Xpm(text, encodeOptions, renderOptions));
     }
@@ -206,6 +231,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteText(stream, Xpm(text, encodeOptions, renderOptions));
     }
@@ -213,6 +239,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec TGA to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Tga(text, encodeOptions, renderOptions));
     }
@@ -220,6 +247,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec TGA to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Tga(text, encodeOptions, renderOptions));
     }
@@ -227,6 +255,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec ICO to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Ico(text, encodeOptions, renderOptions));
     }
@@ -234,6 +263,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec ICO to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Ico(text, encodeOptions, renderOptions));
     }
@@ -241,6 +271,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PDF to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         return RenderIO.WriteBinary(path, Pdf(text, encodeOptions, renderOptions, renderMode));
     }
@@ -248,6 +279,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PDF to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         RenderIO.WriteBinary(stream, Pdf(text, encodeOptions, renderOptions, renderMode));
     }
@@ -255,6 +287,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec EPS to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         return RenderIO.WriteText(path, Eps(text, encodeOptions, renderOptions, renderMode));
     }
@@ -262,6 +295,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec EPS to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(string text, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         RenderIO.WriteText(stream, Eps(text, encodeOptions, renderOptions, renderMode));
     }
@@ -269,6 +303,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PNG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Png(data, encodeOptions, renderOptions));
     }
@@ -276,6 +311,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PNG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Png(data, encodeOptions, renderOptions));
     }
@@ -283,6 +319,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteText(path, Svg(data, encodeOptions, renderOptions));
     }
@@ -290,6 +327,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteText(stream, Svg(data, encodeOptions, renderOptions));
     }
@@ -297,6 +335,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec HTML to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(data, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
@@ -306,6 +345,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec HTML to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(data, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
@@ -315,6 +355,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec JPEG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Jpeg(data, encodeOptions, renderOptions));
     }
@@ -322,6 +363,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec JPEG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Jpeg(data, encodeOptions, renderOptions));
     }
@@ -329,6 +371,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec WebP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Webp(data, encodeOptions, renderOptions));
     }
@@ -336,6 +379,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec WebP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Webp(data, encodeOptions, renderOptions));
     }
@@ -343,6 +387,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec BMP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Bmp(data, encodeOptions, renderOptions));
     }
@@ -350,6 +395,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec BMP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Bmp(data, encodeOptions, renderOptions));
     }
@@ -357,6 +403,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Ppm(data, encodeOptions, renderOptions));
     }
@@ -364,6 +411,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Ppm(data, encodeOptions, renderOptions));
     }
@@ -371,6 +419,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Pbm(data, encodeOptions, renderOptions));
     }
@@ -378,6 +427,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Pbm(data, encodeOptions, renderOptions));
     }
@@ -385,6 +435,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PGM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Pgm(data, encodeOptions, renderOptions));
     }
@@ -392,6 +443,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PGM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Pgm(data, encodeOptions, renderOptions));
     }
@@ -399,6 +451,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PAM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Pam(data, encodeOptions, renderOptions));
     }
@@ -406,6 +459,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PAM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Pam(data, encodeOptions, renderOptions));
     }
@@ -413,6 +467,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteText(path, Xbm(data, encodeOptions, renderOptions));
     }
@@ -420,6 +475,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteText(stream, Xbm(data, encodeOptions, renderOptions));
     }
@@ -427,6 +483,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteText(path, Xpm(data, encodeOptions, renderOptions));
     }
@@ -434,6 +491,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec XPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteText(stream, Xpm(data, encodeOptions, renderOptions));
     }
@@ -441,6 +499,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec TGA to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Tga(data, encodeOptions, renderOptions));
     }
@@ -448,6 +507,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec TGA to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Tga(data, encodeOptions, renderOptions));
     }
@@ -455,6 +515,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec ICO to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Ico(data, encodeOptions, renderOptions));
     }
@@ -462,6 +523,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec ICO to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Ico(data, encodeOptions, renderOptions));
     }
@@ -469,6 +531,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVGZ to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         return RenderIO.WriteBinary(path, Svgz(data, encodeOptions, renderOptions));
     }
@@ -476,6 +539,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec SVGZ to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         RenderIO.WriteBinary(stream, Svgz(data, encodeOptions, renderOptions));
     }
@@ -483,6 +547,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PDF to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         return RenderIO.WriteBinary(path, Pdf(data, encodeOptions, renderOptions, renderMode));
     }
@@ -490,6 +555,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec PDF to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         RenderIO.WriteBinary(stream, Pdf(data, encodeOptions, renderOptions, renderMode));
     }
@@ -497,6 +563,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec EPS to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(ReadOnlySpan<byte> data, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         return RenderIO.WriteText(path, Eps(data, encodeOptions, renderOptions, renderMode));
     }
@@ -504,6 +571,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Saves Aztec EPS to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         RenderIO.WriteText(stream, Eps(data, encodeOptions, renderOptions, renderMode));
     }

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -59,6 +59,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PNG bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPngRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -67,6 +68,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PNG bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixPngRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -75,6 +77,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to SVG markup.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixSvgRenderer.Render(modules, ToSvgOptions(renderOptions));
@@ -83,6 +86,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixSvgzRenderer.Render(modules, ToSvgOptions(renderOptions));
@@ -91,6 +95,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to SVG markup.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixSvgRenderer.Render(modules, ToSvgOptions(renderOptions));
@@ -99,6 +104,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixSvgzRenderer.Render(modules, ToSvgOptions(renderOptions));
@@ -107,6 +113,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to HTML markup.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixHtmlRenderer.Render(modules, ToHtmlOptions(renderOptions));
@@ -115,6 +122,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to HTML markup.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixHtmlRenderer.Render(modules, ToHtmlOptions(renderOptions));
@@ -123,6 +131,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to JPEG bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = ToPngOptions(renderOptions);
@@ -132,6 +141,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to WebP bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = ToPngOptions(renderOptions);
@@ -141,6 +151,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to JPEG bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         var opts = ToPngOptions(renderOptions);
@@ -150,6 +161,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to WebP bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         var opts = ToPngOptions(renderOptions);
@@ -159,6 +171,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to BMP bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixBmpRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -167,6 +180,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to BMP bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixBmpRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -175,6 +189,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PPM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPpmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -183,6 +198,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PPM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixPpmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -191,6 +207,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PBM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPbmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -199,6 +216,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PGM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPgmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -207,6 +225,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PAM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPamRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -215,6 +234,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixXbmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -223,6 +243,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixXpmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -231,6 +252,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PBM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixPbmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -239,6 +261,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PGM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixPgmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -247,6 +270,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PAM bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixPamRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -255,6 +279,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixXbmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -263,6 +288,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixXpmRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -271,6 +297,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to TGA bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixTgaRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -279,6 +306,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to TGA bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixTgaRenderer.Render(modules, ToPngOptions(renderOptions));
@@ -287,6 +315,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to ICO bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixIcoRenderer.Render(modules, ToPngOptions(renderOptions), ToIcoOptions(renderOptions));
@@ -295,6 +324,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to ICO bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixIcoRenderer.Render(modules, ToPngOptions(renderOptions), ToIcoOptions(renderOptions));
@@ -303,6 +333,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PDF bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         return MatrixPdfRenderer.Render(modules, ToPngOptions(renderOptions), renderMode);
@@ -311,6 +342,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to PDF bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(data, encodeOptions);
         return MatrixPdfRenderer.Render(modules, ToPngOptions(renderOptions), renderMode);
@@ -319,6 +351,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to EPS markup.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         return MatrixEpsRenderer.Render(modules, ToPngOptions(renderOptions), renderMode);
@@ -327,6 +360,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to EPS markup.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(data, encodeOptions);
         return MatrixEpsRenderer.Render(modules, ToPngOptions(renderOptions), renderMode);
@@ -335,6 +369,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(string text, AztecEncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixAsciiRenderer.Render(modules, renderOptions);
@@ -343,6 +378,7 @@ public static partial class AztecCode {
     /// <summary>
     /// Renders Aztec to ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         return MatrixAsciiRenderer.Render(modules, renderOptions);

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using CodeGlyphX.Aztec;
-using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -350,35 +349,13 @@ public static partial class AztecCode {
     }
 
     /// <summary>
-    /// Saves Aztec to a file based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps/.txt).
+    /// Saves Aztec to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions)),
-            Png = () => RenderIO.WriteBinary(path, Png(text, encodeOptions, renderOptions)),
-            Webp = () => RenderIO.WriteBinary(path, Webp(text, encodeOptions, renderOptions)),
-            Svg = () => RenderIO.WriteText(path, Svg(text, encodeOptions, renderOptions)),
-            Svgz = () => RenderIO.WriteBinary(path, Svgz(text, encodeOptions, renderOptions)),
-            Html = () => {
-                var html = Html(text, encodeOptions, renderOptions);
-                if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-                return RenderIO.WriteText(path, html);
-            },
-            Jpeg = () => RenderIO.WriteBinary(path, Jpeg(text, encodeOptions, renderOptions)),
-            Bmp = () => RenderIO.WriteBinary(path, Bmp(text, encodeOptions, renderOptions)),
-            Ppm = () => RenderIO.WriteBinary(path, Ppm(text, encodeOptions, renderOptions)),
-            Pbm = () => RenderIO.WriteBinary(path, Pbm(text, encodeOptions, renderOptions)),
-            Pgm = () => RenderIO.WriteBinary(path, Pgm(text, encodeOptions, renderOptions)),
-            Pam = () => RenderIO.WriteBinary(path, Pam(text, encodeOptions, renderOptions)),
-            Xbm = () => RenderIO.WriteText(path, Xbm(text, encodeOptions, renderOptions)),
-            Xpm = () => RenderIO.WriteText(path, Xpm(text, encodeOptions, renderOptions)),
-            Tga = () => RenderIO.WriteBinary(path, Tga(text, encodeOptions, renderOptions)),
-            Ico = () => RenderIO.WriteBinary(path, Ico(text, encodeOptions, renderOptions)),
-            Pdf = () => RenderIO.WriteBinary(path, Pdf(text, encodeOptions, renderOptions)),
-            Eps = () => RenderIO.WriteText(path, Eps(text, encodeOptions, renderOptions)),
-            Text = () => RenderIO.WriteText(path, Ascii(text, encodeOptions))
-        });
+    public static string Save(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(text, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
     }
 
     private static MatrixPngRenderOptions ToPngOptions(MatrixOptions? options) {

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -388,6 +388,18 @@ public static partial class AztecCode {
     /// Saves Aztec to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(string text, string path, AztecEncodeOptions? encodeOptions, MatrixOptions? renderOptions, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(text, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves Aztec to a file based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
     public static string Save(string text, string path, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
         var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
         var output = Render(text, format, encodeOptions, renderOptions, extras);

--- a/CodeGlyphX/Barcode.Builder.cs
+++ b/CodeGlyphX/Barcode.Builder.cs
@@ -449,7 +449,10 @@ public static partial class Barcode {
         /// <summary>
         /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp/.ppm/.pbm/.tga/.ico/.pdf/.eps). Defaults to PNG when no extension is provided.
         /// </summary>
-        public string Save(string path, string? title = null) => Barcode.Save(_type, _content, path, Options, title);
+        public string Save(string path, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return Barcode.Save(_type, _content, path, Options, extras);
+        }
     }
 
 }

--- a/CodeGlyphX/Barcode.Builder.cs
+++ b/CodeGlyphX/Barcode.Builder.cs
@@ -176,275 +176,295 @@ public static partial class Barcode {
         /// </summary>
         public Barcode1D Encode() => Barcode.Encode(_type, _content);
 
+        private RenderedOutput Render(OutputFormat format, RenderExtras? extras = null) {
+            return Barcode.Render(_type, _content, format, Options, extras);
+        }
+
         /// <summary>
         /// Renders PNG bytes.
         /// </summary>
-        public byte[] Png() => Barcode.Png(_type, _content, Options);
+        public byte[] Png() => Render(OutputFormat.Png).Data;
 
         /// <summary>
         /// Renders SVG text.
         /// </summary>
-        public string Svg() => Barcode.Svg(_type, _content, Options);
+        public string Svg() => Render(OutputFormat.Svg).GetText();
 
         /// <summary>
         /// Renders HTML text.
         /// </summary>
-        public string Html() => Barcode.Html(_type, _content, Options);
+        public string Html() => Render(OutputFormat.Html).GetText();
 
         /// <summary>
         /// Renders JPEG bytes.
         /// </summary>
-        public byte[] Jpeg() => Barcode.Jpeg(_type, _content, Options);
+        public byte[] Jpeg() => Render(OutputFormat.Jpeg).Data;
 
         /// <summary>
         /// Renders BMP bytes.
         /// </summary>
-        public byte[] Bmp() => Barcode.Bmp(_type, _content, Options);
+        public byte[] Bmp() => Render(OutputFormat.Bmp).Data;
 
         /// <summary>
         /// Renders PPM bytes.
         /// </summary>
-        public byte[] Ppm() => Barcode.Ppm(_type, _content, Options);
+        public byte[] Ppm() => Render(OutputFormat.Ppm).Data;
 
         /// <summary>
         /// Renders PBM bytes.
         /// </summary>
-        public byte[] Pbm() => Barcode.Pbm(_type, _content, Options);
+        public byte[] Pbm() => Render(OutputFormat.Pbm).Data;
 
         /// <summary>
         /// Renders PGM bytes.
         /// </summary>
-        public byte[] Pgm() => Barcode.Pgm(_type, _content, Options);
+        public byte[] Pgm() => Render(OutputFormat.Pgm).Data;
 
         /// <summary>
         /// Renders PAM bytes.
         /// </summary>
-        public byte[] Pam() => Barcode.Pam(_type, _content, Options);
+        public byte[] Pam() => Render(OutputFormat.Pam).Data;
 
         /// <summary>
         /// Renders XBM text.
         /// </summary>
-        public string Xbm() => Barcode.Xbm(_type, _content, Options);
+        public string Xbm() => Render(OutputFormat.Xbm).GetText();
 
         /// <summary>
         /// Renders XPM text.
         /// </summary>
-        public string Xpm() => Barcode.Xpm(_type, _content, Options);
+        public string Xpm() => Render(OutputFormat.Xpm).GetText();
 
         /// <summary>
         /// Renders TGA bytes.
         /// </summary>
-        public byte[] Tga() => Barcode.Tga(_type, _content, Options);
+        public byte[] Tga() => Render(OutputFormat.Tga).Data;
 
         /// <summary>
         /// Renders ICO bytes.
         /// </summary>
-        public byte[] Ico() => Barcode.Ico(_type, _content, Options);
+        public byte[] Ico() => Render(OutputFormat.Ico).Data;
 
         /// <summary>
         /// Renders SVGZ bytes.
         /// </summary>
-        public byte[] Svgz() => Barcode.Svgz(_type, _content, Options);
+        public byte[] Svgz() => Render(OutputFormat.Svgz).Data;
 
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
         /// <param name="mode">Vector or raster output.</param>
-        public byte[] Pdf(RenderMode mode = RenderMode.Vector) => Barcode.Pdf(_type, _content, Options, mode);
+        public byte[] Pdf(RenderMode mode = RenderMode.Vector) => Render(OutputFormat.Pdf, new RenderExtras { VectorMode = mode }).Data;
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
         /// <param name="mode">Vector or raster output.</param>
-        public string Eps(RenderMode mode = RenderMode.Vector) => Barcode.Eps(_type, _content, Options, mode);
+        public string Eps(RenderMode mode = RenderMode.Vector) => Render(OutputFormat.Eps, new RenderExtras { VectorMode = mode }).GetText();
 
         /// <summary>
         /// Renders ASCII text.
         /// </summary>
-        public string Ascii(BarcodeAsciiRenderOptions? options = null) => Barcode.Ascii(_type, _content, options);
+        public string Ascii(BarcodeAsciiRenderOptions? options = null) => Render(OutputFormat.Ascii, new RenderExtras { BarcodeAscii = options }).GetText();
 
         /// <summary>
         /// Saves PNG to a file.
         /// </summary>
-        public string SavePng(string path) => Barcode.SavePng(_type, _content, path, Options);
+        public string SavePng(string path) => OutputWriter.Write(path, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves PNG to a stream.
         /// </summary>
-        public void SavePng(Stream stream) => Barcode.SavePng(_type, _content, stream, Options);
+        public void SavePng(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves SVG to a file.
         /// </summary>
-        public string SaveSvg(string path) => Barcode.SaveSvg(_type, _content, path, Options);
+        public string SaveSvg(string path) => OutputWriter.Write(path, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves SVG to a stream.
         /// </summary>
-        public void SaveSvg(Stream stream) => Barcode.SaveSvg(_type, _content, stream, Options);
+        public void SaveSvg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves SVGZ to a file.
         /// </summary>
-        public string SaveSvgz(string path) => Barcode.SaveSvgz(_type, _content, path, Options);
+        public string SaveSvgz(string path) => OutputWriter.Write(path, Render(OutputFormat.Svgz));
 
         /// <summary>
         /// Saves SVGZ to a stream.
         /// </summary>
-        public void SaveSvgz(Stream stream) => Barcode.SaveSvgz(_type, _content, stream, Options);
+        public void SaveSvgz(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Svgz));
 
         /// <summary>
         /// Saves HTML to a file.
         /// </summary>
-        public string SaveHtml(string path, string? title = null) => Barcode.SaveHtml(_type, _content, path, Options, title);
+        public string SaveHtml(string path, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return OutputWriter.Write(path, Render(OutputFormat.Html, extras));
+        }
 
         /// <summary>
         /// Saves HTML to a stream.
         /// </summary>
-        public void SaveHtml(Stream stream, string? title = null) => Barcode.SaveHtml(_type, _content, stream, Options, title);
+        public void SaveHtml(Stream stream, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            OutputWriter.Write(stream, Render(OutputFormat.Html, extras));
+        }
 
         /// <summary>
         /// Saves JPEG to a file.
         /// </summary>
-        public string SaveJpeg(string path) => Barcode.SaveJpeg(_type, _content, path, Options);
+        public string SaveJpeg(string path) => OutputWriter.Write(path, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves JPEG to a stream.
         /// </summary>
-        public void SaveJpeg(Stream stream) => Barcode.SaveJpeg(_type, _content, stream, Options);
+        public void SaveJpeg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves WebP to a file.
         /// </summary>
-        public string SaveWebp(string path) => Barcode.SaveWebp(_type, _content, path, Options);
+        public string SaveWebp(string path) => OutputWriter.Write(path, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves WebP to a stream.
         /// </summary>
-        public void SaveWebp(Stream stream) => Barcode.SaveWebp(_type, _content, stream, Options);
+        public void SaveWebp(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves BMP to a file.
         /// </summary>
-        public string SaveBmp(string path) => Barcode.SaveBmp(_type, _content, path, Options);
+        public string SaveBmp(string path) => OutputWriter.Write(path, Render(OutputFormat.Bmp));
 
         /// <summary>
         /// Saves BMP to a stream.
         /// </summary>
-        public void SaveBmp(Stream stream) => Barcode.SaveBmp(_type, _content, stream, Options);
+        public void SaveBmp(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Bmp));
 
         /// <summary>
         /// Saves PGM to a file.
         /// </summary>
-        public string SavePgm(string path) => Barcode.SavePgm(_type, _content, path, Options);
+        public string SavePgm(string path) => OutputWriter.Write(path, Render(OutputFormat.Pgm));
 
         /// <summary>
         /// Saves PGM to a stream.
         /// </summary>
-        public void SavePgm(Stream stream) => Barcode.SavePgm(_type, _content, stream, Options);
+        public void SavePgm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Pgm));
 
         /// <summary>
         /// Saves PAM to a file.
         /// </summary>
-        public string SavePam(string path) => Barcode.SavePam(_type, _content, path, Options);
+        public string SavePam(string path) => OutputWriter.Write(path, Render(OutputFormat.Pam));
 
         /// <summary>
         /// Saves PAM to a stream.
         /// </summary>
-        public void SavePam(Stream stream) => Barcode.SavePam(_type, _content, stream, Options);
+        public void SavePam(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Pam));
 
         /// <summary>
         /// Saves XBM to a file.
         /// </summary>
-        public string SaveXbm(string path) => Barcode.SaveXbm(_type, _content, path, Options);
+        public string SaveXbm(string path) => OutputWriter.Write(path, Render(OutputFormat.Xbm));
 
         /// <summary>
         /// Saves XBM to a stream.
         /// </summary>
-        public void SaveXbm(Stream stream) => Barcode.SaveXbm(_type, _content, stream, Options);
+        public void SaveXbm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Xbm));
 
         /// <summary>
         /// Saves XPM to a file.
         /// </summary>
-        public string SaveXpm(string path) => Barcode.SaveXpm(_type, _content, path, Options);
+        public string SaveXpm(string path) => OutputWriter.Write(path, Render(OutputFormat.Xpm));
 
         /// <summary>
         /// Saves XPM to a stream.
         /// </summary>
-        public void SaveXpm(Stream stream) => Barcode.SaveXpm(_type, _content, stream, Options);
+        public void SaveXpm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Xpm));
 
         /// <summary>
         /// Saves PPM to a file.
         /// </summary>
-        public string SavePpm(string path) => Barcode.SavePpm(_type, _content, path, Options);
+        public string SavePpm(string path) => OutputWriter.Write(path, Render(OutputFormat.Ppm));
 
         /// <summary>
         /// Saves PPM to a stream.
         /// </summary>
-        public void SavePpm(Stream stream) => Barcode.SavePpm(_type, _content, stream, Options);
+        public void SavePpm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Ppm));
 
         /// <summary>
         /// Saves PBM to a file.
         /// </summary>
-        public string SavePbm(string path) => Barcode.SavePbm(_type, _content, path, Options);
+        public string SavePbm(string path) => OutputWriter.Write(path, Render(OutputFormat.Pbm));
 
         /// <summary>
         /// Saves PBM to a stream.
         /// </summary>
-        public void SavePbm(Stream stream) => Barcode.SavePbm(_type, _content, stream, Options);
+        public void SavePbm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Pbm));
 
         /// <summary>
         /// Saves TGA to a file.
         /// </summary>
-        public string SaveTga(string path) => Barcode.SaveTga(_type, _content, path, Options);
+        public string SaveTga(string path) => OutputWriter.Write(path, Render(OutputFormat.Tga));
 
         /// <summary>
         /// Saves TGA to a stream.
         /// </summary>
-        public void SaveTga(Stream stream) => Barcode.SaveTga(_type, _content, stream, Options);
+        public void SaveTga(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Tga));
 
         /// <summary>
         /// Saves ICO to a file.
         /// </summary>
-        public string SaveIco(string path) => Barcode.SaveIco(_type, _content, path, Options);
+        public string SaveIco(string path) => OutputWriter.Write(path, Render(OutputFormat.Ico));
 
         /// <summary>
         /// Saves ICO to a stream.
         /// </summary>
-        public void SaveIco(Stream stream) => Barcode.SaveIco(_type, _content, stream, Options);
+        public void SaveIco(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Ico));
 
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
         /// <param name="path">Output file path.</param>
         /// <param name="mode">Vector or raster output.</param>
-        public string SavePdf(string path, RenderMode mode = RenderMode.Vector) => Barcode.SavePdf(_type, _content, path, Options, mode);
+        public string SavePdf(string path, RenderMode mode = RenderMode.Vector) {
+            return OutputWriter.Write(path, Render(OutputFormat.Pdf, new RenderExtras { VectorMode = mode }));
+        }
 
         /// <summary>
         /// Saves PDF to a stream.
         /// </summary>
         /// <param name="stream">Destination stream.</param>
         /// <param name="mode">Vector or raster output.</param>
-        public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) => Barcode.SavePdf(_type, _content, stream, Options, mode);
+        public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) {
+            OutputWriter.Write(stream, Render(OutputFormat.Pdf, new RenderExtras { VectorMode = mode }));
+        }
 
         /// <summary>
         /// Saves EPS to a file.
         /// </summary>
         /// <param name="path">Output file path.</param>
         /// <param name="mode">Vector or raster output.</param>
-        public string SaveEps(string path, RenderMode mode = RenderMode.Vector) => Barcode.SaveEps(_type, _content, path, Options, mode);
+        public string SaveEps(string path, RenderMode mode = RenderMode.Vector) {
+            return OutputWriter.Write(path, Render(OutputFormat.Eps, new RenderExtras { VectorMode = mode }));
+        }
 
         /// <summary>
         /// Saves EPS to a stream.
         /// </summary>
         /// <param name="stream">Destination stream.</param>
         /// <param name="mode">Vector or raster output.</param>
-        public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) => Barcode.SaveEps(_type, _content, stream, Options, mode);
+        public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) {
+            OutputWriter.Write(stream, Render(OutputFormat.Eps, new RenderExtras { VectorMode = mode }));
+        }
 
         /// <summary>
         /// Saves ASCII to a file.
         /// </summary>
-        public string SaveAscii(string path, BarcodeAsciiRenderOptions? options = null) => Barcode.SaveAscii(_type, _content, path, options);
+        public string SaveAscii(string path, BarcodeAsciiRenderOptions? options = null) {
+            return OutputWriter.Write(path, Render(OutputFormat.Ascii, new RenderExtras { BarcodeAscii = options }));
+        }
 
         /// <summary>
         /// Saves based on file extension (.png/.svg/.html/.jpg/.bmp/.ppm/.pbm/.tga/.ico/.pdf/.eps). Defaults to PNG when no extension is provided.

--- a/CodeGlyphX/Barcode.Render.cs
+++ b/CodeGlyphX/Barcode.Render.cs
@@ -1,0 +1,87 @@
+using System;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pam;
+using CodeGlyphX.Rendering.Pbm;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Pgm;
+using CodeGlyphX.Rendering.Ppm;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+using CodeGlyphX.Rendering.Svgz;
+using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
+using CodeGlyphX.Rendering.Xbm;
+using CodeGlyphX.Rendering.Xpm;
+
+namespace CodeGlyphX;
+
+public static partial class Barcode {
+    /// <summary>
+    /// Renders a barcode to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(BarcodeType type, string content, OutputFormat format, BarcodeOptions? options = null, RenderExtras? extras = null) {
+        var barcode = Encode(type, content);
+        return Render(barcode, format, options, extras);
+    }
+
+    /// <summary>
+    /// Renders a barcode to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(Barcode1D barcode, OutputFormat format, BarcodeOptions? options = null, RenderExtras? extras = null) {
+        if (barcode is null) throw new ArgumentNullException(nameof(barcode));
+        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
+
+        var opts = BuildPngOptions(options);
+        switch (format) {
+            case OutputFormat.Png:
+                return RenderedOutput.FromBinary(format, BarcodePngRenderer.Render(barcode, opts));
+            case OutputFormat.Svg:
+                return RenderedOutput.FromText(format, SvgBarcodeRenderer.Render(barcode, BuildSvgOptions(options)));
+            case OutputFormat.Svgz:
+                return RenderedOutput.FromBinary(format, BarcodeSvgzRenderer.Render(barcode, BuildSvgOptions(options)));
+            case OutputFormat.Html: {
+                var html = HtmlBarcodeRenderer.Render(barcode, BuildHtmlOptions(options));
+                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
+                    html = html.WrapHtml(extras.HtmlTitle);
+                }
+                return RenderedOutput.FromText(format, html);
+            }
+            case OutputFormat.Jpeg:
+                return RenderedOutput.FromBinary(format, BarcodeJpegRenderer.Render(barcode, opts, options?.JpegQuality ?? 90));
+            case OutputFormat.Webp:
+                return RenderedOutput.FromBinary(format, BarcodeWebpRenderer.Render(barcode, opts, options?.WebpQuality ?? 100));
+            case OutputFormat.Bmp:
+                return RenderedOutput.FromBinary(format, BarcodeBmpRenderer.Render(barcode, opts));
+            case OutputFormat.Ppm:
+                return RenderedOutput.FromBinary(format, BarcodePpmRenderer.Render(barcode, opts));
+            case OutputFormat.Pbm:
+                return RenderedOutput.FromBinary(format, BarcodePbmRenderer.Render(barcode, opts));
+            case OutputFormat.Pgm:
+                return RenderedOutput.FromBinary(format, BarcodePgmRenderer.Render(barcode, opts));
+            case OutputFormat.Pam:
+                return RenderedOutput.FromBinary(format, BarcodePamRenderer.Render(barcode, opts));
+            case OutputFormat.Xbm:
+                return RenderedOutput.FromText(format, BarcodeXbmRenderer.Render(barcode, opts));
+            case OutputFormat.Xpm:
+                return RenderedOutput.FromText(format, BarcodeXpmRenderer.Render(barcode, opts));
+            case OutputFormat.Tga:
+                return RenderedOutput.FromBinary(format, BarcodeTgaRenderer.Render(barcode, opts));
+            case OutputFormat.Ico:
+                return RenderedOutput.FromBinary(format, BarcodeIcoRenderer.Render(barcode, opts, BuildIcoOptions(options)));
+            case OutputFormat.Pdf:
+                return RenderedOutput.FromBinary(format, BarcodePdfRenderer.Render(barcode, opts, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Eps:
+                return RenderedOutput.FromText(format, BarcodeEpsRenderer.Render(barcode, opts, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Ascii:
+                return RenderedOutput.FromText(format, BarcodeAsciiRenderer.Render(barcode, extras?.BarcodeAscii));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
+        }
+    }
+}

--- a/CodeGlyphX/Barcode.Render.cs
+++ b/CodeGlyphX/Barcode.Render.cs
@@ -47,8 +47,9 @@ public static partial class Barcode {
                 return RenderedOutput.FromBinary(format, BarcodeSvgzRenderer.Render(barcode, BuildSvgOptions(options)));
             case OutputFormat.Html: {
                 var html = HtmlBarcodeRenderer.Render(barcode, BuildHtmlOptions(options));
-                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
-                    html = html.WrapHtml(extras.HtmlTitle);
+                var title = extras?.HtmlTitle;
+                if (!string.IsNullOrEmpty(title)) {
+                    html = html.WrapHtml(title);
                 }
                 return RenderedOutput.FromText(format, html);
             }

--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Threading;
-using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -346,30 +345,13 @@ public static partial class Barcode {
     }
 
     /// <summary>
-    /// Saves a barcode to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves a barcode to a file based on the file extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => SavePng(type, content, path, options),
-            Png = () => SavePng(type, content, path, options),
-            Webp = () => SaveWebp(type, content, path, options),
-            Svg = () => SaveSvg(type, content, path, options),
-            Svgz = () => SaveSvgz(type, content, path, options),
-            Html = () => SaveHtml(type, content, path, options, title),
-            Jpeg = () => SaveJpeg(type, content, path, options),
-            Bmp = () => SaveBmp(type, content, path, options),
-            Ppm = () => SavePpm(type, content, path, options),
-            Pbm = () => SavePbm(type, content, path, options),
-            Pgm = () => SavePgm(type, content, path, options),
-            Pam = () => SavePam(type, content, path, options),
-            Xbm = () => SaveXbm(type, content, path, options),
-            Xpm = () => SaveXpm(type, content, path, options),
-            Tga = () => SaveTga(type, content, path, options),
-            Ico = () => SaveIco(type, content, path, options),
-            Pdf = () => SavePdf(type, content, path, options),
-            Eps = () => SaveEps(type, content, path, options)
-        });
+    public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(type, content, format, options, extras);
+        return OutputWriter.Write(path, output);
     }
 
 

--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -383,6 +383,16 @@ public static partial class Barcode {
     /// Saves a barcode to a file based on the file extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return Save(type, content, path, options, extras);
+    }
+
+    /// <summary>
+    /// Saves a barcode to a file based on the file extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
     public static string Save(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderExtras? extras = null) {
         var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
         var output = Render(type, content, format, options, extras);

--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -27,6 +27,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PNG and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var png = Png(type, content, options);
         return png.WriteBinary(path);
@@ -35,6 +36,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PNG and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -44,6 +46,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as SVG and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var svg = Svg(type, content, options);
         return svg.WriteText(path);
@@ -52,6 +55,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as SVG and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var svg = Svg(type, content, options);
         svg.WriteText(stream);
@@ -60,6 +64,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as HTML and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
         var html = Html(type, content, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -71,6 +76,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as HTML and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, string? title = null) {
         var html = Html(type, content, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -82,6 +88,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as JPEG and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var jpeg = Jpeg(type, content, options);
         return jpeg.WriteBinary(path);
@@ -90,6 +97,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as JPEG and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -100,6 +108,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as WebP and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var webp = Webp(type, content, options);
         return webp.WriteBinary(path);
@@ -108,6 +117,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as WebP and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -118,6 +128,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as BMP and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var bmp = Bmp(type, content, options);
         return bmp.WriteBinary(path);
@@ -126,6 +137,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as BMP and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -135,6 +147,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PPM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var ppm = Ppm(type, content, options);
         return ppm.WriteBinary(path);
@@ -143,6 +156,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PPM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -152,6 +166,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PBM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var pbm = Pbm(type, content, options);
         return pbm.WriteBinary(path);
@@ -160,6 +175,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PBM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -169,6 +185,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PGM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var pgm = Pgm(type, content, options);
         return pgm.WriteBinary(path);
@@ -177,6 +194,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PGM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -186,6 +204,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PAM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var pam = Pam(type, content, options);
         return pam.WriteBinary(path);
@@ -194,6 +213,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PAM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -203,6 +223,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as XBM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var xbm = Xbm(type, content, options);
         return xbm.WriteText(path);
@@ -211,6 +232,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as XBM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var xbm = Xbm(type, content, options);
         xbm.WriteText(stream);
@@ -219,6 +241,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as XPM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var xpm = Xpm(type, content, options);
         return xpm.WriteText(path);
@@ -227,6 +250,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as XPM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var xpm = Xpm(type, content, options);
         xpm.WriteText(stream);
@@ -235,6 +259,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as TGA and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var tga = Tga(type, content, options);
         return tga.WriteBinary(path);
@@ -243,6 +268,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as TGA and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -252,6 +278,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as ICO and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var ico = Ico(type, content, options);
         return ico.WriteBinary(path);
@@ -260,6 +287,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as ICO and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -269,6 +297,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as SVGZ and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(BarcodeType type, string content, string path, BarcodeOptions? options = null) {
         var svgz = Svgz(type, content, options);
         return svgz.WriteBinary(path);
@@ -277,6 +306,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as SVGZ and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildSvgOptions(options);
@@ -291,6 +321,7 @@ public static partial class Barcode {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var pdf = Pdf(type, content, options, mode);
         return pdf.WriteBinary(path);
@@ -304,6 +335,7 @@ public static partial class Barcode {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -318,6 +350,7 @@ public static partial class Barcode {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = Eps(type, content, options, mode);
         return eps.WriteText(path);
@@ -331,6 +364,7 @@ public static partial class Barcode {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = Eps(type, content, options, mode);
         eps.WriteText(stream);
@@ -339,6 +373,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as ASCII text and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveAscii(BarcodeType type, string content, string path, BarcodeAsciiRenderOptions? options = null) {
         var ascii = Ascii(type, content, options);
         return ascii.WriteText(path);

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -27,7 +27,7 @@ namespace CodeGlyphX;
 /// Simple barcode helpers with fluent and static APIs.
 /// </summary>
 /// <remarks>
-/// Use <see cref="Save(CodeGlyphX.BarcodeType,string,string,CodeGlyphX.BarcodeOptions,string)"/> to pick the output format by file extension.
+/// Use <see cref="Save(CodeGlyphX.BarcodeType,string,string,CodeGlyphX.BarcodeOptions,CodeGlyphX.Rendering.RenderExtras)"/> to pick the output format by file extension.
 /// </remarks>
 /// <example>
 /// <code>

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -53,6 +53,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -62,6 +63,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildSvgOptions(options);
@@ -71,6 +73,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildHtmlOptions(options);
@@ -80,6 +83,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -90,6 +94,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -100,6 +105,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -109,6 +115,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -118,6 +125,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -127,6 +135,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -136,6 +145,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -145,6 +155,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -154,6 +165,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -163,6 +175,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -172,6 +185,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -181,6 +195,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildSvgOptions(options);
@@ -194,6 +209,7 @@ public static partial class Barcode {
     /// <param name="content">The barcode content.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -207,6 +223,7 @@ public static partial class Barcode {
     /// <param name="content">The barcode content.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
@@ -216,6 +233,7 @@ public static partial class Barcode {
     /// <summary>
     /// Renders a barcode as ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(BarcodeType type, string content, BarcodeAsciiRenderOptions? options = null) {
         var barcode = Encode(type, content);
         return BarcodeAsciiRenderer.Render(barcode, options);

--- a/CodeGlyphX/BarcodeEasy.cs
+++ b/CodeGlyphX/BarcodeEasy.cs
@@ -345,6 +345,8 @@ public static class BarcodeEasy {
     /// <summary>
     /// Saves a barcode to a file based on the output extension.
     /// </summary>
-    public static string RenderToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) =>
-        Barcode.Save(type, content, path, options, title);
+    public static string RenderToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return Barcode.Save(type, content, path, options, extras);
+    }
 }

--- a/CodeGlyphX/BarcodeEasy.cs
+++ b/CodeGlyphX/BarcodeEasy.cs
@@ -24,323 +24,389 @@ public static class BarcodeEasy {
         return BarcodeEncoder.Encode(type, content);
     }
 
+    private static RenderedOutput Render(BarcodeType type, string content, OutputFormat format, BarcodeOptions? options = null, RenderExtras? extras = null) {
+        return Barcode.Render(type, content, format, options, extras);
+    }
+
     /// <summary>
     /// Renders a barcode as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPng(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Png(type, content, options);
+        Render(type, content, OutputFormat.Png, options).Data;
 
     /// <summary>
     /// Renders a barcode as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvg(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Svg(type, content, options);
+        Render(type, content, OutputFormat.Svg, options).GetText();
 
     /// <summary>
     /// Renders a barcode as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderHtml(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Html(type, content, options);
+        Render(type, content, OutputFormat.Html, options).GetText();
 
     /// <summary>
     /// Renders a barcode as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderJpeg(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Jpeg(type, content, options);
+        Render(type, content, OutputFormat.Jpeg, options).Data;
 
     /// <summary>
     /// Renders a barcode as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderWebp(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Webp(type, content, options);
+        Render(type, content, OutputFormat.Webp, options).Data;
 
     /// <summary>
     /// Renders a barcode as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderBmp(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Bmp(type, content, options);
+        Render(type, content, OutputFormat.Bmp, options).Data;
 
     /// <summary>
     /// Renders a barcode as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPpm(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Ppm(type, content, options);
+        Render(type, content, OutputFormat.Ppm, options).Data;
 
     /// <summary>
     /// Renders a barcode as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPbm(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Pbm(type, content, options);
+        Render(type, content, OutputFormat.Pbm, options).Data;
 
     /// <summary>
     /// Renders a barcode as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPgm(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Pgm(type, content, options);
+        Render(type, content, OutputFormat.Pgm, options).Data;
 
     /// <summary>
     /// Renders a barcode as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPam(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Pam(type, content, options);
+        Render(type, content, OutputFormat.Pam, options).Data;
 
     /// <summary>
     /// Renders a barcode as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbm(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Xbm(type, content, options);
+        Render(type, content, OutputFormat.Xbm, options).GetText();
 
     /// <summary>
     /// Renders a barcode as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpm(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Xpm(type, content, options);
+        Render(type, content, OutputFormat.Xpm, options).GetText();
 
     /// <summary>
     /// Renders a barcode as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderTga(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Tga(type, content, options);
+        Render(type, content, OutputFormat.Tga, options).Data;
 
     /// <summary>
     /// Renders a barcode as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderIco(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Ico(type, content, options);
+        Render(type, content, OutputFormat.Ico, options).Data;
 
     /// <summary>
     /// Renders a barcode as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderSvgz(BarcodeType type, string content, BarcodeOptions? options = null) =>
-        Barcode.Svgz(type, content, options);
+        Render(type, content, OutputFormat.Svgz, options).Data;
 
     /// <summary>
     /// Renders a barcode as PDF.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPdf(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
-        Barcode.Pdf(type, content, options, mode);
+        Render(type, content, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }).Data;
 
     /// <summary>
     /// Renders a barcode as EPS.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderEps(BarcodeType type, string content, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
-        Barcode.Eps(type, content, options, mode);
+        Render(type, content, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }).GetText();
 
     /// <summary>
     /// Renders a barcode as ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderAscii(BarcodeType type, string content, BarcodeAsciiRenderOptions? options = null) =>
-        Barcode.Ascii(type, content, options);
+        Render(type, content, OutputFormat.Ascii, null, new RenderExtras { BarcodeAscii = options }).GetText();
 
     /// <summary>
     /// Renders a barcode as PNG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPngToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SavePng(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Png, options));
 
     /// <summary>
     /// Renders a barcode as SVG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderSvgToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveSvg(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Svg, options));
 
     /// <summary>
     /// Renders a barcode as HTML to a stream.
     /// </summary>
-    public static void RenderHtmlToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, string? title = null) =>
-        Barcode.SaveHtml(type, content, stream, options, title);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static void RenderHtmlToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, string? title = null) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Html, options, extras));
+    }
 
     /// <summary>
     /// Renders a barcode as JPEG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderJpegToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveJpeg(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Jpeg, options));
 
     /// <summary>
     /// Renders a barcode as WebP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderWebpToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveWebp(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Webp, options));
 
     /// <summary>
     /// Renders a barcode as BMP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderBmpToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveBmp(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Bmp, options));
 
     /// <summary>
     /// Renders a barcode as PPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPpmToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SavePpm(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Ppm, options));
 
     /// <summary>
     /// Renders a barcode as PBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPbmToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SavePbm(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Pbm, options));
 
     /// <summary>
     /// Renders a barcode as PGM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPgmToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SavePgm(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Pgm, options));
 
     /// <summary>
     /// Renders a barcode as PAM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPamToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SavePam(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Pam, options));
 
     /// <summary>
     /// Renders a barcode as XBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderXbmToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveXbm(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Xbm, options));
 
     /// <summary>
     /// Renders a barcode as XPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderXpmToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveXpm(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Xpm, options));
 
     /// <summary>
     /// Renders a barcode as TGA to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderTgaToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveTga(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Tga, options));
 
     /// <summary>
     /// Renders a barcode as ICO to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderIcoToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveIco(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Ico, options));
 
     /// <summary>
     /// Renders a barcode as SVGZ to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderSvgzToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) =>
-        Barcode.SaveSvgz(type, content, stream, options);
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Svgz, options));
 
     /// <summary>
     /// Renders a barcode as PDF to a stream.
     /// </summary>
-    public static void RenderPdfToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
-        Barcode.SavePdf(type, content, stream, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static void RenderPdfToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }));
+    }
 
     /// <summary>
     /// Renders a barcode as EPS to a stream.
     /// </summary>
-    public static void RenderEpsToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
-        Barcode.SaveEps(type, content, stream, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static void RenderEpsToStream(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        OutputWriter.Write(stream, Render(type, content, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }));
+    }
 
     /// <summary>
     /// Renders a barcode as PNG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPngToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SavePng(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Png, options));
 
     /// <summary>
     /// Renders a barcode as SVG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveSvg(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Svg, options));
 
     /// <summary>
     /// Renders a barcode as HTML to a file.
     /// </summary>
-    public static string RenderHtmlToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) =>
-        Barcode.SaveHtml(type, content, path, options, title);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string RenderHtmlToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, string? title = null) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return OutputWriter.Write(path, Render(type, content, OutputFormat.Html, options, extras));
+    }
 
     /// <summary>
     /// Renders a barcode as JPEG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderJpegToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveJpeg(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Jpeg, options));
 
     /// <summary>
     /// Renders a barcode as WebP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderWebpToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveWebp(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Webp, options));
 
     /// <summary>
     /// Renders a barcode as BMP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderBmpToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveBmp(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Bmp, options));
 
     /// <summary>
     /// Renders a barcode as PPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPpmToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SavePpm(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Ppm, options));
 
     /// <summary>
     /// Renders a barcode as PBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPbmToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SavePbm(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Pbm, options));
 
     /// <summary>
     /// Renders a barcode as PGM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPgmToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SavePgm(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Pgm, options));
 
     /// <summary>
     /// Renders a barcode as PAM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPamToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SavePam(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Pam, options));
 
     /// <summary>
     /// Renders a barcode as XBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbmToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveXbm(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Xbm, options));
 
     /// <summary>
     /// Renders a barcode as XPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpmToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveXpm(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Xpm, options));
 
     /// <summary>
     /// Renders a barcode as TGA to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderTgaToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveTga(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Tga, options));
 
     /// <summary>
     /// Renders a barcode as ICO to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderIcoToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveIco(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Ico, options));
 
     /// <summary>
     /// Renders a barcode as SVGZ to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgzToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null) =>
-        Barcode.SaveSvgz(type, content, path, options);
+        OutputWriter.Write(path, Render(type, content, OutputFormat.Svgz, options));
 
     /// <summary>
     /// Renders a barcode as PDF to a file.
     /// </summary>
-    public static string RenderPdfToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
-        Barcode.SavePdf(type, content, path, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string RenderPdfToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return OutputWriter.Write(path, Render(type, content, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }));
+    }
 
     /// <summary>
     /// Renders a barcode as EPS to a file.
     /// </summary>
-    public static string RenderEpsToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) =>
-        Barcode.SaveEps(type, content, path, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string RenderEpsToFile(BarcodeType type, string content, string path, BarcodeOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return OutputWriter.Write(path, Render(type, content, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }));
+    }
 
     /// <summary>
     /// Renders a barcode as ASCII text to a file.
     /// </summary>
-    public static string RenderAsciiToFile(BarcodeType type, string content, string path, BarcodeAsciiRenderOptions? options = null) =>
-        Barcode.SaveAscii(type, content, path, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string RenderAsciiToFile(BarcodeType type, string content, string path, BarcodeAsciiRenderOptions? options = null) {
+        return OutputWriter.Write(path, Render(type, content, OutputFormat.Ascii, null, new RenderExtras { BarcodeAscii = options }));
+    }
 
     /// <summary>
     /// Saves a barcode to a file based on the output extension.

--- a/CodeGlyphX/DataMatrixCode.Builder.cs
+++ b/CodeGlyphX/DataMatrixCode.Builder.cs
@@ -126,39 +126,45 @@ public static partial class DataMatrixCode {
             return _text is not null ? DataMatrixCode.Encode(_text, _mode) : DataMatrixCode.EncodeBytes(_bytes!, _mode);
         }
 
+        private RenderedOutput Render(OutputFormat format, RenderExtras? extras = null) {
+            return _text is not null
+                ? DataMatrixCode.Render(_text, format, _mode, _options, extras)
+                : DataMatrixCode.Render(_bytes!, format, _mode, _options, extras);
+        }
+
         /// <summary>
         /// Renders PNG bytes.
         /// </summary>
         public byte[] Png() {
-            return _text is not null ? DataMatrixCode.Png(_text, _mode, _options) : DataMatrixCode.Png(_bytes!, _mode, _options);
+            return Render(OutputFormat.Png).Data;
         }
 
         /// <summary>
         /// Renders SVG markup.
         /// </summary>
         public string Svg() {
-            return _text is not null ? DataMatrixCode.Svg(_text, _mode, _options) : DataMatrixCode.Svg(_bytes!, _mode, _options);
+            return Render(OutputFormat.Svg).GetText();
         }
 
         /// <summary>
         /// Renders HTML markup.
         /// </summary>
         public string Html() {
-            return _text is not null ? DataMatrixCode.Html(_text, _mode, _options) : DataMatrixCode.Html(_bytes!, _mode, _options);
+            return Render(OutputFormat.Html).GetText();
         }
 
         /// <summary>
         /// Renders JPEG bytes.
         /// </summary>
         public byte[] Jpeg() {
-            return _text is not null ? DataMatrixCode.Jpeg(_text, _mode, _options) : DataMatrixCode.Jpeg(_bytes!, _mode, _options);
+            return Render(OutputFormat.Jpeg).Data;
         }
 
         /// <summary>
         /// Renders BMP bytes.
         /// </summary>
         public byte[] Bmp() {
-            return _text is not null ? DataMatrixCode.Bmp(_text, _mode, _options) : DataMatrixCode.Bmp(_bytes!, _mode, _options);
+            return Render(OutputFormat.Bmp).Data;
         }
 
         /// <summary>
@@ -166,7 +172,7 @@ public static partial class DataMatrixCode {
         /// </summary>
         /// <param name="renderMode">Vector or raster output.</param>
         public byte[] Pdf(RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? DataMatrixCode.Pdf(_text, _mode, _options, renderMode) : DataMatrixCode.Pdf(_bytes!, _mode, _options, renderMode);
+            return Render(OutputFormat.Pdf, new RenderExtras { VectorMode = renderMode }).Data;
         }
 
         /// <summary>
@@ -174,14 +180,14 @@ public static partial class DataMatrixCode {
         /// </summary>
         /// <param name="renderMode">Vector or raster output.</param>
         public string Eps(RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? DataMatrixCode.Eps(_text, _mode, _options, renderMode) : DataMatrixCode.Eps(_bytes!, _mode, _options, renderMode);
+            return Render(OutputFormat.Eps, new RenderExtras { VectorMode = renderMode }).GetText();
         }
 
         /// <summary>
         /// Renders ASCII text.
         /// </summary>
         public string Ascii(MatrixAsciiRenderOptions? options = null) {
-            return _text is not null ? DataMatrixCode.Ascii(_text, _mode, options) : DataMatrixCode.Ascii(_bytes!, _mode, options);
+            return Render(OutputFormat.Ascii, new RenderExtras { MatrixAscii = options }).GetText();
         }
 
         /// <summary>
@@ -197,42 +203,43 @@ public static partial class DataMatrixCode {
         /// Saves PNG to a file.
         /// </summary>
         public string SavePng(string path) {
-            return _text is not null ? DataMatrixCode.SavePng(_text, path, _mode, _options) : DataMatrixCode.SavePng(_bytes!, path, _mode, _options);
+            return OutputWriter.Write(path, Render(OutputFormat.Png));
         }
 
         /// <summary>
         /// Saves SVG to a file.
         /// </summary>
         public string SaveSvg(string path) {
-            return _text is not null ? DataMatrixCode.SaveSvg(_text, path, _mode, _options) : DataMatrixCode.SaveSvg(_bytes!, path, _mode, _options);
+            return OutputWriter.Write(path, Render(OutputFormat.Svg));
         }
 
         /// <summary>
         /// Saves HTML to a file.
         /// </summary>
         public string SaveHtml(string path, string? title = null) {
-            return _text is not null ? DataMatrixCode.SaveHtml(_text, path, _mode, _options, title) : DataMatrixCode.SaveHtml(_bytes!, path, _mode, _options, title);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return OutputWriter.Write(path, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves JPEG to a file.
         /// </summary>
         public string SaveJpeg(string path) {
-            return _text is not null ? DataMatrixCode.SaveJpeg(_text, path, _mode, _options) : DataMatrixCode.SaveJpeg(_bytes!, path, _mode, _options);
+            return OutputWriter.Write(path, Render(OutputFormat.Jpeg));
         }
 
         /// <summary>
         /// Saves WebP to a file.
         /// </summary>
         public string SaveWebp(string path) {
-            return _text is not null ? DataMatrixCode.SaveWebp(_text, path, _mode, _options) : DataMatrixCode.SaveWebp(_bytes!, path, _mode, _options);
+            return OutputWriter.Write(path, Render(OutputFormat.Webp));
         }
 
         /// <summary>
         /// Saves BMP to a file.
         /// </summary>
         public string SaveBmp(string path) {
-            return _text is not null ? DataMatrixCode.SaveBmp(_text, path, _mode, _options) : DataMatrixCode.SaveBmp(_bytes!, path, _mode, _options);
+            return OutputWriter.Write(path, Render(OutputFormat.Bmp));
         }
 
         /// <summary>
@@ -241,7 +248,7 @@ public static partial class DataMatrixCode {
     /// <param name="path">Output file path.</param>
         /// <param name="renderMode">Vector or raster output.</param>
         public string SavePdf(string path, RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? DataMatrixCode.SavePdf(_text, path, _mode, _options, renderMode) : DataMatrixCode.SavePdf(_bytes!, path, _mode, _options, renderMode);
+            return OutputWriter.Write(path, Render(OutputFormat.Pdf, new RenderExtras { VectorMode = renderMode }));
         }
 
         /// <summary>
@@ -250,7 +257,7 @@ public static partial class DataMatrixCode {
     /// <param name="path">Output file path.</param>
         /// <param name="renderMode">Vector or raster output.</param>
         public string SaveEps(string path, RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? DataMatrixCode.SaveEps(_text, path, _mode, _options, renderMode) : DataMatrixCode.SaveEps(_bytes!, path, _mode, _options, renderMode);
+            return OutputWriter.Write(path, Render(OutputFormat.Eps, new RenderExtras { VectorMode = renderMode }));
         }
     }
 

--- a/CodeGlyphX/DataMatrixCode.Builder.cs
+++ b/CodeGlyphX/DataMatrixCode.Builder.cs
@@ -188,8 +188,9 @@ public static partial class DataMatrixCode {
         /// Saves output based on file extension.
         /// </summary>
         public string Save(string path, string? title = null) {
-            if (_text is not null) return DataMatrixCode.Save(_text, path, _mode, _options, title);
-            return DataMatrixCode.Save(_bytes!, path, _mode, _options, title);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            if (_text is not null) return DataMatrixCode.Save(_text, path, _mode, _options, extras);
+            return DataMatrixCode.Save(_bytes!, path, _mode, _options, extras);
         }
 
         /// <summary>

--- a/CodeGlyphX/DataMatrixCode.Render.cs
+++ b/CodeGlyphX/DataMatrixCode.Render.cs
@@ -1,0 +1,103 @@
+using System;
+using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pam;
+using CodeGlyphX.Rendering.Pbm;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Pgm;
+using CodeGlyphX.Rendering.Ppm;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+using CodeGlyphX.Rendering.Svgz;
+using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
+using CodeGlyphX.Rendering.Xbm;
+using CodeGlyphX.Rendering.Xpm;
+
+namespace CodeGlyphX;
+
+public static partial class DataMatrixCode {
+    /// <summary>
+    /// Renders a Data Matrix payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(string text, OutputFormat format, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var modules = Encode(text, mode);
+        return Render(modules, format, options, extras);
+    }
+
+    /// <summary>
+    /// Renders a Data Matrix byte payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(byte[] data, OutputFormat format, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var modules = EncodeBytes(data, mode);
+        return Render(modules, format, options, extras);
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Renders a Data Matrix byte payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(ReadOnlySpan<byte> data, OutputFormat format, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var modules = EncodeBytes(data, mode);
+        return Render(modules, format, options, extras);
+    }
+#endif
+
+    private static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? options, RenderExtras? extras) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
+
+        var pngOptions = BuildPngOptions(options);
+        switch (format) {
+            case OutputFormat.Png:
+                return RenderedOutput.FromBinary(format, MatrixPngRenderer.Render(modules, pngOptions));
+            case OutputFormat.Svg:
+                return RenderedOutput.FromText(format, MatrixSvgRenderer.Render(modules, BuildSvgOptions(options)));
+            case OutputFormat.Svgz:
+                return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, BuildSvgOptions(options)));
+            case OutputFormat.Html: {
+                var html = MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(options));
+                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
+                    html = html.WrapHtml(extras.HtmlTitle);
+                }
+                return RenderedOutput.FromText(format, html);
+            }
+            case OutputFormat.Jpeg:
+                return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85));
+            case OutputFormat.Webp:
+                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, options?.WebpQuality ?? 100));
+            case OutputFormat.Bmp:
+                return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
+            case OutputFormat.Ppm:
+                return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pbm:
+                return RenderedOutput.FromBinary(format, MatrixPbmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pgm:
+                return RenderedOutput.FromBinary(format, MatrixPgmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pam:
+                return RenderedOutput.FromBinary(format, MatrixPamRenderer.Render(modules, pngOptions));
+            case OutputFormat.Xbm:
+                return RenderedOutput.FromText(format, MatrixXbmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Xpm:
+                return RenderedOutput.FromText(format, MatrixXpmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Tga:
+                return RenderedOutput.FromBinary(format, MatrixTgaRenderer.Render(modules, pngOptions));
+            case OutputFormat.Ico:
+                return RenderedOutput.FromBinary(format, MatrixIcoRenderer.Render(modules, pngOptions, BuildIcoOptions(options)));
+            case OutputFormat.Pdf:
+                return RenderedOutput.FromBinary(format, MatrixPdfRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Eps:
+                return RenderedOutput.FromText(format, MatrixEpsRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Ascii:
+                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(modules, extras?.MatrixAscii ?? new MatrixAsciiRenderOptions()));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
+        }
+    }
+}

--- a/CodeGlyphX/DataMatrixCode.Render.cs
+++ b/CodeGlyphX/DataMatrixCode.Render.cs
@@ -63,8 +63,9 @@ public static partial class DataMatrixCode {
                 return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, BuildSvgOptions(options)));
             case OutputFormat.Html: {
                 var html = MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(options));
-                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
-                    html = html.WrapHtml(extras.HtmlTitle);
+                var title = extras?.HtmlTitle;
+                if (!string.IsNullOrEmpty(title)) {
+                    html = html.WrapHtml(title);
                 }
                 return RenderedOutput.FromText(format, html);
             }

--- a/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
@@ -29,6 +29,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PNG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var png = Png(data, mode, options);
         return png.WriteBinary(path);
@@ -37,6 +38,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PNG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPngRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -45,6 +47,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svg = Svg(data, mode, options);
         return svg.WriteText(path);
@@ -53,6 +56,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svg = Svg(data, mode, options);
         svg.WriteText(stream);
@@ -61,6 +65,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix HTML to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
         var html = Html(data, mode, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -72,6 +77,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix HTML to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
         var html = Html(data, mode, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -83,6 +89,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix JPEG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var jpeg = Jpeg(data, mode, options);
         return jpeg.WriteBinary(path);
@@ -91,6 +98,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix WebP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var webp = Webp(data, mode, options);
         return webp.WriteBinary(path);
@@ -99,6 +107,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix BMP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var bmp = Bmp(data, mode, options);
         return bmp.WriteBinary(path);
@@ -107,6 +116,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var ppm = Ppm(data, mode, options);
         return ppm.WriteBinary(path);
@@ -115,6 +125,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pbm = Pbm(data, mode, options);
         return pbm.WriteBinary(path);
@@ -123,6 +134,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PGM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pgm = Pgm(data, mode, options);
         return pgm.WriteBinary(path);
@@ -131,6 +143,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PAM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pam = Pam(data, mode, options);
         return pam.WriteBinary(path);
@@ -139,6 +152,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var xbm = Xbm(data, mode, options);
         return xbm.WriteText(path);
@@ -147,6 +161,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var xpm = Xpm(data, mode, options);
         return xpm.WriteText(path);
@@ -155,6 +170,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix TGA to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var tga = Tga(data, mode, options);
         return tga.WriteBinary(path);
@@ -163,6 +179,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix ICO to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var ico = Ico(data, mode, options);
         return ico.WriteBinary(path);
@@ -171,6 +188,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVGZ to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svgz = Svgz(data, mode, options);
         return svgz.WriteBinary(path);
@@ -184,6 +202,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, mode, options, renderMode);
         return pdf.WriteBinary(path);
@@ -197,6 +216,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, mode, options, renderMode);
         return eps.WriteText(path);
@@ -205,6 +225,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix JPEG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -215,6 +236,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix WebP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -225,6 +247,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix BMP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -233,6 +256,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPpmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -241,6 +265,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPbmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -249,6 +274,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PGM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPgmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -257,6 +283,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PAM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPamRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -265,6 +292,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixXbmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -273,6 +301,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixXpmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -281,6 +310,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix TGA to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixTgaRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -289,6 +319,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix ICO to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixIcoRenderer.RenderToStream(modules, BuildPngOptions(options), stream, BuildIcoOptions(options));
@@ -297,6 +328,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVGZ to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixSvgzRenderer.RenderToStream(modules, BuildSvgOptions(options), stream);
@@ -310,6 +342,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -323,6 +356,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);

--- a/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using CodeGlyphX.DataMatrix;
-using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -330,30 +329,13 @@ public static partial class DataMatrixCode {
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Data Matrix to a file for byte payloads based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
-        return SaveByExtensionHelper.Save(data, path, new SaveByExtensionSpanHandlers {
-            Default = d => SavePng(d, path, mode, options),
-            Png = d => SavePng(d, path, mode, options),
-            Webp = d => SaveWebp(d, path, mode, options),
-            Svg = d => SaveSvg(d, path, mode, options),
-            Svgz = d => SaveSvgz(d, path, mode, options),
-            Html = d => SaveHtml(d, path, mode, options, title),
-            Jpeg = d => SaveJpeg(d, path, mode, options),
-            Bmp = d => SaveBmp(d, path, mode, options),
-            Ppm = d => SavePpm(d, path, mode, options),
-            Pbm = d => SavePbm(d, path, mode, options),
-            Pgm = d => SavePgm(d, path, mode, options),
-            Pam = d => SavePam(d, path, mode, options),
-            Xbm = d => SaveXbm(d, path, mode, options),
-            Xpm = d => SaveXpm(d, path, mode, options),
-            Tga = d => SaveTga(d, path, mode, options),
-            Ico = d => SaveIco(d, path, mode, options),
-            Pdf = d => SavePdf(d, path, mode, options),
-            Eps = d => SaveEps(d, path, mode, options)
-        });
+    public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, mode, options, extras);
+        return OutputWriter.Write(path, output);
     }
 
 }

--- a/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
@@ -366,6 +366,18 @@ public static partial class DataMatrixCode {
     /// Saves Data Matrix to a file for byte payloads based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode, MatrixOptions? options, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, mode, options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file for byte payloads based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
         var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
         var output = Render(data, format, mode, options, extras);

--- a/CodeGlyphX/DataMatrixCode.Save.Text.ByExtension.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.ByExtension.cs
@@ -10,9 +10,34 @@ public static partial class DataMatrixCode {
     /// Saves Data Matrix to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(string text, string path, DataMatrixEncodingMode mode, MatrixOptions? options, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(text, format, mode, options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
     public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
         var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
         var output = Render(text, format, mode, options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves Data Matrix to a file for byte payloads based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(byte[] data, string path, DataMatrixEncodingMode mode, MatrixOptions? options, string? title) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, mode, options, extras);
         return OutputWriter.Write(path, output);
     }
 

--- a/CodeGlyphX/DataMatrixCode.Save.Text.ByExtension.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.ByExtension.cs
@@ -1,63 +1,30 @@
 using System;
 using System.IO;
 using CodeGlyphX.DataMatrix;
-using CodeGlyphX.Internal;
+using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX;
 
 public static partial class DataMatrixCode {
     /// <summary>
-    /// Saves Data Matrix to a file based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves Data Matrix to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => SavePng(text, path, mode, options),
-            Png = () => SavePng(text, path, mode, options),
-            Webp = () => SaveWebp(text, path, mode, options),
-            Svg = () => SaveSvg(text, path, mode, options),
-            Svgz = () => SaveSvgz(text, path, mode, options),
-            Html = () => SaveHtml(text, path, mode, options, title),
-            Jpeg = () => SaveJpeg(text, path, mode, options),
-            Bmp = () => SaveBmp(text, path, mode, options),
-            Ppm = () => SavePpm(text, path, mode, options),
-            Pbm = () => SavePbm(text, path, mode, options),
-            Pgm = () => SavePgm(text, path, mode, options),
-            Pam = () => SavePam(text, path, mode, options),
-            Xbm = () => SaveXbm(text, path, mode, options),
-            Xpm = () => SaveXpm(text, path, mode, options),
-            Tga = () => SaveTga(text, path, mode, options),
-            Ico = () => SaveIco(text, path, mode, options),
-            Pdf = () => SavePdf(text, path, mode, options),
-            Eps = () => SaveEps(text, path, mode, options)
-        });
+    public static string Save(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(text, format, mode, options, extras);
+        return OutputWriter.Write(path, output);
     }
 
     /// <summary>
-    /// Saves Data Matrix to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves Data Matrix to a file for byte payloads based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => SavePng(data, path, mode, options),
-            Png = () => SavePng(data, path, mode, options),
-            Webp = () => SaveWebp(data, path, mode, options),
-            Svg = () => SaveSvg(data, path, mode, options),
-            Svgz = () => SaveSvgz(data, path, mode, options),
-            Html = () => SaveHtml(data, path, mode, options, title),
-            Jpeg = () => SaveJpeg(data, path, mode, options),
-            Bmp = () => SaveBmp(data, path, mode, options),
-            Ppm = () => SavePpm(data, path, mode, options),
-            Pbm = () => SavePbm(data, path, mode, options),
-            Pgm = () => SavePgm(data, path, mode, options),
-            Pam = () => SavePam(data, path, mode, options),
-            Xbm = () => SaveXbm(data, path, mode, options),
-            Xpm = () => SaveXpm(data, path, mode, options),
-            Tga = () => SaveTga(data, path, mode, options),
-            Ico = () => SaveIco(data, path, mode, options),
-            Pdf = () => SavePdf(data, path, mode, options),
-            Eps = () => SaveEps(data, path, mode, options)
-        });
+    public static string Save(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderExtras? extras = null) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, mode, options, extras);
+        return OutputWriter.Write(path, output);
     }
 
 }

--- a/CodeGlyphX/DataMatrixCode.Save.Text.File.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.File.cs
@@ -27,6 +27,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PNG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var png = Png(text, mode, options);
         return png.WriteBinary(path);
@@ -35,6 +36,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PNG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var png = Png(data, mode, options);
         return png.WriteBinary(path);
@@ -43,6 +45,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svg = Svg(text, mode, options);
         return svg.WriteText(path);
@@ -51,6 +54,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVGZ to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svgz = Svgz(text, mode, options);
         return svgz.WriteBinary(path);
@@ -59,6 +63,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svg = Svg(data, mode, options);
         return svg.WriteText(path);
@@ -67,6 +72,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVGZ to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svgz = Svgz(data, mode, options);
         return svgz.WriteBinary(path);
@@ -74,6 +80,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix HTML to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
         var html = Html(text, mode, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -85,6 +92,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix HTML to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
         var html = Html(data, mode, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -95,6 +103,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix JPEG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var jpeg = Jpeg(text, mode, options);
         return jpeg.WriteBinary(path);
@@ -103,6 +112,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix WebP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var webp = Webp(text, mode, options);
         return webp.WriteBinary(path);
@@ -111,6 +121,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix BMP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var bmp = Bmp(text, mode, options);
         return bmp.WriteBinary(path);
@@ -119,6 +130,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PPM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var ppm = Ppm(text, mode, options);
         return ppm.WriteBinary(path);
@@ -127,6 +139,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PBM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pbm = Pbm(text, mode, options);
         return pbm.WriteBinary(path);
@@ -135,6 +148,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PGM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pgm = Pgm(text, mode, options);
         return pgm.WriteBinary(path);
@@ -143,6 +157,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PAM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pam = Pam(text, mode, options);
         return pam.WriteBinary(path);
@@ -151,6 +166,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XBM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var xbm = Xbm(text, mode, options);
         return xbm.WriteText(path);
@@ -159,6 +175,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XPM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var xpm = Xpm(text, mode, options);
         return xpm.WriteText(path);
@@ -167,6 +184,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix TGA to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var tga = Tga(text, mode, options);
         return tga.WriteBinary(path);
@@ -175,6 +193,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix ICO to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var ico = Ico(text, mode, options);
         return ico.WriteBinary(path);
@@ -188,6 +207,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(text, mode, options, renderMode);
         return pdf.WriteBinary(path);
@@ -201,6 +221,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(string text, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(text, mode, options, renderMode);
         return eps.WriteText(path);
@@ -208,6 +229,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix ICO to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var ico = Ico(data, mode, options);
         return ico.WriteBinary(path);
@@ -221,6 +243,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, mode, options, renderMode);
         return pdf.WriteBinary(path);
@@ -234,6 +257,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, mode, options, renderMode);
         return eps.WriteText(path);
@@ -241,6 +265,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix JPEG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var jpeg = Jpeg(data, mode, options);
         return jpeg.WriteBinary(path);
@@ -249,6 +274,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix WebP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var webp = Webp(data, mode, options);
         return webp.WriteBinary(path);
@@ -257,6 +283,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix BMP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var bmp = Bmp(data, mode, options);
         return bmp.WriteBinary(path);
@@ -265,6 +292,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var ppm = Ppm(data, mode, options);
         return ppm.WriteBinary(path);
@@ -273,6 +301,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pbm = Pbm(data, mode, options);
         return pbm.WriteBinary(path);
@@ -281,6 +310,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PGM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pgm = Pgm(data, mode, options);
         return pgm.WriteBinary(path);
@@ -289,6 +319,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PAM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var pam = Pam(data, mode, options);
         return pam.WriteBinary(path);
@@ -297,6 +328,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var xbm = Xbm(data, mode, options);
         return xbm.WriteText(path);
@@ -305,6 +337,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var xpm = Xpm(data, mode, options);
         return xpm.WriteText(path);
@@ -313,6 +346,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix TGA to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(byte[] data, string path, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var tga = Tga(data, mode, options);
         return tga.WriteBinary(path);

--- a/CodeGlyphX/DataMatrixCode.Save.Text.Stream.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.Stream.cs
@@ -28,6 +28,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PNG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixPngRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -36,6 +37,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PNG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPngRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -43,6 +45,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svg = Svg(text, mode, options);
         svg.WriteText(stream);
@@ -51,6 +54,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVGZ to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixSvgzRenderer.RenderToStream(modules, BuildSvgOptions(options), stream);
@@ -59,6 +63,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var svg = Svg(data, mode, options);
         svg.WriteText(stream);
@@ -67,6 +72,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix SVGZ to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixSvgzRenderer.RenderToStream(modules, BuildSvgOptions(options), stream);
@@ -74,6 +80,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix HTML to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
         var html = Html(text, mode, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -85,6 +92,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix HTML to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, string? title = null) {
         var html = Html(data, mode, options);
         if (!string.IsNullOrEmpty(title)) {
@@ -95,6 +103,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix JPEG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         var opts = BuildPngOptions(options);
@@ -105,6 +114,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix WebP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         var opts = BuildPngOptions(options);
@@ -115,6 +125,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix BMP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -123,6 +134,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixPpmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -131,6 +143,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixPbmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -139,6 +152,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PGM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixPgmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -147,6 +161,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PAM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixPamRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -155,6 +170,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixXbmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -163,6 +179,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixXpmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -171,6 +188,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix TGA to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixTgaRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -179,6 +197,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix ICO to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         MatrixIcoRenderer.RenderToStream(modules, BuildPngOptions(options), stream, BuildIcoOptions(options));
@@ -192,6 +211,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -205,6 +225,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -213,6 +234,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix JPEG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -223,6 +245,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix WebP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -233,6 +256,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix BMP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -241,6 +265,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPpmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -249,6 +274,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPbmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -257,6 +283,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PGM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPgmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -265,6 +292,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix PAM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixPamRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -273,6 +301,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixXbmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -281,6 +310,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix XPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixXpmRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -289,6 +319,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix TGA to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixTgaRenderer.RenderToStream(modules, BuildPngOptions(options), stream);
@@ -297,6 +328,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Saves Data Matrix ICO to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         MatrixIcoRenderer.RenderToStream(modules, BuildPngOptions(options), stream, BuildIcoOptions(options));
@@ -310,6 +342,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);
@@ -323,6 +356,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(options), stream, renderMode);

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -73,6 +73,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PNG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(options));
@@ -81,6 +82,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as SVG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(options));
@@ -89,6 +91,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as SVGZ from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(options));
@@ -97,6 +100,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as HTML from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(options));
@@ -105,6 +109,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as JPEG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -115,6 +120,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as WebP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -125,6 +131,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as BMP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
@@ -133,6 +140,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PPM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(options));
@@ -141,6 +149,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PBM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(options));
@@ -149,6 +158,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PGM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(options));
@@ -157,6 +167,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PAM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(options));
@@ -165,6 +176,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as XBM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(options));
@@ -173,6 +185,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as XPM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(options));
@@ -181,6 +194,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as TGA from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(options));
@@ -189,6 +203,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as ICO from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(options), BuildIcoOptions(options));
@@ -201,6 +216,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -213,6 +229,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -221,6 +238,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as ASCII from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixAsciiRenderer.Render(modules, options);
@@ -231,6 +249,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(options));
@@ -239,6 +258,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PNG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(options));
@@ -247,6 +267,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(options));
@@ -255,6 +276,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(options));
@@ -263,6 +285,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as SVG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(options));
@@ -271,6 +294,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as SVGZ from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(options));
@@ -279,6 +303,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(options));
@@ -287,6 +312,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as HTML from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(options));
@@ -295,6 +321,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         var opts = BuildPngOptions(options);
@@ -305,6 +332,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         var opts = BuildPngOptions(options);
@@ -315,6 +343,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
@@ -323,6 +352,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(options));
@@ -331,6 +361,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(options));
@@ -339,6 +370,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(options));
@@ -347,6 +379,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(options));
@@ -355,6 +388,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(options));
@@ -363,6 +397,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(options));
@@ -371,6 +406,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(options));
@@ -379,6 +415,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(options), BuildIcoOptions(options));
@@ -391,6 +428,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -403,6 +441,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, mode);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -411,6 +450,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as ASCII.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
         var modules = Encode(text, mode);
         return MatrixAsciiRenderer.Render(modules, options);
@@ -419,6 +459,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as JPEG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -429,6 +470,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as WebP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
@@ -439,6 +481,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as BMP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(options));
@@ -447,6 +490,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(options));
@@ -455,6 +499,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(options));
@@ -463,6 +508,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(options));
@@ -471,6 +517,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(options));
@@ -479,6 +526,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(options));
@@ -487,6 +535,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(options));
@@ -495,6 +544,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(options));
@@ -503,6 +553,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(options), BuildIcoOptions(options));
@@ -515,6 +566,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -527,6 +579,7 @@ public static partial class DataMatrixCode {
     /// <param name="mode">Vector or raster output.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, mode);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(options), renderMode);
@@ -535,6 +588,7 @@ public static partial class DataMatrixCode {
     /// <summary>
     /// Renders Data Matrix as ASCII from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixAsciiRenderOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         return MatrixAsciiRenderer.Render(modules, options);

--- a/CodeGlyphX/Internal/ObsoleteMessages.cs
+++ b/CodeGlyphX/Internal/ObsoleteMessages.cs
@@ -1,0 +1,7 @@
+namespace CodeGlyphX.Internal;
+
+internal static class ObsoleteMessages {
+    internal const string RenderFormatHelpers =
+        "Use Render(..., OutputFormat) with RenderedOutput/OutputWriter (and RenderExtras for HTML/PDF/EPS). " +
+        "Legacy per-format helpers will be removed in a future release.";
+}

--- a/CodeGlyphX/Otp.cs
+++ b/CodeGlyphX/Otp.cs
@@ -38,12 +38,16 @@ public static class Otp {
         return OtpAuthHotp.Create(issuer, account, secret, counter, alg, digits);
     }
 
+    private static RenderedOutput RenderUri(string uri, OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        return QrCode.Render(uri, format, options, extras);
+    }
+
     /// <summary>
     /// Renders a TOTP QR as PNG from a Base32 secret.
     /// </summary>
     public static byte[] TotpPng(string issuer, string account, string secretBase32, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
-        return QrEasy.RenderPng(uri, options);
+        return RenderUri(uri, OutputFormat.Png, options).Data;
     }
 
     /// <summary>
@@ -51,7 +55,7 @@ public static class Otp {
     /// </summary>
     public static string TotpSvg(string issuer, string account, string secretBase32, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
-        return QrEasy.RenderSvg(uri, options);
+        return RenderUri(uri, OutputFormat.Svg, options).GetText();
     }
 
     /// <summary>
@@ -59,7 +63,7 @@ public static class Otp {
     /// </summary>
     public static string TotpHtml(string issuer, string account, string secretBase32, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
-        return QrEasy.RenderHtml(uri, options);
+        return RenderUri(uri, OutputFormat.Html, options).GetText();
     }
 
     /// <summary>
@@ -67,7 +71,7 @@ public static class Otp {
     /// </summary>
     public static byte[] TotpJpeg(string issuer, string account, string secretBase32, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
-        return QrEasy.RenderJpeg(uri, options);
+        return RenderUri(uri, OutputFormat.Jpeg, options).Data;
     }
 
     /// <summary>
@@ -75,7 +79,7 @@ public static class Otp {
     /// </summary>
     public static byte[] TotpWebp(string issuer, string account, string secretBase32, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
-        return QrEasy.RenderWebp(uri, options);
+        return RenderUri(uri, OutputFormat.Webp, options).Data;
     }
 
     /// <summary>
@@ -83,7 +87,7 @@ public static class Otp {
     /// </summary>
     public static byte[] HotpPng(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
-        return QrEasy.RenderPng(uri, options);
+        return RenderUri(uri, OutputFormat.Png, options).Data;
     }
 
     /// <summary>
@@ -91,7 +95,7 @@ public static class Otp {
     /// </summary>
     public static string HotpSvg(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
-        return QrEasy.RenderSvg(uri, options);
+        return RenderUri(uri, OutputFormat.Svg, options).GetText();
     }
 
     /// <summary>
@@ -99,7 +103,7 @@ public static class Otp {
     /// </summary>
     public static string HotpHtml(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
-        return QrEasy.RenderHtml(uri, options);
+        return RenderUri(uri, OutputFormat.Html, options).GetText();
     }
 
     /// <summary>
@@ -107,7 +111,7 @@ public static class Otp {
     /// </summary>
     public static byte[] HotpJpeg(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
-        return QrEasy.RenderJpeg(uri, options);
+        return RenderUri(uri, OutputFormat.Jpeg, options).Data;
     }
 
     /// <summary>
@@ -115,155 +119,171 @@ public static class Otp {
     /// </summary>
     public static byte[] HotpWebp(string issuer, string account, string secretBase32, long counter, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
-        return QrEasy.RenderWebp(uri, options);
+        return RenderUri(uri, OutputFormat.Webp, options).Data;
     }
 
     /// <summary>
     /// Saves a TOTP PNG to a file.
     /// </summary>
     public static string SaveTotpPng(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        return TotpPng(issuer, account, secretBase32, options, alg, digits, period).WriteBinary(path);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a TOTP PNG to a stream.
     /// </summary>
     public static void SaveTotpPng(string issuer, string account, string secretBase32, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        QR.SavePng(TotpUri(issuer, account, secretBase32, alg, digits, period), stream, options);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a TOTP SVG to a file.
     /// </summary>
     public static string SaveTotpSvg(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        return TotpSvg(issuer, account, secretBase32, options, alg, digits, period).WriteText(path);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves a TOTP SVG to a stream.
     /// </summary>
     public static void SaveTotpSvg(string issuer, string account, string secretBase32, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        TotpSvg(issuer, account, secretBase32, options, alg, digits, period).WriteText(stream);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves a TOTP HTML to a file.
     /// </summary>
     public static string SaveTotpHtml(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30, string? title = null) {
-        var html = TotpHtml(issuer, account, secretBase32, options, alg, digits, period);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        return html.WriteText(path);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves a TOTP HTML to a stream.
     /// </summary>
     public static void SaveTotpHtml(string issuer, string account, string secretBase32, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30, string? title = null) {
-        var html = TotpHtml(issuer, account, secretBase32, options, alg, digits, period);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        html.WriteText(stream);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves a TOTP JPEG to a file.
     /// </summary>
     public static string SaveTotpJpeg(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        return TotpJpeg(issuer, account, secretBase32, options, alg, digits, period).WriteBinary(path);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a TOTP JPEG to a stream.
     /// </summary>
     public static void SaveTotpJpeg(string issuer, string account, string secretBase32, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        QR.SaveJpeg(TotpUri(issuer, account, secretBase32, alg, digits, period), stream, options);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a TOTP WebP to a file.
     /// </summary>
     public static string SaveTotpWebp(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        return TotpWebp(issuer, account, secretBase32, options, alg, digits, period).WriteBinary(path);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a TOTP WebP to a stream.
     /// </summary>
     public static void SaveTotpWebp(string issuer, string account, string secretBase32, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30) {
-        QR.SaveWebp(TotpUri(issuer, account, secretBase32, alg, digits, period), stream, options);
+        var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a HOTP PNG to a file.
     /// </summary>
     public static string SaveHotpPng(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        return HotpPng(issuer, account, secretBase32, counter, options, alg, digits).WriteBinary(path);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a HOTP PNG to a stream.
     /// </summary>
     public static void SaveHotpPng(string issuer, string account, string secretBase32, long counter, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        QR.SavePng(HotpUri(issuer, account, secretBase32, counter, alg, digits), stream, options);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a HOTP SVG to a file.
     /// </summary>
     public static string SaveHotpSvg(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        return HotpSvg(issuer, account, secretBase32, counter, options, alg, digits).WriteText(path);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves a HOTP SVG to a stream.
     /// </summary>
     public static void SaveHotpSvg(string issuer, string account, string secretBase32, long counter, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        HotpSvg(issuer, account, secretBase32, counter, options, alg, digits).WriteText(stream);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves a HOTP HTML to a file.
     /// </summary>
     public static string SaveHotpHtml(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, string? title = null) {
-        var html = HotpHtml(issuer, account, secretBase32, counter, options, alg, digits);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        return html.WriteText(path);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves a HOTP HTML to a stream.
     /// </summary>
     public static void SaveHotpHtml(string issuer, string account, string secretBase32, long counter, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, string? title = null) {
-        var html = HotpHtml(issuer, account, secretBase32, counter, options, alg, digits);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        html.WriteText(stream);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves a HOTP JPEG to a file.
     /// </summary>
     public static string SaveHotpJpeg(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        return HotpJpeg(issuer, account, secretBase32, counter, options, alg, digits).WriteBinary(path);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a HOTP JPEG to a stream.
     /// </summary>
     public static void SaveHotpJpeg(string issuer, string account, string secretBase32, long counter, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        QR.SaveJpeg(HotpUri(issuer, account, secretBase32, counter, alg, digits), stream, options);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a HOTP WebP to a file.
     /// </summary>
     public static string SaveHotpWebp(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        return HotpWebp(issuer, account, secretBase32, counter, options, alg, digits).WriteBinary(path);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        return OutputWriter.Write(path, RenderUri(uri, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a HOTP WebP to a stream.
     /// </summary>
     public static void SaveHotpWebp(string issuer, string account, string secretBase32, long counter, Stream stream, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6) {
-        QR.SaveWebp(HotpUri(issuer, account, secretBase32, counter, alg, digits), stream, options);
+        var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
+        OutputWriter.Write(stream, RenderUri(uri, OutputFormat.Webp, options));
     }
 
     /// <summary>
@@ -273,7 +293,8 @@ public static class Otp {
     public static string SaveTotp(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30, string? title = null) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
         var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
-        return QR.Save(uri, path, options, extras);
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        return OutputWriter.Write(path, RenderUri(uri, format, options, extras));
     }
 
     /// <summary>
@@ -283,7 +304,8 @@ public static class Otp {
     public static string SaveHotp(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, string? title = null) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
         var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
-        return QR.Save(uri, path, options, extras);
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        return OutputWriter.Write(path, RenderUri(uri, format, options, extras));
     }
 
     /// <summary>
@@ -364,95 +386,98 @@ public static class Otp {
         /// </summary>
         public QrCode Encode() => QrEasy.Encode(Uri(), Options);
 
+        private RenderedOutput Render(OutputFormat format, RenderExtras? extras = null) {
+            return RenderUri(Uri(), format, Options, extras);
+        }
+
         /// <summary>
         /// Renders PNG bytes.
         /// </summary>
-        public byte[] Png() => QrEasy.RenderPng(Uri(), Options);
+        public byte[] Png() => Render(OutputFormat.Png).Data;
 
         /// <summary>
         /// Renders SVG text.
         /// </summary>
-        public string Svg() => QrEasy.RenderSvg(Uri(), Options);
+        public string Svg() => Render(OutputFormat.Svg).GetText();
 
         /// <summary>
         /// Renders HTML text.
         /// </summary>
-        public string Html() => QrEasy.RenderHtml(Uri(), Options);
+        public string Html() => Render(OutputFormat.Html).GetText();
 
         /// <summary>
         /// Renders JPEG bytes.
         /// </summary>
-        public byte[] Jpeg() => QrEasy.RenderJpeg(Uri(), Options);
+        public byte[] Jpeg() => Render(OutputFormat.Jpeg).Data;
 
         /// <summary>
         /// Renders WebP bytes.
         /// </summary>
-        public byte[] Webp() => QrEasy.RenderWebp(Uri(), Options);
+        public byte[] Webp() => Render(OutputFormat.Webp).Data;
 
         /// <summary>
         /// Saves PNG to a file.
         /// </summary>
-        public string SavePng(string path) => Png().WriteBinary(path);
+        public string SavePng(string path) => OutputWriter.Write(path, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves PNG to a stream.
         /// </summary>
-        public void SavePng(Stream stream) => QR.SavePng(Uri(), stream, Options);
+        public void SavePng(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves SVG to a file.
         /// </summary>
-        public string SaveSvg(string path) => Svg().WriteText(path);
+        public string SaveSvg(string path) => OutputWriter.Write(path, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves SVG to a stream.
         /// </summary>
-        public void SaveSvg(Stream stream) => Svg().WriteText(stream);
+        public void SaveSvg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves HTML to a file.
         /// </summary>
         public string SaveHtml(string path, string? title = null) {
-            var html = Html();
-            if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-            return html.WriteText(path);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return OutputWriter.Write(path, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves HTML to a stream.
         /// </summary>
         public void SaveHtml(Stream stream, string? title = null) {
-            var html = Html();
-            if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-            html.WriteText(stream);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            OutputWriter.Write(stream, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves JPEG to a file.
         /// </summary>
-        public string SaveJpeg(string path) => Jpeg().WriteBinary(path);
+        public string SaveJpeg(string path) => OutputWriter.Write(path, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves JPEG to a stream.
         /// </summary>
-        public void SaveJpeg(Stream stream) => QR.SaveJpeg(Uri(), stream, Options);
+        public void SaveJpeg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves WebP to a file.
         /// </summary>
-        public string SaveWebp(string path) => Webp().WriteBinary(path);
+        public string SaveWebp(string path) => OutputWriter.Write(path, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves WebP to a stream.
         /// </summary>
-        public void SaveWebp(Stream stream) => QR.SaveWebp(Uri(), stream, Options);
+        public void SaveWebp(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves based on file extension (.png/.webp/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) {
             var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
-            return QR.Save(Uri(), path, Options, extras);
+            var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+            return OutputWriter.Write(path, Render(format, extras));
         }
     }
 
@@ -520,95 +545,98 @@ public static class Otp {
         /// </summary>
         public QrCode Encode() => QrEasy.Encode(Uri(), Options);
 
+        private RenderedOutput Render(OutputFormat format, RenderExtras? extras = null) {
+            return RenderUri(Uri(), format, Options, extras);
+        }
+
         /// <summary>
         /// Renders PNG bytes.
         /// </summary>
-        public byte[] Png() => QrEasy.RenderPng(Uri(), Options);
+        public byte[] Png() => Render(OutputFormat.Png).Data;
 
         /// <summary>
         /// Renders SVG text.
         /// </summary>
-        public string Svg() => QrEasy.RenderSvg(Uri(), Options);
+        public string Svg() => Render(OutputFormat.Svg).GetText();
 
         /// <summary>
         /// Renders HTML text.
         /// </summary>
-        public string Html() => QrEasy.RenderHtml(Uri(), Options);
+        public string Html() => Render(OutputFormat.Html).GetText();
 
         /// <summary>
         /// Renders JPEG bytes.
         /// </summary>
-        public byte[] Jpeg() => QrEasy.RenderJpeg(Uri(), Options);
+        public byte[] Jpeg() => Render(OutputFormat.Jpeg).Data;
 
         /// <summary>
         /// Renders WebP bytes.
         /// </summary>
-        public byte[] Webp() => QrEasy.RenderWebp(Uri(), Options);
+        public byte[] Webp() => Render(OutputFormat.Webp).Data;
 
         /// <summary>
         /// Saves PNG to a file.
         /// </summary>
-        public string SavePng(string path) => Png().WriteBinary(path);
+        public string SavePng(string path) => OutputWriter.Write(path, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves PNG to a stream.
         /// </summary>
-        public void SavePng(Stream stream) => QR.SavePng(Uri(), stream, Options);
+        public void SavePng(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves SVG to a file.
         /// </summary>
-        public string SaveSvg(string path) => Svg().WriteText(path);
+        public string SaveSvg(string path) => OutputWriter.Write(path, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves SVG to a stream.
         /// </summary>
-        public void SaveSvg(Stream stream) => Svg().WriteText(stream);
+        public void SaveSvg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves HTML to a file.
         /// </summary>
         public string SaveHtml(string path, string? title = null) {
-            var html = Html();
-            if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-            return html.WriteText(path);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return OutputWriter.Write(path, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves HTML to a stream.
         /// </summary>
         public void SaveHtml(Stream stream, string? title = null) {
-            var html = Html();
-            if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-            html.WriteText(stream);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            OutputWriter.Write(stream, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves JPEG to a file.
         /// </summary>
-        public string SaveJpeg(string path) => Jpeg().WriteBinary(path);
+        public string SaveJpeg(string path) => OutputWriter.Write(path, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves JPEG to a stream.
         /// </summary>
-        public void SaveJpeg(Stream stream) => QR.SaveJpeg(Uri(), stream, Options);
+        public void SaveJpeg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves WebP to a file.
         /// </summary>
-        public string SaveWebp(string path) => Webp().WriteBinary(path);
+        public string SaveWebp(string path) => OutputWriter.Write(path, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves WebP to a stream.
         /// </summary>
-        public void SaveWebp(Stream stream) => QR.SaveWebp(Uri(), stream, Options);
+        public void SaveWebp(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves based on file extension (.png/.webp/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
         /// </summary>
         public string Save(string path, string? title = null) {
             var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
-            return QR.Save(Uri(), path, Options, extras);
+            var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+            return OutputWriter.Write(path, Render(format, extras));
         }
     }
 }

--- a/CodeGlyphX/Otp.cs
+++ b/CodeGlyphX/Otp.cs
@@ -272,7 +272,8 @@ public static class Otp {
     /// </summary>
     public static string SaveTotp(string issuer, string account, string secretBase32, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, int period = 30, string? title = null) {
         var uri = TotpUri(issuer, account, secretBase32, alg, digits, period);
-        return QR.Save(uri, path, options, title);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return QR.Save(uri, path, options, extras);
     }
 
     /// <summary>
@@ -281,7 +282,8 @@ public static class Otp {
     /// </summary>
     public static string SaveHotp(string issuer, string account, string secretBase32, long counter, string path, QrEasyOptions? options = null, OtpAlgorithm alg = OtpAlgorithm.Sha1, int digits = 6, string? title = null) {
         var uri = HotpUri(issuer, account, secretBase32, counter, alg, digits);
-        return QR.Save(uri, path, options, title);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return QR.Save(uri, path, options, extras);
     }
 
     /// <summary>
@@ -448,7 +450,10 @@ public static class Otp {
         /// <summary>
         /// Saves based on file extension (.png/.webp/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
         /// </summary>
-        public string Save(string path, string? title = null) => QR.Save(Uri(), path, Options, title);
+        public string Save(string path, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return QR.Save(Uri(), path, Options, extras);
+        }
     }
 
     /// <summary>
@@ -601,6 +606,9 @@ public static class Otp {
         /// <summary>
         /// Saves based on file extension (.png/.webp/.svg/.html/.jpg). Defaults to PNG when no extension is provided.
         /// </summary>
-        public string Save(string path, string? title = null) => QR.Save(Uri(), path, Options, title);
+        public string Save(string path, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return QR.Save(Uri(), path, Options, extras);
+        }
     }
 }

--- a/CodeGlyphX/Pdf417Code.Builder.cs
+++ b/CodeGlyphX/Pdf417Code.Builder.cs
@@ -248,8 +248,9 @@ public static partial class Pdf417Code {
         /// Saves output based on file extension.
         /// </summary>
         public string Save(string path, string? title = null) {
-            if (_text is not null) return Pdf417Code.Save(_text, path, _encodeOptions, _renderOptions, title);
-            return Pdf417Code.Save(_bytes!, path, _encodeOptions, _renderOptions, title);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            if (_text is not null) return Pdf417Code.Save(_text, path, _encodeOptions, _renderOptions, extras);
+            return Pdf417Code.Save(_bytes!, path, _encodeOptions, _renderOptions, extras);
         }
 
         /// <summary>

--- a/CodeGlyphX/Pdf417Code.Builder.cs
+++ b/CodeGlyphX/Pdf417Code.Builder.cs
@@ -186,39 +186,45 @@ public static partial class Pdf417Code {
             return _text is not null ? Pdf417Code.Encode(_text, _encodeOptions) : Pdf417Code.EncodeBytes(_bytes!, _encodeOptions);
         }
 
+        private RenderedOutput Render(OutputFormat format, RenderExtras? extras = null) {
+            return _text is not null
+                ? Pdf417Code.Render(_text, format, _encodeOptions, _renderOptions, extras)
+                : Pdf417Code.Render(_bytes!, format, _encodeOptions, _renderOptions, extras);
+        }
+
         /// <summary>
         /// Renders PNG bytes.
         /// </summary>
         public byte[] Png() {
-            return _text is not null ? Pdf417Code.Png(_text, _encodeOptions, _renderOptions) : Pdf417Code.Png(_bytes!, _encodeOptions, _renderOptions);
+            return Render(OutputFormat.Png).Data;
         }
 
         /// <summary>
         /// Renders SVG markup.
         /// </summary>
         public string Svg() {
-            return _text is not null ? Pdf417Code.Svg(_text, _encodeOptions, _renderOptions) : Pdf417Code.Svg(_bytes!, _encodeOptions, _renderOptions);
+            return Render(OutputFormat.Svg).GetText();
         }
 
         /// <summary>
         /// Renders HTML markup.
         /// </summary>
         public string Html() {
-            return _text is not null ? Pdf417Code.Html(_text, _encodeOptions, _renderOptions) : Pdf417Code.Html(_bytes!, _encodeOptions, _renderOptions);
+            return Render(OutputFormat.Html).GetText();
         }
 
         /// <summary>
         /// Renders JPEG bytes.
         /// </summary>
         public byte[] Jpeg() {
-            return _text is not null ? Pdf417Code.Jpeg(_text, _encodeOptions, _renderOptions) : Pdf417Code.Jpeg(_bytes!, _encodeOptions, _renderOptions);
+            return Render(OutputFormat.Jpeg).Data;
         }
 
         /// <summary>
         /// Renders BMP bytes.
         /// </summary>
         public byte[] Bmp() {
-            return _text is not null ? Pdf417Code.Bmp(_text, _encodeOptions, _renderOptions) : Pdf417Code.Bmp(_bytes!, _encodeOptions, _renderOptions);
+            return Render(OutputFormat.Bmp).Data;
         }
 
         /// <summary>
@@ -226,7 +232,7 @@ public static partial class Pdf417Code {
         /// </summary>
         /// <param name="renderMode">Vector or raster output.</param>
         public byte[] Pdf(RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? Pdf417Code.Pdf(_text, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.Pdf(_bytes!, _encodeOptions, _renderOptions, renderMode);
+            return Render(OutputFormat.Pdf, new RenderExtras { VectorMode = renderMode }).Data;
         }
 
         /// <summary>
@@ -234,14 +240,14 @@ public static partial class Pdf417Code {
         /// </summary>
         /// <param name="renderMode">Vector or raster output.</param>
         public string Eps(RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? Pdf417Code.Eps(_text, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.Eps(_bytes!, _encodeOptions, _renderOptions, renderMode);
+            return Render(OutputFormat.Eps, new RenderExtras { VectorMode = renderMode }).GetText();
         }
 
         /// <summary>
         /// Renders ASCII text.
         /// </summary>
         public string Ascii(MatrixAsciiRenderOptions? options = null) {
-            return _text is not null ? Pdf417Code.Ascii(_text, _encodeOptions, options) : Pdf417Code.Ascii(_bytes!, _encodeOptions, options);
+            return Render(OutputFormat.Ascii, new RenderExtras { MatrixAscii = options }).GetText();
         }
 
         /// <summary>
@@ -257,42 +263,43 @@ public static partial class Pdf417Code {
         /// Saves PNG to a file.
         /// </summary>
         public string SavePng(string path) {
-            return _text is not null ? Pdf417Code.SavePng(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SavePng(_bytes!, path, _encodeOptions, _renderOptions);
+            return OutputWriter.Write(path, Render(OutputFormat.Png));
         }
 
         /// <summary>
         /// Saves SVG to a file.
         /// </summary>
         public string SaveSvg(string path) {
-            return _text is not null ? Pdf417Code.SaveSvg(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveSvg(_bytes!, path, _encodeOptions, _renderOptions);
+            return OutputWriter.Write(path, Render(OutputFormat.Svg));
         }
 
         /// <summary>
         /// Saves HTML to a file.
         /// </summary>
         public string SaveHtml(string path, string? title = null) {
-            return _text is not null ? Pdf417Code.SaveHtml(_text, path, _encodeOptions, _renderOptions, title) : Pdf417Code.SaveHtml(_bytes!, path, _encodeOptions, _renderOptions, title);
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return OutputWriter.Write(path, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves JPEG to a file.
         /// </summary>
         public string SaveJpeg(string path) {
-            return _text is not null ? Pdf417Code.SaveJpeg(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveJpeg(_bytes!, path, _encodeOptions, _renderOptions);
+            return OutputWriter.Write(path, Render(OutputFormat.Jpeg));
         }
 
         /// <summary>
         /// Saves WebP to a file.
         /// </summary>
         public string SaveWebp(string path) {
-            return _text is not null ? Pdf417Code.SaveWebp(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveWebp(_bytes!, path, _encodeOptions, _renderOptions);
+            return OutputWriter.Write(path, Render(OutputFormat.Webp));
         }
 
         /// <summary>
         /// Saves BMP to a file.
         /// </summary>
         public string SaveBmp(string path) {
-            return _text is not null ? Pdf417Code.SaveBmp(_text, path, _encodeOptions, _renderOptions) : Pdf417Code.SaveBmp(_bytes!, path, _encodeOptions, _renderOptions);
+            return OutputWriter.Write(path, Render(OutputFormat.Bmp));
         }
 
         /// <summary>
@@ -301,7 +308,7 @@ public static partial class Pdf417Code {
     /// <param name="path">Output file path.</param>
         /// <param name="renderMode">Vector or raster output.</param>
         public string SavePdf(string path, RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? Pdf417Code.SavePdf(_text, path, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.SavePdf(_bytes!, path, _encodeOptions, _renderOptions, renderMode);
+            return OutputWriter.Write(path, Render(OutputFormat.Pdf, new RenderExtras { VectorMode = renderMode }));
         }
 
         /// <summary>
@@ -310,7 +317,7 @@ public static partial class Pdf417Code {
     /// <param name="path">Output file path.</param>
         /// <param name="renderMode">Vector or raster output.</param>
         public string SaveEps(string path, RenderMode renderMode = RenderMode.Vector) {
-            return _text is not null ? Pdf417Code.SaveEps(_text, path, _encodeOptions, _renderOptions, renderMode) : Pdf417Code.SaveEps(_bytes!, path, _encodeOptions, _renderOptions, renderMode);
+            return OutputWriter.Write(path, Render(OutputFormat.Eps, new RenderExtras { VectorMode = renderMode }));
         }
     }
 

--- a/CodeGlyphX/Pdf417Code.Macro.Save.cs
+++ b/CodeGlyphX/Pdf417Code.Macro.Save.cs
@@ -1,40 +1,18 @@
 using System;
 using System.IO;
 using CodeGlyphX.Pdf417;
-using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX;
 
 public static partial class Pdf417Code {
     /// <summary>
-    /// Saves Macro PDF417 to a file based on extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves Macro PDF417 to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string SaveMacro(string text, Pdf417MacroOptions macro, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null, RenderMode renderMode = RenderMode.Vector) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Png = () => PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Webp = () => PngMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Svg = () => SvgMacro(text, macro, encodeOptions, renderOptions).WriteText(path),
-            Svgz = () => SvgzMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Html = () => {
-                var html = HtmlMacro(text, macro, encodeOptions, renderOptions);
-                if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-                return html.WriteText(path);
-            },
-            Jpeg = () => JpegMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Bmp = () => BmpMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Ppm = () => PpmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Pbm = () => PbmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Pgm = () => PgmMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Pam = () => PamMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Xbm = () => XbmMacro(text, macro, encodeOptions, renderOptions).WriteText(path),
-            Xpm = () => XpmMacro(text, macro, encodeOptions, renderOptions).WriteText(path),
-            Tga = () => TgaMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Ico = () => IcoMacro(text, macro, encodeOptions, renderOptions).WriteBinary(path),
-            Pdf = () => PdfMacro(text, macro, encodeOptions, renderOptions, renderMode).WriteBinary(path),
-            Eps = () => EpsMacro(text, macro, encodeOptions, renderOptions, renderMode).WriteText(path)
-        });
+    public static string SaveMacro(string text, Pdf417MacroOptions macro, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = RenderMacro(text, macro, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
     }
 }

--- a/CodeGlyphX/Pdf417Code.Macro.cs
+++ b/CodeGlyphX/Pdf417Code.Macro.cs
@@ -25,6 +25,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PngMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -33,6 +34,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SvgMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -41,6 +43,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] SvgzMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -49,6 +52,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string HtmlMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
@@ -57,6 +61,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] JpegMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -67,6 +72,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] BmpMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -75,6 +81,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PpmMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -83,6 +90,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PbmMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -91,6 +99,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PgmMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -99,6 +108,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PamMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -107,6 +117,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string XbmMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -115,6 +126,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string XpmMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -123,6 +135,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] TgaMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -131,6 +144,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] IcoMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(renderOptions), BuildIcoOptions(renderOptions));
@@ -144,6 +158,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PdfMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -157,6 +172,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string EpsMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -165,6 +181,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders Macro PDF417 as ASCII.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string AsciiMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         return MatrixAsciiRenderer.Render(modules, options);

--- a/CodeGlyphX/Pdf417Code.Render.cs
+++ b/CodeGlyphX/Pdf417Code.Render.cs
@@ -71,8 +71,9 @@ public static partial class Pdf417Code {
                 return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions)));
             case OutputFormat.Html: {
                 var html = MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
-                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
-                    html = html.WrapHtml(extras.HtmlTitle);
+                var title = extras?.HtmlTitle;
+                if (!string.IsNullOrEmpty(title)) {
+                    html = html.WrapHtml(title);
                 }
                 return RenderedOutput.FromText(format, html);
             }

--- a/CodeGlyphX/Pdf417Code.Render.cs
+++ b/CodeGlyphX/Pdf417Code.Render.cs
@@ -1,0 +1,111 @@
+using System;
+using CodeGlyphX.Pdf417;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pam;
+using CodeGlyphX.Rendering.Pbm;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Pgm;
+using CodeGlyphX.Rendering.Ppm;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+using CodeGlyphX.Rendering.Svgz;
+using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
+using CodeGlyphX.Rendering.Xbm;
+using CodeGlyphX.Rendering.Xpm;
+
+namespace CodeGlyphX;
+
+public static partial class Pdf417Code {
+    /// <summary>
+    /// Renders a PDF417 payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(string text, OutputFormat format, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var modules = Encode(text, encodeOptions);
+        return Render(modules, format, renderOptions, extras);
+    }
+
+    /// <summary>
+    /// Renders a Macro PDF417 payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput RenderMacro(string text, Pdf417MacroOptions macro, OutputFormat format, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var modules = EncodeMacro(text, macro, encodeOptions);
+        return Render(modules, format, renderOptions, extras);
+    }
+
+    /// <summary>
+    /// Renders a PDF417 byte payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(byte[] data, OutputFormat format, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return Render(modules, format, renderOptions, extras);
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Renders a PDF417 byte payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(ReadOnlySpan<byte> data, OutputFormat format, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var modules = EncodeBytes(data, encodeOptions);
+        return Render(modules, format, renderOptions, extras);
+    }
+#endif
+
+    private static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? renderOptions, RenderExtras? extras) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
+
+        var pngOptions = BuildPngOptions(renderOptions);
+        switch (format) {
+            case OutputFormat.Png:
+                return RenderedOutput.FromBinary(format, MatrixPngRenderer.Render(modules, pngOptions));
+            case OutputFormat.Svg:
+                return RenderedOutput.FromText(format, MatrixSvgRenderer.Render(modules, BuildSvgOptions(renderOptions)));
+            case OutputFormat.Svgz:
+                return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions)));
+            case OutputFormat.Html: {
+                var html = MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
+                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
+                    html = html.WrapHtml(extras.HtmlTitle);
+                }
+                return RenderedOutput.FromText(format, html);
+            }
+            case OutputFormat.Jpeg:
+                return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
+            case OutputFormat.Webp:
+                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, renderOptions?.WebpQuality ?? 100));
+            case OutputFormat.Bmp:
+                return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
+            case OutputFormat.Ppm:
+                return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pbm:
+                return RenderedOutput.FromBinary(format, MatrixPbmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pgm:
+                return RenderedOutput.FromBinary(format, MatrixPgmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Pam:
+                return RenderedOutput.FromBinary(format, MatrixPamRenderer.Render(modules, pngOptions));
+            case OutputFormat.Xbm:
+                return RenderedOutput.FromText(format, MatrixXbmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Xpm:
+                return RenderedOutput.FromText(format, MatrixXpmRenderer.Render(modules, pngOptions));
+            case OutputFormat.Tga:
+                return RenderedOutput.FromBinary(format, MatrixTgaRenderer.Render(modules, pngOptions));
+            case OutputFormat.Ico:
+                return RenderedOutput.FromBinary(format, MatrixIcoRenderer.Render(modules, pngOptions, BuildIcoOptions(renderOptions)));
+            case OutputFormat.Pdf:
+                return RenderedOutput.FromBinary(format, MatrixPdfRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Eps:
+                return RenderedOutput.FromText(format, MatrixEpsRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
+            case OutputFormat.Ascii:
+                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(modules, extras?.MatrixAscii ?? new MatrixAsciiRenderOptions()));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
+        }
+    }
+}

--- a/CodeGlyphX/Pdf417Code.Save.Bytes.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Bytes.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading;
 using System.Text;
 using CodeGlyphX.Pdf417;
-using CodeGlyphX.Internal;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
@@ -331,30 +330,13 @@ public static partial class Pdf417Code {
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps).
+    /// Saves PDF417 to a file for byte payloads based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        return SaveByExtensionHelper.Save(data, path, new SaveByExtensionSpanHandlers {
-            Default = d => SavePng(d, path, encodeOptions, renderOptions),
-            Png = d => SavePng(d, path, encodeOptions, renderOptions),
-            Webp = d => SaveWebp(d, path, encodeOptions, renderOptions),
-            Svg = d => SaveSvg(d, path, encodeOptions, renderOptions),
-            Svgz = d => SaveSvgz(d, path, encodeOptions, renderOptions),
-            Html = d => SaveHtml(d, path, encodeOptions, renderOptions, title),
-            Jpeg = d => SaveJpeg(d, path, encodeOptions, renderOptions),
-            Bmp = d => SaveBmp(d, path, encodeOptions, renderOptions),
-            Ppm = d => SavePpm(d, path, encodeOptions, renderOptions),
-            Pbm = d => SavePbm(d, path, encodeOptions, renderOptions),
-            Pgm = d => SavePgm(d, path, encodeOptions, renderOptions),
-            Pam = d => SavePam(d, path, encodeOptions, renderOptions),
-            Xbm = d => SaveXbm(d, path, encodeOptions, renderOptions),
-            Xpm = d => SaveXpm(d, path, encodeOptions, renderOptions),
-            Tga = d => SaveTga(d, path, encodeOptions, renderOptions),
-            Ico = d => SaveIco(d, path, encodeOptions, renderOptions),
-            Pdf = d => SavePdf(d, path, encodeOptions, renderOptions),
-            Eps = d => SaveEps(d, path, encodeOptions, renderOptions)
-        });
+    public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
     }
 
 }

--- a/CodeGlyphX/Pdf417Code.Save.Bytes.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Bytes.cs
@@ -30,6 +30,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PNG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var png = Png(data, encodeOptions, renderOptions);
         return png.WriteBinary(path);
@@ -38,6 +39,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PNG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPngRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -46,6 +48,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svg = Svg(data, encodeOptions, renderOptions);
         return svg.WriteText(path);
@@ -54,6 +57,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVGZ to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svgz = Svgz(data, encodeOptions, renderOptions);
         return svgz.WriteBinary(path);
@@ -62,6 +66,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svg = Svg(data, encodeOptions, renderOptions);
         svg.WriteText(stream);
@@ -70,6 +75,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVGZ to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixSvgzRenderer.RenderToStream(modules, BuildSvgOptions(renderOptions), stream);
@@ -78,6 +84,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 HTML to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(data, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) {
@@ -89,6 +96,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 HTML to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(data, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) {
@@ -100,6 +108,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 JPEG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var jpeg = Jpeg(data, encodeOptions, renderOptions);
         return jpeg.WriteBinary(path);
@@ -108,6 +117,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 WebP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var webp = Webp(data, encodeOptions, renderOptions);
         return webp.WriteBinary(path);
@@ -116,6 +126,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 BMP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var bmp = Bmp(data, encodeOptions, renderOptions);
         return bmp.WriteBinary(path);
@@ -124,6 +135,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var ppm = Ppm(data, encodeOptions, renderOptions);
         return ppm.WriteBinary(path);
@@ -132,6 +144,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pbm = Pbm(data, encodeOptions, renderOptions);
         return pbm.WriteBinary(path);
@@ -140,6 +153,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PGM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pgm = Pgm(data, encodeOptions, renderOptions);
         return pgm.WriteBinary(path);
@@ -148,6 +162,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PAM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pam = Pam(data, encodeOptions, renderOptions);
         return pam.WriteBinary(path);
@@ -156,6 +171,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var xbm = Xbm(data, encodeOptions, renderOptions);
         return xbm.WriteText(path);
@@ -164,6 +180,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var xpm = Xpm(data, encodeOptions, renderOptions);
         return xpm.WriteText(path);
@@ -172,6 +189,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 TGA to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var tga = Tga(data, encodeOptions, renderOptions);
         return tga.WriteBinary(path);
@@ -180,6 +198,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 ICO to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var ico = Ico(data, encodeOptions, renderOptions);
         return ico.WriteBinary(path);
@@ -193,6 +212,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
@@ -206,6 +226,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
@@ -214,6 +235,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 JPEG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -224,6 +246,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 WebP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -234,6 +257,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 BMP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -242,6 +266,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPpmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -250,6 +275,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPbmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -258,6 +284,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PGM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPgmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -266,6 +293,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PAM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPamRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -274,6 +302,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixXbmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -282,6 +311,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixXpmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -290,6 +320,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 TGA to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixTgaRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -298,6 +329,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 ICO to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixIcoRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, BuildIcoOptions(renderOptions));
@@ -311,6 +343,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -324,6 +357,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);

--- a/CodeGlyphX/Pdf417Code.Save.Bytes.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Bytes.cs
@@ -367,6 +367,18 @@ public static partial class Pdf417Code {
     /// Saves PDF417 to a file for byte payloads based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions, MatrixOptions? renderOptions, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file for byte payloads based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
     public static string Save(ReadOnlySpan<byte> data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
         var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
         var output = Render(data, format, encodeOptions, renderOptions, extras);

--- a/CodeGlyphX/Pdf417Code.Save.Text.ByExtension.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.ByExtension.cs
@@ -1,63 +1,30 @@
 using System;
 using System.IO;
 using CodeGlyphX.Pdf417;
-using CodeGlyphX.Internal;
+using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX;
 
 public static partial class Pdf417Code {
     /// <summary>
-    /// Saves PDF417 to a file based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves PDF417 to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => SavePng(text, path, encodeOptions, renderOptions),
-            Png = () => SavePng(text, path, encodeOptions, renderOptions),
-            Webp = () => SaveWebp(text, path, encodeOptions, renderOptions),
-            Svg = () => SaveSvg(text, path, encodeOptions, renderOptions),
-            Svgz = () => SaveSvgz(text, path, encodeOptions, renderOptions),
-            Html = () => SaveHtml(text, path, encodeOptions, renderOptions, title),
-            Jpeg = () => SaveJpeg(text, path, encodeOptions, renderOptions),
-            Bmp = () => SaveBmp(text, path, encodeOptions, renderOptions),
-            Ppm = () => SavePpm(text, path, encodeOptions, renderOptions),
-            Pbm = () => SavePbm(text, path, encodeOptions, renderOptions),
-            Pgm = () => SavePgm(text, path, encodeOptions, renderOptions),
-            Pam = () => SavePam(text, path, encodeOptions, renderOptions),
-            Xbm = () => SaveXbm(text, path, encodeOptions, renderOptions),
-            Xpm = () => SaveXpm(text, path, encodeOptions, renderOptions),
-            Tga = () => SaveTga(text, path, encodeOptions, renderOptions),
-            Ico = () => SaveIco(text, path, encodeOptions, renderOptions),
-            Pdf = () => SavePdf(text, path, encodeOptions, renderOptions),
-            Eps = () => SaveEps(text, path, encodeOptions, renderOptions)
-        });
+    public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(text, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
     }
 
     /// <summary>
-    /// Saves PDF417 to a file for byte payloads based on extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves PDF417 to a file for byte payloads based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => SavePng(data, path, encodeOptions, renderOptions),
-            Png = () => SavePng(data, path, encodeOptions, renderOptions),
-            Webp = () => SaveWebp(data, path, encodeOptions, renderOptions),
-            Svg = () => SaveSvg(data, path, encodeOptions, renderOptions),
-            Svgz = () => SaveSvgz(data, path, encodeOptions, renderOptions),
-            Html = () => SaveHtml(data, path, encodeOptions, renderOptions, title),
-            Jpeg = () => SaveJpeg(data, path, encodeOptions, renderOptions),
-            Bmp = () => SaveBmp(data, path, encodeOptions, renderOptions),
-            Ppm = () => SavePpm(data, path, encodeOptions, renderOptions),
-            Pbm = () => SavePbm(data, path, encodeOptions, renderOptions),
-            Pgm = () => SavePgm(data, path, encodeOptions, renderOptions),
-            Pam = () => SavePam(data, path, encodeOptions, renderOptions),
-            Xbm = () => SaveXbm(data, path, encodeOptions, renderOptions),
-            Xpm = () => SaveXpm(data, path, encodeOptions, renderOptions),
-            Tga = () => SaveTga(data, path, encodeOptions, renderOptions),
-            Ico = () => SaveIco(data, path, encodeOptions, renderOptions),
-            Pdf = () => SavePdf(data, path, encodeOptions, renderOptions),
-            Eps = () => SaveEps(data, path, encodeOptions, renderOptions)
-        });
+    public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
     }
 
 }

--- a/CodeGlyphX/Pdf417Code.Save.Text.ByExtension.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.ByExtension.cs
@@ -10,9 +10,34 @@ public static partial class Pdf417Code {
     /// Saves PDF417 to a file based on extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions, MatrixOptions? renderOptions, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(text, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
     public static string Save(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderExtras? extras = null) {
         var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
         var output = Render(text, format, encodeOptions, renderOptions, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves PDF417 to a file for byte payloads based on extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(byte[] data, string path, Pdf417EncodeOptions? encodeOptions, MatrixOptions? renderOptions, string? title) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(data, format, encodeOptions, renderOptions, extras);
         return OutputWriter.Write(path, output);
     }
 

--- a/CodeGlyphX/Pdf417Code.Save.Text.File.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.File.cs
@@ -28,6 +28,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PNG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var png = Png(text, encodeOptions, renderOptions);
         return png.WriteBinary(path);
@@ -36,6 +37,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PNG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var png = Png(data, encodeOptions, renderOptions);
         return png.WriteBinary(path);
@@ -43,6 +45,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svg = Svg(text, encodeOptions, renderOptions);
         return svg.WriteText(path);
@@ -51,6 +54,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVGZ to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svgz = Svgz(text, encodeOptions, renderOptions);
         return svgz.WriteBinary(path);
@@ -59,6 +63,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svg = Svg(data, encodeOptions, renderOptions);
         return svg.WriteText(path);
@@ -67,6 +72,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVGZ to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svgz = Svgz(data, encodeOptions, renderOptions);
         return svgz.WriteBinary(path);
@@ -74,6 +80,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 HTML to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(text, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) {
@@ -85,6 +92,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 HTML to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(data, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) {
@@ -95,6 +103,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 JPEG to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var jpeg = Jpeg(text, encodeOptions, renderOptions);
         return jpeg.WriteBinary(path);
@@ -103,6 +112,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 WebP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var webp = Webp(text, encodeOptions, renderOptions);
         return webp.WriteBinary(path);
@@ -111,6 +121,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 BMP to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var bmp = Bmp(text, encodeOptions, renderOptions);
         return bmp.WriteBinary(path);
@@ -119,6 +130,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PPM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var ppm = Ppm(text, encodeOptions, renderOptions);
         return ppm.WriteBinary(path);
@@ -127,6 +139,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PBM to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pbm = Pbm(text, encodeOptions, renderOptions);
         return pbm.WriteBinary(path);
@@ -135,6 +148,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PGM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pgm = Pgm(text, encodeOptions, renderOptions);
         return pgm.WriteBinary(path);
@@ -143,6 +157,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PAM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pam = Pam(text, encodeOptions, renderOptions);
         return pam.WriteBinary(path);
@@ -151,6 +166,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XBM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var xbm = Xbm(text, encodeOptions, renderOptions);
         return xbm.WriteText(path);
@@ -159,6 +175,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XPM to a file for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var xpm = Xpm(text, encodeOptions, renderOptions);
         return xpm.WriteText(path);
@@ -167,6 +184,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 TGA to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var tga = Tga(text, encodeOptions, renderOptions);
         return tga.WriteBinary(path);
@@ -175,6 +193,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 ICO to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var ico = Ico(text, encodeOptions, renderOptions);
         return ico.WriteBinary(path);
@@ -188,6 +207,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(text, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
@@ -201,6 +221,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(string text, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(text, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
@@ -209,6 +230,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 ICO to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var ico = Ico(data, encodeOptions, renderOptions);
         return ico.WriteBinary(path);
@@ -222,6 +244,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var pdf = Pdf(data, encodeOptions, renderOptions, renderMode);
         return pdf.WriteBinary(path);
@@ -235,6 +258,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var eps = Eps(data, encodeOptions, renderOptions, renderMode);
         return eps.WriteText(path);
@@ -242,6 +266,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 JPEG to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var jpeg = Jpeg(data, encodeOptions, renderOptions);
         return jpeg.WriteBinary(path);
@@ -250,6 +275,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 WebP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var webp = Webp(data, encodeOptions, renderOptions);
         return webp.WriteBinary(path);
@@ -258,6 +284,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 BMP to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var bmp = Bmp(data, encodeOptions, renderOptions);
         return bmp.WriteBinary(path);
@@ -266,6 +293,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var ppm = Ppm(data, encodeOptions, renderOptions);
         return ppm.WriteBinary(path);
@@ -274,6 +302,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pbm = Pbm(data, encodeOptions, renderOptions);
         return pbm.WriteBinary(path);
@@ -282,6 +311,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PGM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pgm = Pgm(data, encodeOptions, renderOptions);
         return pgm.WriteBinary(path);
@@ -290,6 +320,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PAM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var pam = Pam(data, encodeOptions, renderOptions);
         return pam.WriteBinary(path);
@@ -298,6 +329,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XBM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var xbm = Xbm(data, encodeOptions, renderOptions);
         return xbm.WriteText(path);
@@ -306,6 +338,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XPM to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var xpm = Xpm(data, encodeOptions, renderOptions);
         return xpm.WriteText(path);
@@ -314,6 +347,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 TGA to a file for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(byte[] data, string path, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var tga = Tga(data, encodeOptions, renderOptions);
         return tga.WriteBinary(path);

--- a/CodeGlyphX/Pdf417Code.Save.Text.Stream.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.Stream.cs
@@ -29,6 +29,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PNG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixPngRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -37,6 +38,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PNG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPngRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -44,6 +46,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svg = Svg(text, encodeOptions, renderOptions);
         svg.WriteText(stream);
@@ -52,6 +55,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVGZ to a stream for text payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixSvgzRenderer.RenderToStream(modules, BuildSvgOptions(renderOptions), stream);
@@ -60,6 +64,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var svg = Svg(data, encodeOptions, renderOptions);
         svg.WriteText(stream);
@@ -68,6 +73,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 SVGZ to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixSvgzRenderer.RenderToStream(modules, BuildSvgOptions(renderOptions), stream);
@@ -75,6 +81,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 HTML to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(text, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) {
@@ -86,6 +93,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 HTML to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, string? title = null) {
         var html = Html(data, encodeOptions, renderOptions);
         if (!string.IsNullOrEmpty(title)) {
@@ -96,6 +104,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 JPEG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -106,6 +115,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 WebP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -116,6 +126,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 BMP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -124,6 +135,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixPpmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -132,6 +144,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixPbmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -140,6 +153,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PGM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixPgmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -148,6 +162,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PAM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixPamRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -156,6 +171,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixXbmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -164,6 +180,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixXpmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -172,6 +189,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 TGA to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixTgaRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -180,6 +198,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 ICO to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         MatrixIcoRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, BuildIcoOptions(renderOptions));
@@ -193,6 +212,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -206,6 +226,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -214,6 +235,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 JPEG to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -224,6 +246,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 WebP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -234,6 +257,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 BMP to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixBmpRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -242,6 +266,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPpmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -250,6 +275,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPbmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -258,6 +284,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PGM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPgmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -266,6 +293,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 PAM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPamRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -274,6 +302,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XBM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixXbmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -282,6 +311,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 XPM to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixXpmRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -290,6 +320,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 TGA to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixTgaRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream);
@@ -298,6 +329,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Saves PDF417 ICO to a stream for byte payloads.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixIcoRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, BuildIcoOptions(renderOptions));
@@ -311,6 +343,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixPdfRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);
@@ -324,6 +357,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         MatrixEpsRenderer.RenderToStream(modules, BuildPngOptions(renderOptions), stream, renderMode);

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -81,6 +81,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PNG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -89,6 +90,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as SVG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -97,6 +99,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as SVGZ from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -105,6 +108,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as HTML from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
@@ -113,6 +117,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as JPEG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -123,6 +128,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as WebP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -133,6 +139,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as BMP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -141,6 +148,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PPM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -149,6 +157,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PBM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -157,6 +166,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PGM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -165,6 +175,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PAM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -173,6 +184,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as XBM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -181,6 +193,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as XPM from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -189,6 +202,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as TGA from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -197,6 +211,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as ICO from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(renderOptions), BuildIcoOptions(renderOptions));
@@ -209,6 +224,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -221,6 +237,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -229,6 +246,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as ASCII from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixAsciiRenderer.Render(modules, options);
@@ -239,6 +257,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -247,6 +266,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PNG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Png(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPngRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -255,6 +275,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -263,6 +284,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -271,6 +293,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as SVG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Svg(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixSvgRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -279,6 +302,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as SVGZ from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Svgz(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions));
@@ -287,6 +311,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
@@ -295,6 +320,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as HTML from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Html(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
@@ -303,6 +329,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -313,6 +340,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -323,6 +351,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -331,6 +360,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -339,6 +369,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -347,6 +378,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -355,6 +387,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -363,6 +396,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -371,6 +405,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -379,6 +414,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -387,6 +423,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(renderOptions), BuildIcoOptions(renderOptions));
@@ -399,6 +436,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -411,6 +449,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = Encode(text, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -419,6 +458,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as ASCII.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
         var modules = Encode(text, encodeOptions);
         return MatrixAsciiRenderer.Render(modules, options);
@@ -427,6 +467,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as JPEG from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Jpeg(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -437,6 +478,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as WebP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Webp(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
@@ -447,6 +489,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as BMP from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Bmp(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixBmpRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -455,6 +498,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ppm(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -463,6 +507,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pbm(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -471,6 +516,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pgm(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPgmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -479,6 +525,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pam(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPamRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -487,6 +534,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xbm(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixXbmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -495,6 +543,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Xpm(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixXpmRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -503,6 +552,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Tga(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixTgaRenderer.Render(modules, BuildPngOptions(renderOptions));
@@ -511,6 +561,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Ico(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixIcoRenderer.Render(modules, BuildPngOptions(renderOptions), BuildIcoOptions(renderOptions));
@@ -523,6 +574,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] Pdf(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixPdfRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -535,6 +587,7 @@ public static partial class Pdf417Code {
     /// <param name="encodeOptions">Encoding options.</param>
     /// <param name="renderOptions">Rendering options.</param>
     /// <param name="renderMode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Eps(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null, RenderMode renderMode = RenderMode.Vector) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixEpsRenderer.Render(modules, BuildPngOptions(renderOptions), renderMode);
@@ -543,6 +596,7 @@ public static partial class Pdf417Code {
     /// <summary>
     /// Renders PDF417 as ASCII from bytes.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixAsciiRenderOptions? options = null) {
         var modules = EncodeBytes(data, encodeOptions);
         return MatrixAsciiRenderer.Render(modules, options);

--- a/CodeGlyphX/QR.Builder.cs
+++ b/CodeGlyphX/QR.Builder.cs
@@ -682,8 +682,11 @@ public static partial class QR {
         /// <summary>
         /// Saves based on file extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps). Defaults to PNG when no extension is provided.
         /// </summary>
-        public string Save(string path, string? title = null) => _payloadData is null
-            ? QR.Save(_payload, path, Options, title)
-            : QR.Save(_payloadData, path, Options, title);
+        public string Save(string path, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return _payloadData is null
+                ? QR.Save(_payload, path, Options, extras)
+                : QR.Save(_payloadData, path, Options, extras);
+        }
     }
 }

--- a/CodeGlyphX/QR.Builder.cs
+++ b/CodeGlyphX/QR.Builder.cs
@@ -310,329 +310,251 @@ public static partial class QR {
         /// </summary>
         public QrCode Encode() => _payloadData is null ? QrEasy.Encode(_payload, Options) : QrEasy.Encode(_payloadData, Options);
 
+        private RenderedOutput Render(OutputFormat format, RenderExtras? extras = null) {
+            return QrEasy.Render(Encode(), format, Options, extras);
+        }
+
         /// <summary>
         /// Renders PNG bytes.
         /// </summary>
-        public byte[] Png() => _payloadData is null ? QrEasy.RenderPng(_payload, Options) : QrEasy.RenderPng(_payloadData, Options);
+        public byte[] Png() => Render(OutputFormat.Png).Data;
 
         /// <summary>
         /// Renders SVG text.
         /// </summary>
-        public string Svg() => _payloadData is null ? QrEasy.RenderSvg(_payload, Options) : QrEasy.RenderSvg(_payloadData, Options);
+        public string Svg() => Render(OutputFormat.Svg).GetText();
 
         /// <summary>
         /// Renders HTML text.
         /// </summary>
-        public string Html() => _payloadData is null ? QrEasy.RenderHtml(_payload, Options) : QrEasy.RenderHtml(_payloadData, Options);
+        public string Html() => Render(OutputFormat.Html).GetText();
 
         /// <summary>
         /// Renders JPEG bytes.
         /// </summary>
-        public byte[] Jpeg() => _payloadData is null ? QrEasy.RenderJpeg(_payload, Options) : QrEasy.RenderJpeg(_payloadData, Options);
+        public byte[] Jpeg() => Render(OutputFormat.Jpeg).Data;
 
         /// <summary>
         /// Renders PPM bytes.
         /// </summary>
-        public byte[] Ppm() => _payloadData is null ? QrEasy.RenderPpm(_payload, Options) : QrEasy.RenderPpm(_payloadData, Options);
+        public byte[] Ppm() => Render(OutputFormat.Ppm).Data;
 
         /// <summary>
         /// Renders PBM bytes.
         /// </summary>
-        public byte[] Pbm() => _payloadData is null ? QrEasy.RenderPbm(_payload, Options) : QrEasy.RenderPbm(_payloadData, Options);
+        public byte[] Pbm() => Render(OutputFormat.Pbm).Data;
 
         /// <summary>
         /// Renders PGM bytes.
         /// </summary>
-        public byte[] Pgm() => _payloadData is null ? QrEasy.RenderPgm(_payload, Options) : QrEasy.RenderPgm(_payloadData, Options);
+        public byte[] Pgm() => Render(OutputFormat.Pgm).Data;
 
         /// <summary>
         /// Renders PAM bytes.
         /// </summary>
-        public byte[] Pam() => _payloadData is null ? QrEasy.RenderPam(_payload, Options) : QrEasy.RenderPam(_payloadData, Options);
+        public byte[] Pam() => Render(OutputFormat.Pam).Data;
 
         /// <summary>
         /// Renders XBM text.
         /// </summary>
-        public string Xbm() => _payloadData is null ? QrEasy.RenderXbm(_payload, Options) : QrEasy.RenderXbm(_payloadData, Options);
+        public string Xbm() => Render(OutputFormat.Xbm).GetText();
 
         /// <summary>
         /// Renders XPM text.
         /// </summary>
-        public string Xpm() => _payloadData is null ? QrEasy.RenderXpm(_payload, Options) : QrEasy.RenderXpm(_payloadData, Options);
+        public string Xpm() => Render(OutputFormat.Xpm).GetText();
 
         /// <summary>
         /// Renders TGA bytes.
         /// </summary>
-        public byte[] Tga() => _payloadData is null ? QrEasy.RenderTga(_payload, Options) : QrEasy.RenderTga(_payloadData, Options);
+        public byte[] Tga() => Render(OutputFormat.Tga).Data;
 
         /// <summary>
         /// Renders ICO bytes.
         /// </summary>
-        public byte[] Ico() => _payloadData is null ? QrEasy.RenderIco(_payload, Options) : QrEasy.RenderIco(_payloadData, Options);
+        public byte[] Ico() => Render(OutputFormat.Ico).Data;
 
         /// <summary>
         /// Renders SVGZ bytes.
         /// </summary>
-        public byte[] Svgz() => _payloadData is null ? QrEasy.RenderSvgz(_payload, Options) : QrEasy.RenderSvgz(_payloadData, Options);
+        public byte[] Svgz() => Render(OutputFormat.Svgz).Data;
 
         /// <summary>
         /// Renders PDF bytes.
         /// </summary>
         /// <param name="mode">Vector or raster output.</param>
-        public byte[] Pdf(RenderMode mode = RenderMode.Vector) => _payloadData is null ? QrEasy.RenderPdf(_payload, Options, mode) : QrEasy.RenderPdf(_payloadData, Options, mode);
+        public byte[] Pdf(RenderMode mode = RenderMode.Vector) => Render(OutputFormat.Pdf, new RenderExtras { VectorMode = mode }).Data;
 
         /// <summary>
         /// Renders EPS text.
         /// </summary>
         /// <param name="mode">Vector or raster output.</param>
-        public string Eps(RenderMode mode = RenderMode.Vector) => _payloadData is null ? QrEasy.RenderEps(_payload, Options, mode) : QrEasy.RenderEps(_payloadData, Options, mode);
+        public string Eps(RenderMode mode = RenderMode.Vector) => Render(OutputFormat.Eps, new RenderExtras { VectorMode = mode }).GetText();
 
         /// <summary>
         /// Saves PNG to a file.
         /// </summary>
-        public string SavePng(string path) => _payloadData is null ? QR.SavePng(_payload, path, Options) : QR.SavePng(_payloadData, path, Options);
+        public string SavePng(string path) => OutputWriter.Write(path, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves PNG to a stream.
         /// </summary>
-        public void SavePng(Stream stream) {
-            if (_payloadData is null) {
-                QR.SavePng(_payload, stream, Options);
-            } else {
-                QR.SavePng(_payloadData, stream, Options);
-            }
-        }
+        public void SavePng(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Png));
 
         /// <summary>
         /// Saves SVG to a file.
         /// </summary>
-        public string SaveSvg(string path) => _payloadData is null ? QR.SaveSvg(_payload, path, Options) : QR.SaveSvg(_payloadData, path, Options);
+        public string SaveSvg(string path) => OutputWriter.Write(path, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves SVG to a stream.
         /// </summary>
-        public void SaveSvg(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveSvg(_payload, stream, Options);
-            } else {
-                QR.SaveSvg(_payloadData, stream, Options);
-            }
-        }
+        public void SaveSvg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Svg));
 
         /// <summary>
         /// Saves HTML to a file.
         /// </summary>
-        public string SaveHtml(string path, string? title = null) => _payloadData is null ? QR.SaveHtml(_payload, path, Options, title) : QR.SaveHtml(_payloadData, path, Options, title);
+        public string SaveHtml(string path, string? title = null) {
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            return OutputWriter.Write(path, Render(OutputFormat.Html, extras));
+        }
 
         /// <summary>
         /// Saves HTML to a stream.
         /// </summary>
         public void SaveHtml(Stream stream, string? title = null) {
-            if (_payloadData is null) {
-                QR.SaveHtml(_payload, stream, Options, title);
-            } else {
-                QR.SaveHtml(_payloadData, stream, Options, title);
-            }
+            var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+            OutputWriter.Write(stream, Render(OutputFormat.Html, extras));
         }
 
         /// <summary>
         /// Saves JPEG to a file.
         /// </summary>
-        public string SaveJpeg(string path) => _payloadData is null ? QR.SaveJpeg(_payload, path, Options) : QR.SaveJpeg(_payloadData, path, Options);
+        public string SaveJpeg(string path) => OutputWriter.Write(path, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves JPEG to a stream.
         /// </summary>
-        public void SaveJpeg(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveJpeg(_payload, stream, Options);
-            } else {
-                QR.SaveJpeg(_payloadData, stream, Options);
-            }
-        }
+        public void SaveJpeg(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Jpeg));
 
         /// <summary>
         /// Saves WebP to a file.
         /// </summary>
-        public string SaveWebp(string path) => _payloadData is null ? QR.SaveWebp(_payload, path, Options) : QR.SaveWebp(_payloadData, path, Options);
+        public string SaveWebp(string path) => OutputWriter.Write(path, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves WebP to a stream.
         /// </summary>
-        public void SaveWebp(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveWebp(_payload, stream, Options);
-            } else {
-                QR.SaveWebp(_payloadData, stream, Options);
-            }
-        }
+        public void SaveWebp(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Webp));
 
         /// <summary>
         /// Saves BMP to a file.
         /// </summary>
-        public string SaveBmp(string path) => _payloadData is null ? QR.SaveBmp(_payload, path, Options) : QR.SaveBmp(_payloadData, path, Options);
+        public string SaveBmp(string path) => OutputWriter.Write(path, Render(OutputFormat.Bmp));
 
         /// <summary>
         /// Saves BMP to a stream.
         /// </summary>
-        public void SaveBmp(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveBmp(_payload, stream, Options);
-            } else {
-                QR.SaveBmp(_payloadData, stream, Options);
-            }
-        }
+        public void SaveBmp(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Bmp));
 
         /// <summary>
         /// Saves PPM to a file.
         /// </summary>
-        public string SavePpm(string path) => _payloadData is null ? QR.SavePpm(_payload, path, Options) : QR.SavePpm(_payloadData, path, Options);
+        public string SavePpm(string path) => OutputWriter.Write(path, Render(OutputFormat.Ppm));
 
         /// <summary>
         /// Saves PPM to a stream.
         /// </summary>
-        public void SavePpm(Stream stream) {
-            if (_payloadData is null) {
-                QR.SavePpm(_payload, stream, Options);
-            } else {
-                QR.SavePpm(_payloadData, stream, Options);
-            }
-        }
+        public void SavePpm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Ppm));
 
         /// <summary>
         /// Saves PBM to a file.
         /// </summary>
-        public string SavePbm(string path) => _payloadData is null ? QR.SavePbm(_payload, path, Options) : QR.SavePbm(_payloadData, path, Options);
+        public string SavePbm(string path) => OutputWriter.Write(path, Render(OutputFormat.Pbm));
 
         /// <summary>
         /// Saves PBM to a stream.
         /// </summary>
-        public void SavePbm(Stream stream) {
-            if (_payloadData is null) {
-                QR.SavePbm(_payload, stream, Options);
-            } else {
-                QR.SavePbm(_payloadData, stream, Options);
-            }
-        }
+        public void SavePbm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Pbm));
 
         /// <summary>
         /// Saves PGM to a file.
         /// </summary>
-        public string SavePgm(string path) => _payloadData is null ? QR.SavePgm(_payload, path, Options) : QR.SavePgm(_payloadData, path, Options);
+        public string SavePgm(string path) => OutputWriter.Write(path, Render(OutputFormat.Pgm));
 
         /// <summary>
         /// Saves PGM to a stream.
         /// </summary>
-        public void SavePgm(Stream stream) {
-            if (_payloadData is null) {
-                QR.SavePgm(_payload, stream, Options);
-            } else {
-                QR.SavePgm(_payloadData, stream, Options);
-            }
-        }
+        public void SavePgm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Pgm));
 
         /// <summary>
         /// Saves PAM to a file.
         /// </summary>
-        public string SavePam(string path) => _payloadData is null ? QR.SavePam(_payload, path, Options) : QR.SavePam(_payloadData, path, Options);
+        public string SavePam(string path) => OutputWriter.Write(path, Render(OutputFormat.Pam));
 
         /// <summary>
         /// Saves PAM to a stream.
         /// </summary>
-        public void SavePam(Stream stream) {
-            if (_payloadData is null) {
-                QR.SavePam(_payload, stream, Options);
-            } else {
-                QR.SavePam(_payloadData, stream, Options);
-            }
-        }
+        public void SavePam(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Pam));
 
         /// <summary>
         /// Saves XBM to a file.
         /// </summary>
-        public string SaveXbm(string path) => _payloadData is null ? QR.SaveXbm(_payload, path, Options) : QR.SaveXbm(_payloadData, path, Options);
+        public string SaveXbm(string path) => OutputWriter.Write(path, Render(OutputFormat.Xbm));
 
         /// <summary>
         /// Saves XBM to a stream.
         /// </summary>
-        public void SaveXbm(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveXbm(_payload, stream, Options);
-            } else {
-                QR.SaveXbm(_payloadData, stream, Options);
-            }
-        }
+        public void SaveXbm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Xbm));
 
         /// <summary>
         /// Saves XPM to a file.
         /// </summary>
-        public string SaveXpm(string path) => _payloadData is null ? QR.SaveXpm(_payload, path, Options) : QR.SaveXpm(_payloadData, path, Options);
+        public string SaveXpm(string path) => OutputWriter.Write(path, Render(OutputFormat.Xpm));
 
         /// <summary>
         /// Saves XPM to a stream.
         /// </summary>
-        public void SaveXpm(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveXpm(_payload, stream, Options);
-            } else {
-                QR.SaveXpm(_payloadData, stream, Options);
-            }
-        }
+        public void SaveXpm(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Xpm));
 
         /// <summary>
         /// Saves TGA to a file.
         /// </summary>
-        public string SaveTga(string path) => _payloadData is null ? QR.SaveTga(_payload, path, Options) : QR.SaveTga(_payloadData, path, Options);
+        public string SaveTga(string path) => OutputWriter.Write(path, Render(OutputFormat.Tga));
 
         /// <summary>
         /// Saves TGA to a stream.
         /// </summary>
-        public void SaveTga(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveTga(_payload, stream, Options);
-            } else {
-                QR.SaveTga(_payloadData, stream, Options);
-            }
-        }
+        public void SaveTga(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Tga));
 
         /// <summary>
         /// Saves ICO to a file.
         /// </summary>
-        public string SaveIco(string path) => _payloadData is null ? QR.SaveIco(_payload, path, Options) : QR.SaveIco(_payloadData, path, Options);
+        public string SaveIco(string path) => OutputWriter.Write(path, Render(OutputFormat.Ico));
 
         /// <summary>
         /// Saves ICO to a stream.
         /// </summary>
-        public void SaveIco(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveIco(_payload, stream, Options);
-            } else {
-                QR.SaveIco(_payloadData, stream, Options);
-            }
-        }
+        public void SaveIco(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Ico));
 
         /// <summary>
         /// Saves SVGZ to a file.
         /// </summary>
-        public string SaveSvgz(string path) => _payloadData is null ? QR.SaveSvgz(_payload, path, Options) : QR.SaveSvgz(_payloadData, path, Options);
+        public string SaveSvgz(string path) => OutputWriter.Write(path, Render(OutputFormat.Svgz));
 
         /// <summary>
         /// Saves SVGZ to a stream.
         /// </summary>
-        public void SaveSvgz(Stream stream) {
-            if (_payloadData is null) {
-                QR.SaveSvgz(_payload, stream, Options);
-            } else {
-                QR.SaveSvgz(_payloadData, stream, Options);
-            }
-        }
+        public void SaveSvgz(Stream stream) => OutputWriter.Write(stream, Render(OutputFormat.Svgz));
 
         /// <summary>
         /// Saves PDF to a file.
         /// </summary>
     /// <param name="path">Output file path.</param>
         /// <param name="mode">Vector or raster output.</param>
-        public string SavePdf(string path, RenderMode mode = RenderMode.Vector) => _payloadData is null ? QR.SavePdf(_payload, path, Options, mode) : QR.SavePdf(_payloadData, path, Options, mode);
+        public string SavePdf(string path, RenderMode mode = RenderMode.Vector) {
+            return OutputWriter.Write(path, Render(OutputFormat.Pdf, new RenderExtras { VectorMode = mode }));
+        }
 
         /// <summary>
         /// Saves PDF to a stream.
@@ -640,11 +562,7 @@ public static partial class QR {
     /// <param name="stream">Destination stream.</param>
         /// <param name="mode">Vector or raster output.</param>
         public void SavePdf(Stream stream, RenderMode mode = RenderMode.Vector) {
-            if (_payloadData is null) {
-                QR.SavePdf(_payload, stream, Options, mode);
-            } else {
-                QR.SavePdf(_payloadData, stream, Options, mode);
-            }
+            OutputWriter.Write(stream, Render(OutputFormat.Pdf, new RenderExtras { VectorMode = mode }));
         }
 
         /// <summary>
@@ -652,7 +570,9 @@ public static partial class QR {
         /// </summary>
     /// <param name="path">Output file path.</param>
         /// <param name="mode">Vector or raster output.</param>
-        public string SaveEps(string path, RenderMode mode = RenderMode.Vector) => _payloadData is null ? QR.SaveEps(_payload, path, Options, mode) : QR.SaveEps(_payloadData, path, Options, mode);
+        public string SaveEps(string path, RenderMode mode = RenderMode.Vector) {
+            return OutputWriter.Write(path, Render(OutputFormat.Eps, new RenderExtras { VectorMode = mode }));
+        }
 
         /// <summary>
         /// Saves EPS to a stream.
@@ -660,24 +580,22 @@ public static partial class QR {
     /// <param name="stream">Destination stream.</param>
         /// <param name="mode">Vector or raster output.</param>
         public void SaveEps(Stream stream, RenderMode mode = RenderMode.Vector) {
-            if (_payloadData is null) {
-                QR.SaveEps(_payload, stream, Options, mode);
-            } else {
-                QR.SaveEps(_payloadData, stream, Options, mode);
-            }
+            OutputWriter.Write(stream, Render(OutputFormat.Eps, new RenderExtras { VectorMode = mode }));
         }
 
         /// <summary>
         /// Renders ASCII text.
         /// </summary>
-        public string Ascii(MatrixAsciiRenderOptions? asciiOptions = null) => _payloadData is null
-            ? QR.Ascii(_payload, asciiOptions, Options)
-            : QR.Ascii(_payloadData, asciiOptions, Options);
+        public string Ascii(MatrixAsciiRenderOptions? asciiOptions = null) {
+            return Render(OutputFormat.Ascii, new RenderExtras { MatrixAscii = asciiOptions }).GetText();
+        }
 
         /// <summary>
         /// Saves ASCII to a file.
         /// </summary>
-        public string SaveAscii(string path, MatrixAsciiRenderOptions? asciiOptions = null) => Ascii(asciiOptions).WriteText(path);
+        public string SaveAscii(string path, MatrixAsciiRenderOptions? asciiOptions = null) {
+            return OutputWriter.Write(path, Render(OutputFormat.Ascii, new RenderExtras { MatrixAscii = asciiOptions }));
+        }
 
         /// <summary>
         /// Saves based on file extension (.png/.svg/.svgz/.html/.jpg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps). Defaults to PNG when no extension is provided.

--- a/CodeGlyphX/QR.Save.cs
+++ b/CodeGlyphX/QR.Save.cs
@@ -13,447 +13,485 @@ public static partial class QR {
     /// <summary>
     /// Saves a PNG QR to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(string payload, string path, QrEasyOptions? options = null) {
-        return Png(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a PNG QR to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePng(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Png(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a PNG QR to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPngToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves a PNG QR to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePng(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPngToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Png, options));
     }
 
     /// <summary>
     /// Saves an SVG QR to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(string payload, string path, QrEasyOptions? options = null) {
-        return Svg(payload, options).WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves an SVG QR to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvg(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Svg(payload, options).WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves an SVG QR to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(string payload, Stream stream, QrEasyOptions? options = null) {
-        Svg(payload, options).WriteText(stream);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves an SVG QR to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvg(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        Svg(payload, options).WriteText(stream);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Svg, options));
     }
 
     /// <summary>
     /// Saves an HTML QR to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(string payload, string path, QrEasyOptions? options = null, string? title = null) {
-        var html = Html(payload, options);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        return html.WriteText(path);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves an HTML QR to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveHtml(QrPayloadData payload, string path, QrEasyOptions? options = null, string? title = null) {
-        var html = Html(payload, options);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        return html.WriteText(path);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves an HTML QR to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(string payload, Stream stream, QrEasyOptions? options = null, string? title = null) {
-        var html = Html(payload, options);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        html.WriteText(stream);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves an HTML QR to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveHtml(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, string? title = null) {
-        var html = Html(payload, options);
-        if (!string.IsNullOrEmpty(title)) html = html.WrapHtml(title);
-        html.WriteText(stream);
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Html, options, extras));
     }
 
     /// <summary>
     /// Saves a JPEG QR to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(string payload, string path, QrEasyOptions? options = null) {
-        return Jpeg(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a JPEG QR to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveJpeg(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Jpeg(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a JPEG QR to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderJpegToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a JPEG QR to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveJpeg(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderJpegToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Jpeg, options));
     }
 
     /// <summary>
     /// Saves a WebP QR to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(string payload, string path, QrEasyOptions? options = null) {
-        return Webp(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a WebP QR to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveWebp(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Webp(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a WebP QR to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderWebpToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a WebP QR to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveWebp(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderWebpToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Webp, options));
     }
 
     /// <summary>
     /// Saves a BMP QR to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(string payload, string path, QrEasyOptions? options = null) {
-        return Bmp(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Bmp, options));
     }
 
     /// <summary>
     /// Saves a BMP QR to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveBmp(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        return Bmp(payload, options).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Bmp, options));
     }
 
     /// <summary>
     /// Saves a BMP QR to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderBmpToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Bmp, options));
     }
 
     /// <summary>
     /// Saves a BMP QR to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveBmp(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderBmpToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Bmp, options));
     }
 
     /// <summary>
     /// Renders a QR code as PPM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(string payload, string path, QrEasyOptions? options = null) {
-        var ppm = Ppm(payload, options);
-        return ppm.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Ppm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PPM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePpm(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var ppm = Ppm(payload, options);
-        return ppm.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Ppm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PPM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPpmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Ppm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PPM and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePpm(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPpmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Ppm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PBM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(string payload, string path, QrEasyOptions? options = null) {
-        var pbm = Pbm(payload, options);
-        return pbm.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PBM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePbm(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var pbm = Pbm(payload, options);
-        return pbm.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PBM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPbmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PBM and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePbm(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPbmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PGM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(string payload, string path, QrEasyOptions? options = null) {
-        var pgm = Pgm(payload, options);
-        return pgm.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pgm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PGM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePgm(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var pgm = Pgm(payload, options);
-        return pgm.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pgm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PGM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPgmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pgm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PGM and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePgm(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPgmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pgm, options));
     }
 
     /// <summary>
     /// Renders a QR code as PAM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(string payload, string path, QrEasyOptions? options = null) {
-        var pam = Pam(payload, options);
-        return pam.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pam, options));
     }
 
     /// <summary>
     /// Renders a QR code as PAM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePam(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var pam = Pam(payload, options);
-        return pam.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pam, options));
     }
 
     /// <summary>
     /// Renders a QR code as PAM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPamToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pam, options));
     }
 
     /// <summary>
     /// Renders a QR code as PAM and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePam(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderPamToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pam, options));
     }
 
     /// <summary>
     /// Renders a QR code as XBM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(string payload, string path, QrEasyOptions? options = null) {
-        var xbm = Xbm(payload, options);
-        return xbm.WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Xbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XBM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXbm(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var xbm = Xbm(payload, options);
-        return xbm.WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Xbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XBM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderXbmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Xbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XBM and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXbm(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderXbmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Xbm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XPM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(string payload, string path, QrEasyOptions? options = null) {
-        var xpm = Xpm(payload, options);
-        return xpm.WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Xpm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XPM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveXpm(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var xpm = Xpm(payload, options);
-        return xpm.WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Xpm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XPM and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderXpmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Xpm, options));
     }
 
     /// <summary>
     /// Renders a QR code as XPM and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveXpm(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderXpmToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Xpm, options));
     }
 
     /// <summary>
     /// Renders a QR code as TGA and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(string payload, string path, QrEasyOptions? options = null) {
-        var tga = Tga(payload, options);
-        return tga.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Tga, options));
     }
 
     /// <summary>
     /// Renders a QR code as TGA and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveTga(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var tga = Tga(payload, options);
-        return tga.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Tga, options));
     }
 
     /// <summary>
     /// Renders a QR code as TGA and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderTgaToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Tga, options));
     }
 
     /// <summary>
     /// Renders a QR code as TGA and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveTga(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderTgaToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Tga, options));
     }
 
     /// <summary>
     /// Renders a QR code as ICO and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(string payload, string path, QrEasyOptions? options = null) {
-        var ico = Ico(payload, options);
-        return ico.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Ico, options));
     }
 
     /// <summary>
     /// Renders a QR code as ICO and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveIco(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var ico = Ico(payload, options);
-        return ico.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Ico, options));
     }
 
     /// <summary>
     /// Renders a QR code as ICO and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderIcoToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Ico, options));
     }
 
     /// <summary>
     /// Renders a QR code as ICO and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveIco(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderIcoToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Ico, options));
     }
 
     /// <summary>
     /// Renders a QR code as SVGZ and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(string payload, string path, QrEasyOptions? options = null) {
-        var svgz = Svgz(payload, options);
-        return svgz.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Svgz, options));
     }
 
     /// <summary>
     /// Renders a QR code as SVGZ and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveSvgz(QrPayloadData payload, string path, QrEasyOptions? options = null) {
-        var svgz = Svgz(payload, options);
-        return svgz.WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Svgz, options));
     }
 
     /// <summary>
     /// Renders a QR code as SVGZ and writes it to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(string payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderSvgzToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Svgz, options));
     }
 
     /// <summary>
     /// Renders a QR code as SVGZ and writes it to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveSvgz(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
-        QrEasy.RenderSvgzToStream(payload, stream, options);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Svgz, options));
     }
 
     /// <summary>
@@ -463,8 +501,9 @@ public static partial class QR {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        return Pdf(payload, options, mode).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -474,8 +513,9 @@ public static partial class QR {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SavePdf(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        return Pdf(payload, options, mode).WriteBinary(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -485,8 +525,9 @@ public static partial class QR {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        QrEasy.RenderPdfToStream(payload, stream, options, mode);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -496,8 +537,9 @@ public static partial class QR {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SavePdf(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        QrEasy.RenderPdfToStream(payload, stream, options, mode);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -507,8 +549,9 @@ public static partial class QR {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        return Eps(payload, options, mode).WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -518,8 +561,9 @@ public static partial class QR {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SaveEps(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        return Eps(payload, options, mode).WriteText(path);
+        return OutputWriter.Write(path, Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -529,8 +573,9 @@ public static partial class QR {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        QrEasy.RenderEpsToStream(payload, stream, options, mode);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>
@@ -540,8 +585,9 @@ public static partial class QR {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void SaveEps(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        QrEasy.RenderEpsToStream(payload, stream, options, mode);
+        OutputWriter.Write(stream, Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }));
     }
 
     /// <summary>

--- a/CodeGlyphX/QR.Save.cs
+++ b/CodeGlyphX/QR.Save.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Threading;
-using CodeGlyphX.Internal;
 using CodeGlyphX.Payloads;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
@@ -546,51 +545,33 @@ public static partial class QR {
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves a QR code to a file based on the file extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(string payload, string path, QrEasyOptions? options = null, string? title = null) {
-        return SaveByExtension(path, payload, null, options, title);
+    public static string Save(string payload, string path, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = QrCode.Render(payload, format, options, extras);
+        return OutputWriter.Write(path, output);
     }
 
     /// <summary>
-    /// Detects a payload type and saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Detects a payload type and saves a QR code to a file based on the file extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string SaveAuto(string payload, string path, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, string? title = null) {
-        var detected = QrPayloads.Detect(payload, detectOptions);
-        return SaveByExtension(path, detected.Text, detected, options, title);
+    public static string SaveAuto(string payload, string path, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = QrCode.RenderAuto(payload, format, detectOptions, options, extras);
+        return OutputWriter.Write(path, output);
     }
 
     /// <summary>
-    /// Saves a QR code to a file based on the file extension (.png/.webp/.svg/.svgz/.svg.gz/.html/.htm/.jpg/.jpeg/.bmp/.ppm/.pbm/.pgm/.pam/.xbm/.xpm/.tga/.ico/.pdf/.eps/.ps).
+    /// Saves a QR code to a file based on the file extension.
     /// Defaults to PNG when no extension is provided.
     /// </summary>
-    public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, string? title = null) {
+    public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderExtras? extras = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
-        return SaveByExtension(path, payload.Text, payload, options, title);
-    }
-
-    private static string SaveByExtension(string path, string payload, QrPayloadData? payloadData, QrEasyOptions? options, string? title) {
-        return SaveByExtensionHelper.Save(path, new SaveByExtensionHandlers {
-            Default = () => payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options),
-            Png = () => payloadData is null ? SavePng(payload, path, options) : SavePng(payloadData, path, options),
-            Webp = () => payloadData is null ? SaveWebp(payload, path, options) : SaveWebp(payloadData, path, options),
-            Svg = () => payloadData is null ? SaveSvg(payload, path, options) : SaveSvg(payloadData, path, options),
-            Svgz = () => payloadData is null ? SaveSvgz(payload, path, options) : SaveSvgz(payloadData, path, options),
-            Html = () => payloadData is null ? SaveHtml(payload, path, options, title) : SaveHtml(payloadData, path, options, title),
-            Jpeg = () => payloadData is null ? SaveJpeg(payload, path, options) : SaveJpeg(payloadData, path, options),
-            Bmp = () => payloadData is null ? SaveBmp(payload, path, options) : SaveBmp(payloadData, path, options),
-            Ppm = () => payloadData is null ? SavePpm(payload, path, options) : SavePpm(payloadData, path, options),
-            Pbm = () => payloadData is null ? SavePbm(payload, path, options) : SavePbm(payloadData, path, options),
-            Pgm = () => payloadData is null ? SavePgm(payload, path, options) : SavePgm(payloadData, path, options),
-            Pam = () => payloadData is null ? SavePam(payload, path, options) : SavePam(payloadData, path, options),
-            Xbm = () => payloadData is null ? SaveXbm(payload, path, options) : SaveXbm(payloadData, path, options),
-            Xpm = () => payloadData is null ? SaveXpm(payload, path, options) : SaveXpm(payloadData, path, options),
-            Tga = () => payloadData is null ? SaveTga(payload, path, options) : SaveTga(payloadData, path, options),
-            Ico = () => payloadData is null ? SaveIco(payload, path, options) : SaveIco(payloadData, path, options),
-            Pdf = () => payloadData is null ? SavePdf(payload, path, options) : SavePdf(payloadData, path, options),
-            Eps = () => payloadData is null ? SaveEps(payload, path, options) : SaveEps(payloadData, path, options)
-        });
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = QrCode.Render(payload, format, options, extras);
+        return OutputWriter.Write(path, output);
     }
 }

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -53,260 +53,317 @@ public static partial class QR {
     /// </summary>
     public static QrCode Encode(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.Encode(payload, options);
 
+    private static RenderedOutput Render(string payload, OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        return QrCode.Render(payload, format, options, extras);
+    }
+
+    private static RenderedOutput RenderAuto(string payload, OutputFormat format, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        return QrCode.RenderAuto(payload, format, detectOptions, options, extras);
+    }
+
+    private static RenderedOutput Render(QrPayloadData payload, OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        return QrCode.Render(payload, format, options, extras);
+    }
+
     /// <summary>
     /// Renders a QR code as PNG.
     /// </summary>
-    public static byte[] Png(string payload, QrEasyOptions? options = null) => QrEasy.RenderPng(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Png(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Png, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PngAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderPngAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Png, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as PNG for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Png(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPng(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Png(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Png, options).Data;
 
     /// <summary>
     /// Renders a QR code as SVG.
     /// </summary>
-    public static string Svg(string payload, QrEasyOptions? options = null) => QrEasy.RenderSvg(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Svg(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Svg, options).GetText();
 
     /// <summary>
     /// Detects a payload type and renders a QR code as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string SvgAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderSvgAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Svg, detectOptions, options).GetText();
     }
 
     /// <summary>
     /// Renders a QR code as SVG for a payload with embedded defaults.
     /// </summary>
-    public static string Svg(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderSvg(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Svg(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Svg, options).GetText();
 
     /// <summary>
     /// Renders a QR code as HTML.
     /// </summary>
-    public static string Html(string payload, QrEasyOptions? options = null) => QrEasy.RenderHtml(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Html(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Html, options).GetText();
 
     /// <summary>
     /// Detects a payload type and renders a QR code as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string HtmlAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderHtmlAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Html, detectOptions, options).GetText();
     }
 
     /// <summary>
     /// Renders a QR code as HTML for a payload with embedded defaults.
     /// </summary>
-    public static string Html(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderHtml(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Html(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Html, options).GetText();
 
     /// <summary>
     /// Renders a QR code as JPEG.
     /// </summary>
-    public static byte[] Jpeg(string payload, QrEasyOptions? options = null) => QrEasy.RenderJpeg(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Jpeg(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Jpeg, options).Data;
 
     /// <summary>
     /// Renders a QR code as WebP.
     /// </summary>
-    public static byte[] Webp(string payload, QrEasyOptions? options = null) => QrEasy.RenderWebp(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Webp(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Webp, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] JpegAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderJpegAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Jpeg, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Detects a payload type and renders a QR code as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] WebpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderWebpAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Webp, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as JPEG for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Jpeg(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderJpeg(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Jpeg(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Jpeg, options).Data;
 
     /// <summary>
     /// Renders a QR code as WebP for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Webp(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderWebp(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Webp(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Webp, options).Data;
 
     /// <summary>
     /// Renders a QR code as BMP.
     /// </summary>
-    public static byte[] Bmp(string payload, QrEasyOptions? options = null) => QrEasy.RenderBmp(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Bmp(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Bmp, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] BmpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderBmpAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Bmp, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as BMP for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Bmp(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderBmp(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Bmp(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Bmp, options).Data;
 
     /// <summary>
     /// Renders a QR code as PPM.
     /// </summary>
-    public static byte[] Ppm(string payload, QrEasyOptions? options = null) => QrEasy.RenderPpm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Ppm(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Ppm, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PpmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderPpmAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Ppm, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as PPM for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Ppm(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPpm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Ppm(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Ppm, options).Data;
 
     /// <summary>
     /// Renders a QR code as PBM.
     /// </summary>
-    public static byte[] Pbm(string payload, QrEasyOptions? options = null) => QrEasy.RenderPbm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pbm(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Pbm, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PbmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderPbmAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Pbm, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as PBM for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Pbm(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPbm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pbm(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Pbm, options).Data;
 
     /// <summary>
     /// Renders a QR code as PGM.
     /// </summary>
-    public static byte[] Pgm(string payload, QrEasyOptions? options = null) => QrEasy.RenderPgm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pgm(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Pgm, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PgmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderPgmAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Pgm, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as PGM for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Pgm(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPgm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pgm(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Pgm, options).Data;
 
     /// <summary>
     /// Renders a QR code as PAM.
     /// </summary>
-    public static byte[] Pam(string payload, QrEasyOptions? options = null) => QrEasy.RenderPam(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pam(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Pam, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PamAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderPamAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Pam, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as PAM for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Pam(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderPam(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pam(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Pam, options).Data;
 
     /// <summary>
     /// Renders a QR code as XBM.
     /// </summary>
-    public static string Xbm(string payload, QrEasyOptions? options = null) => QrEasy.RenderXbm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Xbm(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Xbm, options).GetText();
 
     /// <summary>
     /// Detects a payload type and renders a QR code as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string XbmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderXbmAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Xbm, detectOptions, options).GetText();
     }
 
     /// <summary>
     /// Renders a QR code as XBM for a payload with embedded defaults.
     /// </summary>
-    public static string Xbm(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderXbm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Xbm(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Xbm, options).GetText();
 
     /// <summary>
     /// Renders a QR code as XPM.
     /// </summary>
-    public static string Xpm(string payload, QrEasyOptions? options = null) => QrEasy.RenderXpm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Xpm(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Xpm, options).GetText();
 
     /// <summary>
     /// Detects a payload type and renders a QR code as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string XpmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderXpmAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Xpm, detectOptions, options).GetText();
     }
 
     /// <summary>
     /// Renders a QR code as XPM for a payload with embedded defaults.
     /// </summary>
-    public static string Xpm(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderXpm(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Xpm(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Xpm, options).GetText();
 
     /// <summary>
     /// Renders a QR code as TGA.
     /// </summary>
-    public static byte[] Tga(string payload, QrEasyOptions? options = null) => QrEasy.RenderTga(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Tga(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Tga, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] TgaAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderTgaAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Tga, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as TGA for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Tga(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderTga(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Tga(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Tga, options).Data;
 
     /// <summary>
     /// Renders a QR code as ICO.
     /// </summary>
-    public static byte[] Ico(string payload, QrEasyOptions? options = null) => QrEasy.RenderIco(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Ico(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Ico, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] IcoAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderIcoAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Ico, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as ICO for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Ico(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderIco(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Ico(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Ico, options).Data;
 
     /// <summary>
     /// Renders a QR code as SVGZ.
     /// </summary>
-    public static byte[] Svgz(string payload, QrEasyOptions? options = null) => QrEasy.RenderSvgz(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Svgz(string payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Svgz, options).Data;
 
     /// <summary>
     /// Detects a payload type and renders a QR code as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] SvgzAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderSvgzAuto(payload, detectOptions, options);
+        return RenderAuto(payload, OutputFormat.Svgz, detectOptions, options).Data;
     }
 
     /// <summary>
     /// Renders a QR code as SVGZ for a payload with embedded defaults.
     /// </summary>
-    public static byte[] Svgz(QrPayloadData payload, QrEasyOptions? options = null) => QrEasy.RenderSvgz(payload, options);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Svgz(QrPayloadData payload, QrEasyOptions? options = null) => Render(payload, OutputFormat.Svgz, options).Data;
 
     /// <summary>
     /// Renders a QR code as PDF.
@@ -314,7 +371,10 @@ public static partial class QR {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
-    public static byte[] Pdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderPdf(payload, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }).Data;
+    }
 
     /// <summary>
     /// Detects a payload type and renders a QR code as PDF.
@@ -323,8 +383,9 @@ public static partial class QR {
     /// <param name="detectOptions">Payload detection options.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] PdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        return QrEasy.RenderPdfAuto(payload, detectOptions, options, mode);
+        return RenderAuto(payload, OutputFormat.Pdf, detectOptions, options, new RenderExtras { VectorMode = mode }).Data;
     }
 
     /// <summary>
@@ -333,7 +394,10 @@ public static partial class QR {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
-    public static byte[] Pdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderPdf(payload, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static byte[] Pdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Render(payload, OutputFormat.Pdf, options, new RenderExtras { VectorMode = mode }).Data;
+    }
 
     /// <summary>
     /// Renders a QR code as EPS.
@@ -341,7 +405,10 @@ public static partial class QR {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
-    public static string Eps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderEps(payload, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Eps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }).GetText();
+    }
 
     /// <summary>
     /// Detects a payload type and renders a QR code as EPS.
@@ -350,8 +417,9 @@ public static partial class QR {
     /// <param name="detectOptions">Payload detection options.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string EpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
-        return QrEasy.RenderEpsAuto(payload, detectOptions, options, mode);
+        return RenderAuto(payload, OutputFormat.Eps, detectOptions, options, new RenderExtras { VectorMode = mode }).GetText();
     }
 
     /// <summary>
@@ -360,26 +428,32 @@ public static partial class QR {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
-    public static string Eps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) => QrEasy.RenderEps(payload, options, mode);
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
+    public static string Eps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
+        return Render(payload, OutputFormat.Eps, options, new RenderExtras { VectorMode = mode }).GetText();
+    }
 
     /// <summary>
     /// Renders a QR code as ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(string payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderAscii(payload, asciiOptions, options);
+        return Render(payload, OutputFormat.Ascii, options, new RenderExtras { MatrixAscii = asciiOptions }).GetText();
     }
 
     /// <summary>
     /// Detects a payload type and renders a QR code as ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string AsciiAuto(string payload, QrPayloadDetectOptions? detectOptions = null, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderAsciiAuto(payload, detectOptions, asciiOptions, options);
+        return RenderAuto(payload, OutputFormat.Ascii, detectOptions, options, new RenderExtras { MatrixAscii = asciiOptions }).GetText();
     }
 
     /// <summary>
     /// Renders a QR code as ASCII text for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(QrPayloadData payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
-        return QrEasy.RenderAscii(payload, asciiOptions, options);
+        return Render(payload, OutputFormat.Ascii, options, new RenderExtras { MatrixAscii = asciiOptions }).GetText();
     }
 }

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -13,7 +13,7 @@ namespace CodeGlyphX;
 /// Simple QR helpers with fluent and static APIs.
 /// </summary>
 /// <remarks>
-/// Use <see cref="Save(string,string,CodeGlyphX.QrEasyOptions,string)"/> to pick the output format by file extension.
+/// Use <see cref="Save(string,string,CodeGlyphX.QrEasyOptions,CodeGlyphX.Rendering.RenderExtras)"/> to pick the output format by file extension.
 /// </remarks>
 /// <example>
 /// <code>

--- a/CodeGlyphX/QrCode.cs
+++ b/CodeGlyphX/QrCode.cs
@@ -119,7 +119,27 @@ public sealed class QrCode {
     /// <summary>
     /// Saves a payload to a file, choosing the output format based on file extension.
     /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(string payload, string path, QrEasyOptions? options, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
+        var output = Render(payload, OutputFormatInfo.Resolve(path, OutputFormat.Png), options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves a payload to a file, choosing the output format based on file extension.
+    /// </summary>
     public static string Save(string payload, string path, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var output = Render(payload, OutputFormatInfo.Resolve(path, OutputFormat.Png), options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves a payload with embedded defaults to a file, choosing the output format based on file extension.
+    /// </summary>
+    [Obsolete("Use the overload with RenderExtras and set HtmlTitle instead.")]
+    public static string Save(QrPayloadData payload, string path, QrEasyOptions? options, string? title) {
+        var extras = string.IsNullOrEmpty(title) ? null : new RenderExtras { HtmlTitle = title };
         var output = Render(payload, OutputFormatInfo.Resolve(path, OutputFormat.Png), options, extras);
         return OutputWriter.Write(path, output);
     }

--- a/CodeGlyphX/QrCode.cs
+++ b/CodeGlyphX/QrCode.cs
@@ -1,4 +1,6 @@
 using System;
+using CodeGlyphX.Payloads;
+using CodeGlyphX.Rendering;
 
 namespace CodeGlyphX;
 
@@ -43,5 +45,90 @@ public sealed class QrCode {
         Version = version;
         ErrorCorrectionLevel = errorCorrectionLevel;
         Mask = mask;
+    }
+
+    /// <summary>
+    /// Encodes a payload into a <see cref="QrCode"/>.
+    /// </summary>
+    public static QrCode Encode(string payload, QrEasyOptions? options = null) {
+        return QrEasy.Encode(payload, options);
+    }
+
+    /// <summary>
+    /// Detects a payload type and encodes it into a <see cref="QrCode"/>.
+    /// </summary>
+    public static QrCode EncodeAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
+        return QrEasy.EncodeAuto(payload, detectOptions, options);
+    }
+
+    /// <summary>
+    /// Encodes a payload with embedded defaults into a <see cref="QrCode"/>.
+    /// </summary>
+    public static QrCode Encode(QrPayloadData payload, QrEasyOptions? options = null) {
+        return QrEasy.Encode(payload, options);
+    }
+
+    /// <summary>
+    /// Renders this QR code to the requested output format.
+    /// </summary>
+    public RenderedOutput Render(OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        return QrEasy.Render(this, format, options, extras);
+    }
+
+    /// <summary>
+    /// Renders a payload to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(string payload, OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var qr = Encode(payload, options);
+        return QrEasy.Render(qr, format, options, extras);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code.
+    /// </summary>
+    public static RenderedOutput RenderAuto(string payload, OutputFormat format, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var qr = EncodeAuto(payload, detectOptions, options);
+        return QrEasy.Render(qr, format, options, extras);
+    }
+
+    /// <summary>
+    /// Renders a payload with embedded defaults to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(QrPayloadData payload, OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var qr = Encode(payload, options);
+        return QrEasy.Render(qr, format, options, extras);
+    }
+
+    /// <summary>
+    /// Saves this QR code to a file, choosing the output format based on file extension.
+    /// </summary>
+    public string Save(string path, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(format, options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves this QR code to a stream in the specified format.
+    /// </summary>
+    public void Save(OutputFormat format, System.IO.Stream stream, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var output = Render(format, options, extras);
+        OutputWriter.Write(stream, output);
+    }
+
+    /// <summary>
+    /// Saves a payload to a file, choosing the output format based on file extension.
+    /// </summary>
+    public static string Save(string payload, string path, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var output = Render(payload, OutputFormatInfo.Resolve(path, OutputFormat.Png), options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves a payload with embedded defaults to a file, choosing the output format based on file extension.
+    /// </summary>
+    public static string Save(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        var output = Render(payload, OutputFormatInfo.Resolve(path, OutputFormat.Png), options, extras);
+        return OutputWriter.Write(path, output);
     }
 }

--- a/CodeGlyphX/QrEasy.Render.Core.cs
+++ b/CodeGlyphX/QrEasy.Render.Core.cs
@@ -28,6 +28,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPng(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -38,6 +39,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as PNG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPngAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -47,6 +49,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PNG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPngToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -61,6 +64,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPngToFile(string payload, string path, QrEasyOptions? options = null) {
         var png = RenderPng(payload, options);
         return RenderIO.WriteBinary(path, png);
@@ -73,6 +77,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPngToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var png = RenderPng(payload, options);
         return RenderIO.WriteBinary(path, png);
@@ -81,6 +86,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PNG for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPng(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -92,6 +98,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PNG to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPngToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -103,6 +110,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvg(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -125,6 +133,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as SVG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -138,6 +147,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgToFile(string payload, string path, QrEasyOptions? options = null) {
         var svg = RenderSvg(payload, options);
         return RenderIO.WriteText(path, svg);
@@ -150,6 +160,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var svg = RenderSvg(payload, options);
         return RenderIO.WriteText(path, svg);
@@ -158,6 +169,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVG for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvg(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -181,6 +193,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as HTML (table-based).
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderHtml(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -204,6 +217,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as HTML.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderHtmlAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -217,6 +231,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderHtmlToFile(string payload, string path, QrEasyOptions? options = null) {
         var html = RenderHtml(payload, options);
         return RenderIO.WriteText(path, html);
@@ -229,6 +244,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderHtmlToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var html = RenderHtml(payload, options);
         return RenderIO.WriteText(path, html);
@@ -237,6 +253,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as HTML for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderHtml(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -261,6 +278,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderJpeg(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -271,6 +289,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderWebp(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -281,6 +300,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as JPEG.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderJpegAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -290,6 +310,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as WebP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderWebpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -299,6 +320,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as JPEG to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderJpegToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -309,6 +331,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as WebP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderWebpToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -323,6 +346,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderJpegToFile(string payload, string path, QrEasyOptions? options = null) {
         var jpeg = RenderJpeg(payload, options);
         return RenderIO.WriteBinary(path, jpeg);
@@ -335,6 +359,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderWebpToFile(string payload, string path, QrEasyOptions? options = null) {
         var webp = RenderWebp(payload, options);
         return RenderIO.WriteBinary(path, webp);
@@ -347,6 +372,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderJpegToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var jpeg = RenderJpeg(payload, options);
         return RenderIO.WriteBinary(path, jpeg);
@@ -359,6 +385,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <returns>The output file path.</returns>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderWebpToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var webp = RenderWebp(payload, options);
         return RenderIO.WriteBinary(path, webp);
@@ -367,6 +394,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as JPEG for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderJpeg(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -378,6 +406,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as WebP for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderWebp(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -389,6 +418,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as JPEG to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderJpegToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -400,6 +430,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as WebP to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderWebpToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -411,6 +442,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderBmp(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -421,6 +453,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as BMP.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderBmpAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -430,6 +463,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as BMP to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderBmpToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -440,6 +474,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as BMP and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderBmpToFile(string payload, string path, QrEasyOptions? options = null) {
         var bmp = RenderBmp(payload, options);
         return RenderIO.WriteBinary(path, bmp);
@@ -448,6 +483,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as BMP and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderBmpToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var bmp = RenderBmp(payload, options);
         return RenderIO.WriteBinary(path, bmp);
@@ -456,6 +492,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as BMP for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderBmp(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -467,6 +504,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as BMP to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderBmpToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -478,6 +516,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPpm(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -488,6 +527,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as PPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPpmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -497,6 +537,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPpmToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -507,6 +548,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PPM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPpmToFile(string payload, string path, QrEasyOptions? options = null) {
         var ppm = RenderPpm(payload, options);
         return RenderIO.WriteBinary(path, ppm);
@@ -515,6 +557,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PPM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPpmToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var ppm = RenderPpm(payload, options);
         return RenderIO.WriteBinary(path, ppm);
@@ -523,6 +566,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PPM for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPpm(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -534,6 +578,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PPM to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPpmToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -545,6 +590,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPbm(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -555,6 +601,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as PBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPbmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -564,6 +611,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPbmToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -574,6 +622,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PBM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPbmToFile(string payload, string path, QrEasyOptions? options = null) {
         var pbm = RenderPbm(payload, options);
         return RenderIO.WriteBinary(path, pbm);
@@ -582,6 +631,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PBM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPbmToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var pbm = RenderPbm(payload, options);
         return RenderIO.WriteBinary(path, pbm);
@@ -590,6 +640,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PBM for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPbm(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -601,6 +652,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PBM to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPbmToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -612,6 +664,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPgm(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -622,6 +675,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as PGM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPgmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -631,6 +685,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PGM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPgmToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -641,6 +696,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PGM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPgmToFile(string payload, string path, QrEasyOptions? options = null) {
         var pgm = RenderPgm(payload, options);
         return RenderIO.WriteBinary(path, pgm);
@@ -649,6 +705,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PGM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPgmToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var pgm = RenderPgm(payload, options);
         return RenderIO.WriteBinary(path, pgm);
@@ -657,6 +714,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PGM for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPgm(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -668,6 +726,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PGM to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPgmToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -679,6 +738,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPam(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);

--- a/CodeGlyphX/QrEasy.Render.Extras.cs
+++ b/CodeGlyphX/QrEasy.Render.Extras.cs
@@ -27,6 +27,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as PAM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPamAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -36,6 +37,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PAM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPamToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -46,6 +48,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PAM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPamToFile(string payload, string path, QrEasyOptions? options = null) {
         var pam = RenderPam(payload, options);
         return RenderIO.WriteBinary(path, pam);
@@ -54,6 +57,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PAM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPamToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var pam = RenderPam(payload, options);
         return RenderIO.WriteBinary(path, pam);
@@ -62,6 +66,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PAM for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPam(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -73,6 +78,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as PAM to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPamToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -84,6 +90,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbm(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -94,6 +101,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as XBM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -103,6 +111,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XBM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderXbmToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var xbm = RenderXbm(payload, options);
         xbm.WriteText(stream);
@@ -111,6 +120,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XBM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbmToFile(string payload, string path, QrEasyOptions? options = null) {
         var xbm = RenderXbm(payload, options);
         return xbm.WriteText(path);
@@ -119,6 +129,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XBM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbmToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var xbm = RenderXbm(payload, options);
         return xbm.WriteText(path);
@@ -127,6 +138,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XBM for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXbm(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -138,6 +150,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XBM to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderXbmToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var xbm = RenderXbm(payload, options);
@@ -147,6 +160,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpm(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -157,6 +171,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as XPM.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpmAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -166,6 +181,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XPM to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderXpmToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var xpm = RenderXpm(payload, options);
         xpm.WriteText(stream);
@@ -174,6 +190,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XPM and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpmToFile(string payload, string path, QrEasyOptions? options = null) {
         var xpm = RenderXpm(payload, options);
         return xpm.WriteText(path);
@@ -182,6 +199,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XPM and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpmToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var xpm = RenderXpm(payload, options);
         return xpm.WriteText(path);
@@ -190,6 +208,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XPM for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderXpm(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -201,6 +220,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as XPM to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderXpmToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var xpm = RenderXpm(payload, options);
@@ -210,6 +230,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderTga(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -220,6 +241,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as TGA.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderTgaAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -229,6 +251,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as TGA to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderTgaToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -239,6 +262,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as TGA and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderTgaToFile(string payload, string path, QrEasyOptions? options = null) {
         var tga = RenderTga(payload, options);
         return RenderIO.WriteBinary(path, tga);
@@ -247,6 +271,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as TGA and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderTgaToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var tga = RenderTga(payload, options);
         return RenderIO.WriteBinary(path, tga);
@@ -255,6 +280,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as TGA for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderTga(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -266,6 +292,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as TGA to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderTgaToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -277,6 +304,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderIco(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -287,6 +315,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as ICO.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderIcoAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -296,6 +325,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ICO to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderIcoToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -306,6 +336,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ICO and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderIcoToFile(string payload, string path, QrEasyOptions? options = null) {
         var ico = RenderIco(payload, options);
         return RenderIO.WriteBinary(path, ico);
@@ -314,6 +345,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ICO and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderIcoToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var ico = RenderIco(payload, options);
         return RenderIO.WriteBinary(path, ico);
@@ -322,6 +354,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ICO for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderIco(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -333,6 +366,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ICO to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderIcoToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -344,6 +378,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderSvgz(string payload, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -354,6 +389,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as SVGZ.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderSvgzAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -363,6 +399,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVGZ to a stream.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderSvgzToStream(string payload, Stream stream, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -373,6 +410,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVGZ and writes it to a file.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgzToFile(string payload, string path, QrEasyOptions? options = null) {
         var svgz = RenderSvgz(payload, options);
         return RenderIO.WriteBinary(path, svgz);
@@ -381,6 +419,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVGZ and writes it to a file for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderSvgzToFile(QrPayloadData payload, string path, QrEasyOptions? options = null) {
         var svgz = RenderSvgz(payload, options);
         return RenderIO.WriteBinary(path, svgz);
@@ -389,6 +428,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVGZ for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderSvgz(QrPayloadData payload, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -400,6 +440,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as SVGZ to a stream for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderSvgzToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -414,6 +455,7 @@ public static partial class QrEasy {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPdf(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -428,6 +470,7 @@ public static partial class QrEasy {
     /// <param name="detectOptions">Payload detection options.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPdfAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -441,6 +484,7 @@ public static partial class QrEasy {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPdfToStream(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -455,6 +499,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPdfToFile(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var pdf = RenderPdf(payload, options, mode);
         return RenderIO.WriteBinary(path, pdf);
@@ -467,6 +512,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderPdfToFile(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var pdf = RenderPdf(payload, options, mode);
         return RenderIO.WriteBinary(path, pdf);
@@ -478,6 +524,7 @@ public static partial class QrEasy {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static byte[] RenderPdf(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -493,6 +540,7 @@ public static partial class QrEasy {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderPdfToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -507,6 +555,7 @@ public static partial class QrEasy {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderEps(string payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -521,6 +570,7 @@ public static partial class QrEasy {
     /// <param name="detectOptions">Payload detection options.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderEpsAuto(string payload, QrPayloadDetectOptions? detectOptions = null, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -534,6 +584,7 @@ public static partial class QrEasy {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderEpsToStream(string payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -548,6 +599,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderEpsToFile(string payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = RenderEps(payload, options, mode);
         return RenderIO.WriteText(path, eps);
@@ -560,6 +612,7 @@ public static partial class QrEasy {
     /// <param name="path">Output file path.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderEpsToFile(QrPayloadData payload, string path, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         var eps = RenderEps(payload, options, mode);
         return RenderIO.WriteText(path, eps);
@@ -571,6 +624,7 @@ public static partial class QrEasy {
     /// <param name="payload">The payload text.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderEps(QrPayloadData payload, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -586,6 +640,7 @@ public static partial class QrEasy {
     /// <param name="stream">Destination stream.</param>
     /// <param name="options">Optional rendering options.</param>
     /// <param name="mode">Vector or raster output.</param>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static void RenderEpsToStream(QrPayloadData payload, Stream stream, QrEasyOptions? options = null, RenderMode mode = RenderMode.Vector) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -597,6 +652,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderAscii(string payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
@@ -607,6 +663,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Detects a payload type and renders a QR code as ASCII text.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderAsciiAuto(string payload, QrPayloadDetectOptions? detectOptions = null, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var detected = QrPayloads.Detect(payload, detectOptions);
@@ -616,6 +673,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as ASCII text for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderAscii(QrPayloadData payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
         if (payload is null) throw new ArgumentNullException(nameof(payload));
         var opts = MergeOptions(payload, options);
@@ -627,6 +685,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as console-friendly ASCII using scan-oriented defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderAsciiConsole(
         string payload,
         int scale = 4,
@@ -641,6 +700,7 @@ public static partial class QrEasy {
     /// <summary>
     /// Renders a QR code as console-friendly ASCII using scan-oriented defaults for a payload with embedded defaults.
     /// </summary>
+    [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string RenderAsciiConsole(
         QrPayloadData payload,
         int scale = 4,

--- a/CodeGlyphX/QrEasy.Render.Generic.cs
+++ b/CodeGlyphX/QrEasy.Render.Generic.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Text;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pam;
+using CodeGlyphX.Rendering.Pbm;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Pgm;
+using CodeGlyphX.Rendering.Ppm;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+using CodeGlyphX.Rendering.Svgz;
+using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Webp;
+using CodeGlyphX.Rendering.Xbm;
+using CodeGlyphX.Rendering.Xpm;
+
+namespace CodeGlyphX;
+
+public static partial class QrEasy {
+    internal static RenderedOutput Render(QrCode qr, OutputFormat format, QrEasyOptions? options = null, RenderExtras? extras = null) {
+        if (qr is null) throw new ArgumentNullException(nameof(qr));
+        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
+
+        var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
+        switch (format) {
+            case OutputFormat.Png: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrPngRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Svg: {
+                var render = BuildSvgOptions(opts, qr.Modules.Width);
+                return RenderedOutput.FromText(format, SvgQrRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Svgz: {
+                var render = BuildSvgOptions(opts, qr.Modules.Width);
+                return RenderedOutput.FromBinary(format, QrSvgzRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Html: {
+                var baseRender = BuildPngOptions(opts, qr);
+                var render = new QrHtmlRenderOptions {
+                    ModuleSize = baseRender.ModuleSize,
+                    QuietZone = baseRender.QuietZone,
+                    DarkColor = ToCss(baseRender.Foreground),
+                    LightColor = ToCss(baseRender.Background),
+                    EmailSafeTable = opts.HtmlEmailSafeTable,
+                    Logo = BuildLogoOptions(opts),
+                    ModuleShape = baseRender.ModuleShape,
+                    ModuleScale = baseRender.ModuleScale,
+                    ModuleCornerRadiusPx = baseRender.ModuleCornerRadiusPx,
+                    ForegroundGradient = baseRender.ForegroundGradient,
+                    Eyes = baseRender.Eyes,
+                };
+                var html = HtmlQrRenderer.Render(qr.Modules, render);
+                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
+                    html = html.WrapHtml(extras.HtmlTitle);
+                }
+                return RenderedOutput.FromText(format, html);
+            }
+            case OutputFormat.Jpeg: {
+                var render = BuildPngOptions(opts, qr);
+                var quality = opts.JpegQuality;
+                return RenderedOutput.FromBinary(format, QrJpegRenderer.Render(qr.Modules, render, quality));
+            }
+            case OutputFormat.Webp: {
+                var render = BuildPngOptions(opts, qr);
+                var quality = opts.WebpQuality;
+                return RenderedOutput.FromBinary(format, QrWebpRenderer.Render(qr.Modules, render, quality));
+            }
+            case OutputFormat.Bmp: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrBmpRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Ppm: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrPpmRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Pbm: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrPbmRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Pgm: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrPgmRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Pam: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrPamRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Xbm: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromText(format, QrXbmRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Xpm: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromText(format, QrXpmRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Tga: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrTgaRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Ico: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrIcoRenderer.Render(qr.Modules, render, BuildIcoOptions(opts)));
+            }
+            case OutputFormat.Pdf: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrPdfRenderer.Render(qr.Modules, render, extras?.VectorMode ?? RenderMode.Vector));
+            }
+            case OutputFormat.Eps: {
+                var render = BuildPngOptions(opts, qr);
+                var eps = QrEpsRenderer.Render(qr.Modules, render, extras?.VectorMode ?? RenderMode.Vector);
+                return RenderedOutput.FromText(format, eps, Encoding.ASCII);
+            }
+            case OutputFormat.Ascii: {
+                var asciiOptions = BuildAsciiOptions(extras?.MatrixAscii, opts);
+                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(qr.Modules, asciiOptions));
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
+        }
+    }
+}

--- a/CodeGlyphX/QrEasy.Render.Generic.cs
+++ b/CodeGlyphX/QrEasy.Render.Generic.cs
@@ -57,8 +57,9 @@ public static partial class QrEasy {
                     Eyes = baseRender.Eyes,
                 };
                 var html = HtmlQrRenderer.Render(qr.Modules, render);
-                if (!string.IsNullOrEmpty(extras?.HtmlTitle)) {
-                    html = html.WrapHtml(extras.HtmlTitle);
+                var title = extras?.HtmlTitle;
+                if (!string.IsNullOrEmpty(title)) {
+                    html = html.WrapHtml(title);
                 }
                 return RenderedOutput.FromText(format, html);
             }

--- a/CodeGlyphX/Rendering/OutputFormat.cs
+++ b/CodeGlyphX/Rendering/OutputFormat.cs
@@ -1,0 +1,83 @@
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Supported output formats for rendered barcodes and QR codes.
+/// </summary>
+public enum OutputFormat {
+    /// <summary>
+    /// Unknown or unsupported format.
+    /// </summary>
+    Unknown = 0,
+    /// <summary>
+    /// PNG image.
+    /// </summary>
+    Png,
+    /// <summary>
+    /// SVG (text).
+    /// </summary>
+    Svg,
+    /// <summary>
+    /// SVGZ (compressed SVG).
+    /// </summary>
+    Svgz,
+    /// <summary>
+    /// HTML (text).
+    /// </summary>
+    Html,
+    /// <summary>
+    /// JPEG image.
+    /// </summary>
+    Jpeg,
+    /// <summary>
+    /// WebP image.
+    /// </summary>
+    Webp,
+    /// <summary>
+    /// BMP image.
+    /// </summary>
+    Bmp,
+    /// <summary>
+    /// PPM image.
+    /// </summary>
+    Ppm,
+    /// <summary>
+    /// PBM image.
+    /// </summary>
+    Pbm,
+    /// <summary>
+    /// PGM image.
+    /// </summary>
+    Pgm,
+    /// <summary>
+    /// PAM image.
+    /// </summary>
+    Pam,
+    /// <summary>
+    /// XBM (text).
+    /// </summary>
+    Xbm,
+    /// <summary>
+    /// XPM (text).
+    /// </summary>
+    Xpm,
+    /// <summary>
+    /// TGA image.
+    /// </summary>
+    Tga,
+    /// <summary>
+    /// ICO image.
+    /// </summary>
+    Ico,
+    /// <summary>
+    /// PDF document.
+    /// </summary>
+    Pdf,
+    /// <summary>
+    /// EPS document (text).
+    /// </summary>
+    Eps,
+    /// <summary>
+    /// ASCII art (text).
+    /// </summary>
+    Ascii
+}

--- a/CodeGlyphX/Rendering/OutputFormatInfo.cs
+++ b/CodeGlyphX/Rendering/OutputFormatInfo.cs
@@ -115,6 +115,7 @@ public static class OutputFormatInfo {
             case ".svg":
                 return OutputFormat.Svg;
             case ".svgz":
+            case ".svg.gz":
                 return OutputFormat.Svgz;
             case ".html":
             case ".htm":

--- a/CodeGlyphX/Rendering/OutputFormatInfo.cs
+++ b/CodeGlyphX/Rendering/OutputFormatInfo.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Helpers for output format detection and metadata.
+/// </summary>
+public static class OutputFormatInfo {
+    /// <summary>
+    /// Returns the output kind for a given format.
+    /// </summary>
+    public static OutputKind GetKind(OutputFormat format) {
+        return format switch {
+            OutputFormat.Svg => OutputKind.Text,
+            OutputFormat.Html => OutputKind.Text,
+            OutputFormat.Xbm => OutputKind.Text,
+            OutputFormat.Xpm => OutputKind.Text,
+            OutputFormat.Eps => OutputKind.Text,
+            OutputFormat.Ascii => OutputKind.Text,
+            _ => OutputKind.Binary
+        };
+    }
+
+    /// <summary>
+    /// Returns true when the format is textual.
+    /// </summary>
+    public static bool IsText(OutputFormat format) => GetKind(format) == OutputKind.Text;
+
+    /// <summary>
+    /// Returns true when the format is binary.
+    /// </summary>
+    public static bool IsBinary(OutputFormat format) => GetKind(format) == OutputKind.Binary;
+
+    /// <summary>
+    /// Returns the default file extension (without a leading dot) for a format.
+    /// </summary>
+    public static string GetDefaultExtension(OutputFormat format) {
+        return format switch {
+            OutputFormat.Png => "png",
+            OutputFormat.Svg => "svg",
+            OutputFormat.Svgz => "svgz",
+            OutputFormat.Html => "html",
+            OutputFormat.Jpeg => "jpg",
+            OutputFormat.Webp => "webp",
+            OutputFormat.Bmp => "bmp",
+            OutputFormat.Ppm => "ppm",
+            OutputFormat.Pbm => "pbm",
+            OutputFormat.Pgm => "pgm",
+            OutputFormat.Pam => "pam",
+            OutputFormat.Xbm => "xbm",
+            OutputFormat.Xpm => "xpm",
+            OutputFormat.Tga => "tga",
+            OutputFormat.Ico => "ico",
+            OutputFormat.Pdf => "pdf",
+            OutputFormat.Eps => "eps",
+            OutputFormat.Ascii => "txt",
+            _ => string.Empty
+        };
+    }
+
+    /// <summary>
+    /// Returns a MIME type for the format when known.
+    /// </summary>
+    public static string GetMimeType(OutputFormat format) {
+        return format switch {
+            OutputFormat.Png => "image/png",
+            OutputFormat.Svg => "image/svg+xml",
+            OutputFormat.Svgz => "image/svg+xml",
+            OutputFormat.Html => "text/html",
+            OutputFormat.Jpeg => "image/jpeg",
+            OutputFormat.Webp => "image/webp",
+            OutputFormat.Bmp => "image/bmp",
+            OutputFormat.Ppm => "image/x-portable-pixmap",
+            OutputFormat.Pbm => "image/x-portable-bitmap",
+            OutputFormat.Pgm => "image/x-portable-graymap",
+            OutputFormat.Pam => "image/x-portable-anymap",
+            OutputFormat.Xbm => "image/x-xbitmap",
+            OutputFormat.Xpm => "image/x-xpixmap",
+            OutputFormat.Tga => "image/x-tga",
+            OutputFormat.Ico => "image/x-icon",
+            OutputFormat.Pdf => "application/pdf",
+            OutputFormat.Eps => "application/postscript",
+            OutputFormat.Ascii => "text/plain",
+            _ => "application/octet-stream"
+        };
+    }
+
+    /// <summary>
+    /// Detects the output format from a file path.
+    /// </summary>
+    public static OutputFormat FromPath(string path) {
+        if (string.IsNullOrWhiteSpace(path)) return OutputFormat.Unknown;
+        if (path.EndsWith(".svgz", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".svg.gz", StringComparison.OrdinalIgnoreCase)) {
+            return OutputFormat.Svgz;
+        }
+
+        var ext = Path.GetExtension(path);
+        if (string.IsNullOrWhiteSpace(ext)) return OutputFormat.Unknown;
+        return FromExtension(ext);
+    }
+
+    /// <summary>
+    /// Detects the output format from a file extension (with or without a leading dot).
+    /// </summary>
+    public static OutputFormat FromExtension(string extension) {
+        if (string.IsNullOrWhiteSpace(extension)) return OutputFormat.Unknown;
+        var ext = extension.StartsWith(".", StringComparison.Ordinal) ? extension : "." + extension;
+        switch (ext.ToLowerInvariant()) {
+            case ".png":
+                return OutputFormat.Png;
+            case ".webp":
+                return OutputFormat.Webp;
+            case ".svg":
+                return OutputFormat.Svg;
+            case ".svgz":
+                return OutputFormat.Svgz;
+            case ".html":
+            case ".htm":
+                return OutputFormat.Html;
+            case ".jpg":
+            case ".jpeg":
+                return OutputFormat.Jpeg;
+            case ".bmp":
+                return OutputFormat.Bmp;
+            case ".ppm":
+                return OutputFormat.Ppm;
+            case ".pbm":
+                return OutputFormat.Pbm;
+            case ".pgm":
+                return OutputFormat.Pgm;
+            case ".pam":
+                return OutputFormat.Pam;
+            case ".xbm":
+                return OutputFormat.Xbm;
+            case ".xpm":
+                return OutputFormat.Xpm;
+            case ".tga":
+                return OutputFormat.Tga;
+            case ".ico":
+                return OutputFormat.Ico;
+            case ".pdf":
+                return OutputFormat.Pdf;
+            case ".eps":
+            case ".ps":
+                return OutputFormat.Eps;
+            case ".txt":
+                return OutputFormat.Ascii;
+            default:
+                return OutputFormat.Unknown;
+        }
+    }
+
+    /// <summary>
+    /// Detects the format from a path and falls back to a default if unknown.
+    /// </summary>
+    public static OutputFormat Resolve(string path, OutputFormat fallback) {
+        var format = FromPath(path);
+        return format == OutputFormat.Unknown ? fallback : format;
+    }
+}

--- a/CodeGlyphX/Rendering/OutputKind.cs
+++ b/CodeGlyphX/Rendering/OutputKind.cs
@@ -1,0 +1,15 @@
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Output kind for a rendered asset.
+/// </summary>
+public enum OutputKind {
+    /// <summary>
+    /// Binary output (bytes).
+    /// </summary>
+    Binary,
+    /// <summary>
+    /// Text output (string).
+    /// </summary>
+    Text
+}

--- a/CodeGlyphX/Rendering/OutputWriter.cs
+++ b/CodeGlyphX/Rendering/OutputWriter.cs
@@ -14,6 +14,9 @@ public static class OutputWriter {
     public static string Write(string path, RenderedOutput output, Encoding? encoding = null) {
         if (output is null) throw new ArgumentNullException(nameof(output));
         if (output.IsText) {
+            if (encoding is null) {
+                return RenderIO.WriteBinary(path, output.Data);
+            }
             return RenderIO.WriteText(path, output.GetText(encoding), encoding);
         }
         return RenderIO.WriteBinary(path, output.Data);
@@ -25,6 +28,10 @@ public static class OutputWriter {
     public static void Write(Stream stream, RenderedOutput output, Encoding? encoding = null) {
         if (output is null) throw new ArgumentNullException(nameof(output));
         if (output.IsText) {
+            if (encoding is null) {
+                RenderIO.WriteBinary(stream, output.Data);
+                return;
+            }
             RenderIO.WriteText(stream, output.GetText(encoding), encoding);
             return;
         }

--- a/CodeGlyphX/Rendering/OutputWriter.cs
+++ b/CodeGlyphX/Rendering/OutputWriter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Writes rendered outputs to files and streams.
+/// </summary>
+public static class OutputWriter {
+    /// <summary>
+    /// Writes a rendered output to a file and returns the path.
+    /// </summary>
+    public static string Write(string path, RenderedOutput output, Encoding? encoding = null) {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (output.IsText) {
+            return RenderIO.WriteText(path, output.GetText(encoding), encoding);
+        }
+        return RenderIO.WriteBinary(path, output.Data);
+    }
+
+    /// <summary>
+    /// Writes a rendered output to a stream.
+    /// </summary>
+    public static void Write(Stream stream, RenderedOutput output, Encoding? encoding = null) {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (output.IsText) {
+            RenderIO.WriteText(stream, output.GetText(encoding), encoding);
+            return;
+        }
+        RenderIO.WriteBinary(stream, output.Data);
+    }
+}

--- a/CodeGlyphX/Rendering/RenderExtras.cs
+++ b/CodeGlyphX/Rendering/RenderExtras.cs
@@ -1,0 +1,28 @@
+using CodeGlyphX.Rendering.Ascii;
+
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Optional render extras for format-specific output.
+/// </summary>
+public sealed class RenderExtras {
+    /// <summary>
+    /// Vector or raster output for PDF/EPS.
+    /// </summary>
+    public RenderMode VectorMode { get; set; } = RenderMode.Vector;
+
+    /// <summary>
+    /// Optional HTML title (wraps HTML output).
+    /// </summary>
+    public string? HtmlTitle { get; set; }
+
+    /// <summary>
+    /// ASCII render options for matrix codes.
+    /// </summary>
+    public MatrixAsciiRenderOptions? MatrixAscii { get; set; }
+
+    /// <summary>
+    /// ASCII render options for barcodes.
+    /// </summary>
+    public BarcodeAsciiRenderOptions? BarcodeAscii { get; set; }
+}

--- a/CodeGlyphX/Rendering/RenderedOutput.cs
+++ b/CodeGlyphX/Rendering/RenderedOutput.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Text;
+
+namespace CodeGlyphX.Rendering;
+
+/// <summary>
+/// Represents rendered output (text or binary).
+/// </summary>
+public sealed class RenderedOutput {
+    private string? _text;
+
+    /// <summary>
+    /// Output format.
+    /// </summary>
+    public OutputFormat Format { get; }
+
+    /// <summary>
+    /// Output kind.
+    /// </summary>
+    public OutputKind Kind { get; }
+
+    /// <summary>
+    /// MIME type when known.
+    /// </summary>
+    public string MimeType { get; }
+
+    /// <summary>
+    /// Output bytes.
+    /// </summary>
+    public byte[] Data { get; }
+
+    private RenderedOutput(OutputFormat format, OutputKind kind, byte[] data, string? text) {
+        Format = format;
+        Kind = kind;
+        Data = data ?? throw new ArgumentNullException(nameof(data));
+        _text = text;
+        MimeType = OutputFormatInfo.GetMimeType(format);
+    }
+
+    /// <summary>
+    /// Creates a binary output.
+    /// </summary>
+    public static RenderedOutput FromBinary(OutputFormat format, byte[] data) {
+        return new RenderedOutput(format, OutputKind.Binary, data, text: null);
+    }
+
+    /// <summary>
+    /// Creates a text output (UTF-8 bytes).
+    /// </summary>
+    public static RenderedOutput FromText(OutputFormat format, string text, Encoding? encoding = null) {
+        var enc = encoding ?? Encoding.UTF8;
+        var bytes = enc.GetBytes(text ?? string.Empty);
+        return new RenderedOutput(format, OutputKind.Text, bytes, text ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Returns the text representation when this is a text output.
+    /// </summary>
+    public string GetText(Encoding? encoding = null) {
+        if (Kind != OutputKind.Text) {
+            throw new InvalidOperationException("Output is binary.");
+        }
+        if (_text is not null) return _text;
+        var enc = encoding ?? Encoding.UTF8;
+        _text = enc.GetString(Data);
+        return _text;
+    }
+
+    /// <summary>
+    /// Returns true when this output is textual.
+    /// </summary>
+    public bool IsText => Kind == OutputKind.Text;
+}

--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ var extras = new RenderExtras { HtmlTitle = "My Code", VectorMode = RenderMode.R
 Barcode.Save(BarcodeType.Code128, "CODE128-12345", "barcode.html", extras: extras);
 ```
 
+Per-format helpers (e.g., `Png`, `Svg`, `SavePng`) remain for convenience, but new code should prefer `Render(..., OutputFormat)` to keep output handling consistent.
+
 ### ICO multi-size
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -410,8 +410,22 @@ For other matrix barcodes (e.g., KIX/Royal Mail 4‑State), use the `Matrix*` re
 | HTML | `.html`, `.htm` | Table-based output |
 | PDF | `.pdf` | Vector by default, raster via RenderMode |
 | EPS | `.eps`, `.ps` | Vector by default, raster via RenderMode |
-| ASCII | API only | Use `RenderAscii` methods |
+| ASCII | API only | Use `Render(..., OutputFormat.Ascii)` |
 | Raw RGBA | API only | Use `RenderPixels` methods |
+
+### Render to bytes or text
+
+```csharp
+using CodeGlyphX;
+using CodeGlyphX.Rendering;
+
+var svg = Barcode.Render(BarcodeType.Code128, "CODE128-12345", OutputFormat.Svg).GetText();
+var png = QrCode.Render("https://example.com", OutputFormat.Png).Data;
+
+// HTML title + PDF/EPS vector/raster output
+var extras = new RenderExtras { HtmlTitle = "My Code", VectorMode = RenderMode.Raster };
+Barcode.Save(BarcodeType.Code128, "CODE128-12345", "barcode.html", extras: extras);
+```
 
 ### ICO multi-size
 


### PR DESCRIPTION
## Summary\n- route obsolete per-format helpers through OutputFormat/RenderedOutput\n- update QR/OTP/BarcodeEasy/builders/save helpers to avoid obsolete calls\n- add shared obsolete message constant\n\n## Testing\n- dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release -f net8.0\n- dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release -f net10.0\n- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0 --no-build