### PR TITLE
Improve console ASCII QR rendering

### DIFF
--- a/CodeGlyphX.Examples/QrAsciiExample.cs
+++ b/CodeGlyphX.Examples/QrAsciiExample.cs
@@ -9,29 +9,144 @@ namespace CodeGlyphX.Examples;
 
 internal static class QrAsciiExample {
     public static void Run(string outputDir) {
+        const int CompactTargetWidth = 28;
+        const int CompactTargetHeight = 14;
+        const int SquareTargetWidth = 48;
+        const int SquareTargetHeight = 24;
+
         var payload = "https://example.com/console";
+        var payloadCompact = "https://exm.pl";
+        var payloadLarge = "https://example.com/console?ref=codematrix";
         var qr = QrCodeEncoder.EncodeText(payload, QrErrorCorrectionLevel.M);
+        var qrCompact = QrCodeEncoder.EncodeText(payloadCompact, QrErrorCorrectionLevel.M);
+        var qrLarge = QrCodeEncoder.EncodeText(payloadLarge, QrErrorCorrectionLevel.M);
 
-        var windowWidth = 120;
-        try {
-            windowWidth = Console.WindowWidth;
-        } catch {
-            // Some hosts (CI, redirected output) do not expose window size.
-        }
+        var darkCompactOptions = AsciiConsolePresets.CompactDarkForeground();
+        darkCompactOptions.DarkColor = new Rgba32(0, 220, 255);
+        darkCompactOptions.DarkGradient = new AsciiGradientOptions {
+            Type = AsciiGradientType.Diagonal,
+            StartColor = new Rgba32(0, 220, 255),
+            EndColor = new Rgba32(255, 96, 200)
+        };
+        darkCompactOptions.QuietZone = 0;
+        darkCompactOptions.MinScale = 1;
+        darkCompactOptions.MaxScale = 1;
+        darkCompactOptions.PaddingColumns = 1;
+        darkCompactOptions.PaddingRows = 1;
+        darkCompactOptions.TargetWidth = CompactTargetWidth;
+        darkCompactOptions.TargetHeight = CompactTargetHeight;
+        darkCompactOptions.CellAspectRatio = 0.45;
+        var darkCompactAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, darkCompactOptions);
+        var darkCompactAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, darkCompactAsciiOptions);
 
-        var baseOptions = AsciiPresets.Console(scale: 1, darkColor: new Rgba32(12, 12, 12));
-        var widthModules = qr.Size + baseOptions.QuietZone * 2;
-        var charsPerModule = Math.Max(1, baseOptions.ModuleWidth);
-        var usableWidth = Math.Max(40, windowWidth - 4);
-        var scaleFit = usableWidth / Math.Max(1, widthModules * charsPerModule);
-        if (scaleFit < 1) scaleFit = 1;
-        if (scaleFit > 3) scaleFit = 3;
+        var lightCompactOptions = AsciiConsolePresets.Compact();
+        lightCompactOptions.DarkColor = new Rgba32(0, 0, 0);
+        lightCompactOptions.LightColor = new Rgba32(255, 255, 255);
+        lightCompactOptions.QuietZone = 0;
+        lightCompactOptions.MinScale = 1;
+        lightCompactOptions.MaxScale = 1;
+        lightCompactOptions.PaddingColumns = 1;
+        lightCompactOptions.PaddingRows = 1;
+        lightCompactOptions.TargetWidth = CompactTargetWidth;
+        lightCompactOptions.TargetHeight = CompactTargetHeight;
+        lightCompactOptions.CellAspectRatio = 0.45;
+        var lightCompactAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, lightCompactOptions);
+        var lightCompactAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, lightCompactAsciiOptions);
 
-        var ascii = QrCode.Render(
-            payload,
-            OutputFormat.Ascii,
-            extras: new RenderExtras { MatrixAscii = AsciiPresets.Console(scale: scaleFit, darkColor: new Rgba32(12, 12, 12)) }
-        ).GetText();
+        var lightSquareOptions = AsciiConsolePresets.Square();
+        lightSquareOptions.DarkColor = new Rgba32(0, 0, 0);
+        lightSquareOptions.LightColor = new Rgba32(255, 255, 255);
+        lightSquareOptions.QuietZone = 1;
+        lightSquareOptions.MinScale = 1;
+        lightSquareOptions.MaxScale = 1;
+        lightSquareOptions.PaddingColumns = 1;
+        lightSquareOptions.PaddingRows = 1;
+        lightSquareOptions.TargetWidth = SquareTargetWidth;
+        lightSquareOptions.TargetHeight = SquareTargetHeight;
+        lightSquareOptions.CellAspectRatio = 0.5;
+        lightSquareOptions.AllowModuleWidthShrink = false;
+        lightSquareOptions.ModuleWidth = 2;
+        lightSquareOptions.ModuleHeight = 1;
+        var lightSquareAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, lightSquareOptions);
+        var lightSquareAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, lightSquareAsciiOptions);
+
+        var paletteCompactOptions = AsciiConsolePresets.Compact();
+        paletteCompactOptions.DarkPalette = new AsciiPaletteOptions {
+            Mode = AsciiPaletteMode.CycleDiagonal,
+            Colors = new[] {
+                new Rgba32(0, 190, 230),
+                new Rgba32(120, 210, 255),
+                new Rgba32(255, 140, 210)
+            }
+        };
+        paletteCompactOptions.QuietZone = 0;
+        paletteCompactOptions.MinScale = 1;
+        paletteCompactOptions.MaxScale = 1;
+        paletteCompactOptions.PaddingColumns = 1;
+        paletteCompactOptions.PaddingRows = 1;
+        paletteCompactOptions.TargetWidth = CompactTargetWidth;
+        paletteCompactOptions.TargetHeight = CompactTargetHeight;
+        paletteCompactOptions.CellAspectRatio = 0.45;
+        var paletteCompactAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, paletteCompactOptions);
+        var paletteCompactAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, paletteCompactAsciiOptions);
+
+        var radialCompactOptions = AsciiConsolePresets.Compact();
+        radialCompactOptions.DarkGradient = new AsciiGradientOptions {
+            Type = AsciiGradientType.Radial,
+            StartColor = new Rgba32(64, 220, 255),
+            EndColor = new Rgba32(255, 110, 180),
+            CenterX = 0.5,
+            CenterY = 0.5
+        };
+        radialCompactOptions.QuietZone = 0;
+        radialCompactOptions.MinScale = 1;
+        radialCompactOptions.MaxScale = 1;
+        radialCompactOptions.PaddingColumns = 1;
+        radialCompactOptions.PaddingRows = 1;
+        radialCompactOptions.TargetWidth = CompactTargetWidth;
+        radialCompactOptions.TargetHeight = CompactTargetHeight;
+        radialCompactOptions.CellAspectRatio = 0.45;
+        var radialCompactAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, radialCompactOptions);
+        var radialCompactAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, radialCompactAsciiOptions);
+
+        var scanSafeOptions = AsciiConsolePresets.ScanSafe();
+        scanSafeOptions.DarkColor = new Rgba32(10, 10, 10);
+        scanSafeOptions.LightColor = new Rgba32(255, 255, 255);
+        scanSafeOptions.TargetWidth = CompactTargetWidth;
+        scanSafeOptions.TargetHeight = CompactTargetHeight;
+        scanSafeOptions.CellAspectRatio = 0.45;
+        var scanSafeAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, scanSafeOptions);
+        var scanSafeAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, scanSafeAsciiOptions);
+
+        var tinyOptions = AsciiConsolePresets.Tiny();
+        tinyOptions.DarkColor = new Rgba32(0, 0, 0);
+        tinyOptions.LightColor = new Rgba32(255, 255, 255);
+        tinyOptions.TargetWidth = 24;
+        tinyOptions.TargetHeight = 12;
+        var tinyAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, tinyOptions);
+        var tinyAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, tinyAsciiOptions);
+
+        var monoAnsiOptions = new AsciiConsoleOptions {
+            UseHalfBlocks = false,
+            UseUnicodeBlocks = true,
+            UseAnsiColors = true,
+            UseTrueColor = true,
+            ColorizeLight = true,
+            QuietZone = 2,
+            MinScale = 1,
+            MaxScale = 1,
+            ModuleWidth = 2,
+            ModuleHeight = 1,
+            AllowModuleWidthShrink = false,
+            DarkColor = new Rgba32(0, 0, 0),
+            LightColor = new Rgba32(255, 255, 255),
+            PaddingColumns = 1,
+            PaddingRows = 1,
+            TargetWidth = SquareTargetWidth,
+            TargetHeight = SquareTargetHeight
+        };
+        var monoAnsiAsciiOptions = AsciiConsole.Fit(qrCompact.Modules, monoAnsiOptions);
+        var monoAnsiAscii = MatrixAsciiRenderer.Render(qrCompact.Modules, monoAnsiAsciiOptions);
 
         var pngPath = Path.Combine(outputDir, "qr-ascii-console.png");
         var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
@@ -42,8 +157,33 @@ internal static class QrAsciiExample {
         });
         File.WriteAllBytes(pngPath, png);
 
-        Console.WriteLine($"ANSI ASCII QR preview (scale {scaleFit}, window width {windowWidth}):");
-        Console.WriteLine(ascii);
+        Console.WriteLine($"ANSI ASCII QR preview (dark compact, {qrCompact.Size}x{qrCompact.Size} modules, scale {darkCompactAsciiOptions.Scale}, half-blocks {darkCompactAsciiOptions.UseHalfBlocks}, module {darkCompactAsciiOptions.ModuleWidth}x{darkCompactAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(darkCompactAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (light compact, {qrCompact.Size}x{qrCompact.Size} modules, scale {lightCompactAsciiOptions.Scale}, half-blocks {lightCompactAsciiOptions.UseHalfBlocks}, module {lightCompactAsciiOptions.ModuleWidth}x{lightCompactAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(lightCompactAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (light square, {qrCompact.Size}x{qrCompact.Size} modules, scale {lightSquareAsciiOptions.Scale}, half-blocks {lightSquareAsciiOptions.UseHalfBlocks}, module {lightSquareAsciiOptions.ModuleWidth}x{lightSquareAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(lightSquareAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (palette compact, {qrCompact.Size}x{qrCompact.Size} modules, scale {paletteCompactAsciiOptions.Scale}, half-blocks {paletteCompactAsciiOptions.UseHalfBlocks}, module {paletteCompactAsciiOptions.ModuleWidth}x{paletteCompactAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(paletteCompactAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (radial compact, {qrCompact.Size}x{qrCompact.Size} modules, scale {radialCompactAsciiOptions.Scale}, half-blocks {radialCompactAsciiOptions.UseHalfBlocks}, module {radialCompactAsciiOptions.ModuleWidth}x{radialCompactAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(radialCompactAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (scan safe compact, {qrCompact.Size}x{qrCompact.Size} modules, scale {scanSafeAsciiOptions.Scale}, half-blocks {scanSafeAsciiOptions.UseHalfBlocks}, module {scanSafeAsciiOptions.ModuleWidth}x{scanSafeAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(scanSafeAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (tiny target, {qrCompact.Size}x{qrCompact.Size} modules, scale {tinyAsciiOptions.Scale}, half-blocks {tinyAsciiOptions.UseHalfBlocks}, module {tinyAsciiOptions.ModuleWidth}x{tinyAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(tinyAscii);
+        Console.WriteLine();
+        Console.WriteLine($"ANSI ASCII QR preview (mono square, {qrCompact.Size}x{qrCompact.Size} modules, scale {monoAnsiAsciiOptions.Scale}, half-blocks {monoAnsiAsciiOptions.UseHalfBlocks}, module {monoAnsiAsciiOptions.ModuleWidth}x{monoAnsiAsciiOptions.ModuleHeight}):");
+        Console.WriteLine(monoAnsiAscii);
+        Console.WriteLine();
+        Console.WriteLine("Tip: The QR size is driven by payload length (module count). Shorter payloads = smaller QR.");
+        Console.WriteLine("Tip: If the QR looks too tall or wide, tweak AsciiConsoleOptions.CellAspectRatio (try 0.40-0.60).");
+        Console.WriteLine("Tip: To shrink output, lower TargetWidth/TargetHeight (or MaxWindowWidth/MaxWindowHeight).");
         Console.WriteLine();
         Console.WriteLine($"Saved a phone-friendly PNG to: {pngPath}");
     }

--- a/CodeGlyphX.Examples/QrAsciiExample.cs
+++ b/CodeGlyphX.Examples/QrAsciiExample.cs
@@ -16,10 +16,8 @@ internal static class QrAsciiExample {
 
         var payload = "https://example.com/console";
         var payloadCompact = "https://exm.pl";
-        var payloadLarge = "https://example.com/console?ref=codematrix";
         var qr = QrCodeEncoder.EncodeText(payload, QrErrorCorrectionLevel.M);
         var qrCompact = QrCodeEncoder.EncodeText(payloadCompact, QrErrorCorrectionLevel.M);
-        var qrLarge = QrCodeEncoder.EncodeText(payloadLarge, QrErrorCorrectionLevel.M);
 
         var darkCompactOptions = AsciiConsolePresets.CompactDarkForeground();
         darkCompactOptions.DarkColor = new Rgba32(0, 220, 255);

--- a/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
+++ b/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net10.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -14,7 +15,7 @@
     <ProjectReference Include="..\CodeGlyphX\CodeGlyphX.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
     <Compile Include="**\*.cs" Exclude="bin\**;obj\**;Net472\**" />
   </ItemGroup>
 

--- a/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
+++ b/CodeGlyphX.Tests/Net472/QrNet472SmokeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
 using Xunit;
@@ -189,6 +190,29 @@ public sealed class QrNet472SmokeTests {
         var ok = QrImageDecoder.TryDecode(rotated, rw, rh, rstride, PixelFormat.Rgba32, out var decoded);
         Assert.True(ok);
         Assert.Equal(Payload, decoded.Text);
+    }
+
+    [Fact]
+    public void Net472_AsciiConsole_Render_Succeeds() {
+        var qr = QrCodeEncoder.EncodeText("NET472-ASCII");
+        var options = new AsciiConsoleOptions {
+            UseHalfBlocks = true,
+            UseUnicodeBlocks = true,
+            UseAnsiColors = true,
+            PreferScanReliability = true,
+            TargetWidth = 28,
+            TargetHeight = 14,
+            DarkGradient = new AsciiGradientOptions {
+                Type = AsciiGradientType.Horizontal,
+                StartColor = new Rgba32(0, 0, 0),
+                EndColor = new Rgba32(40, 40, 40)
+            }
+        };
+
+        var fit = AsciiConsole.Fit(qr.Modules, options);
+        var ascii = MatrixAsciiRenderer.Render(qr.Modules, fit);
+        Assert.False(string.IsNullOrWhiteSpace(ascii));
+        Assert.Contains("\u001b[", ascii, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/CodeGlyphX/QR.Builder.cs
+++ b/CodeGlyphX/QR.Builder.cs
@@ -591,10 +591,24 @@ public static partial class QR {
         }
 
         /// <summary>
+        /// Renders console-friendly ASCII text with auto-fit.
+        /// </summary>
+        public string AsciiConsole(AsciiConsoleOptions? consoleOptions = null) {
+            return Render(OutputFormat.Ascii, new RenderExtras { AsciiConsole = consoleOptions }).GetText();
+        }
+
+        /// <summary>
         /// Saves ASCII to a file.
         /// </summary>
         public string SaveAscii(string path, MatrixAsciiRenderOptions? asciiOptions = null) {
             return OutputWriter.Write(path, Render(OutputFormat.Ascii, new RenderExtras { MatrixAscii = asciiOptions }));
+        }
+
+        /// <summary>
+        /// Saves console-friendly ASCII to a file.
+        /// </summary>
+        public string SaveAsciiConsole(string path, AsciiConsoleOptions? consoleOptions = null) {
+            return OutputWriter.Write(path, Render(OutputFormat.Ascii, new RenderExtras { AsciiConsole = consoleOptions }));
         }
 
         /// <summary>

--- a/CodeGlyphX/QR.cs
+++ b/CodeGlyphX/QR.cs
@@ -442,6 +442,13 @@ public static partial class QR {
     }
 
     /// <summary>
+    /// Renders a QR code as console-friendly ASCII text with auto-fit.
+    /// </summary>
+    public static string AsciiConsole(string payload, AsciiConsoleOptions? consoleOptions = null, QrEasyOptions? options = null) {
+        return Render(payload, OutputFormat.Ascii, options, new RenderExtras { AsciiConsole = consoleOptions }).GetText();
+    }
+
+    /// <summary>
     /// Detects a payload type and renders a QR code as ASCII text.
     /// </summary>
     [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
@@ -450,10 +457,24 @@ public static partial class QR {
     }
 
     /// <summary>
+    /// Detects a payload type and renders a QR code as console-friendly ASCII text with auto-fit.
+    /// </summary>
+    public static string AsciiConsoleAuto(string payload, QrPayloadDetectOptions? detectOptions = null, AsciiConsoleOptions? consoleOptions = null, QrEasyOptions? options = null) {
+        return RenderAuto(payload, OutputFormat.Ascii, detectOptions, options, new RenderExtras { AsciiConsole = consoleOptions }).GetText();
+    }
+
+    /// <summary>
     /// Renders a QR code as ASCII text for a payload with embedded defaults.
     /// </summary>
     [Obsolete(CodeGlyphX.Internal.ObsoleteMessages.RenderFormatHelpers)]
     public static string Ascii(QrPayloadData payload, MatrixAsciiRenderOptions? asciiOptions = null, QrEasyOptions? options = null) {
         return Render(payload, OutputFormat.Ascii, options, new RenderExtras { MatrixAscii = asciiOptions }).GetText();
+    }
+
+    /// <summary>
+    /// Renders a QR code as console-friendly ASCII text with auto-fit for a payload with embedded defaults.
+    /// </summary>
+    public static string AsciiConsole(QrPayloadData payload, AsciiConsoleOptions? consoleOptions = null, QrEasyOptions? options = null) {
+        return Render(payload, OutputFormat.Ascii, options, new RenderExtras { AsciiConsole = consoleOptions }).GetText();
     }
 }

--- a/CodeGlyphX/QrEasy.Render.Console.cs
+++ b/CodeGlyphX/QrEasy.Render.Console.cs
@@ -1,0 +1,84 @@
+using System;
+using CodeGlyphX.Payloads;
+using CodeGlyphX.Rendering.Ascii;
+
+namespace CodeGlyphX;
+
+public static partial class QrEasy {
+    /// <summary>
+    /// Renders a QR code as console-friendly ASCII with auto-fit.
+    /// </summary>
+    public static string RenderAsciiConsole(string payload, AsciiConsoleOptions? consoleOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
+        var qr = EncodePayload(payload, opts);
+        var fitOptions = MergeConsoleOptions(consoleOptions, opts.QuietZone);
+        return AsciiConsole.Render(qr.Modules, fitOptions);
+    }
+
+    /// <summary>
+    /// Detects a payload type and renders a QR code as console-friendly ASCII with auto-fit.
+    /// </summary>
+    public static string RenderAsciiConsoleAuto(string payload, QrPayloadDetectOptions? detectOptions = null, AsciiConsoleOptions? consoleOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var detected = QrPayloads.Detect(payload, detectOptions);
+        return RenderAsciiConsole(detected, consoleOptions, options);
+    }
+
+    /// <summary>
+    /// Renders a QR code as console-friendly ASCII with auto-fit for a payload with embedded defaults.
+    /// </summary>
+    public static string RenderAsciiConsole(QrPayloadData payload, AsciiConsoleOptions? consoleOptions = null, QrEasyOptions? options = null) {
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
+        var opts = MergeOptions(payload, options);
+        var qr = Encode(payload.Text, opts);
+        var fitOptions = MergeConsoleOptions(consoleOptions, opts.QuietZone);
+        return AsciiConsole.Render(qr.Modules, fitOptions);
+    }
+
+    private static AsciiConsoleOptions MergeConsoleOptions(AsciiConsoleOptions? consoleOptions, int quietZone) {
+        if (consoleOptions is null) {
+            return new AsciiConsoleOptions {
+                QuietZone = quietZone
+            };
+        }
+
+        return new AsciiConsoleOptions {
+            WindowWidth = consoleOptions.WindowWidth,
+            WindowHeight = consoleOptions.WindowHeight,
+            MaxWindowWidth = consoleOptions.MaxWindowWidth,
+            MaxWindowHeight = consoleOptions.MaxWindowHeight,
+            TargetWidth = consoleOptions.TargetWidth,
+            TargetHeight = consoleOptions.TargetHeight,
+            PaddingColumns = consoleOptions.PaddingColumns,
+            PaddingRows = consoleOptions.PaddingRows,
+            MinScale = consoleOptions.MinScale,
+            MaxScale = consoleOptions.MaxScale,
+            MinQuietZone = consoleOptions.MinQuietZone,
+            QuietZone = consoleOptions.QuietZone ?? quietZone,
+            AllowQuietZoneShrink = consoleOptions.AllowQuietZoneShrink,
+            AllowModuleWidthShrink = consoleOptions.AllowModuleWidthShrink,
+            ModuleWidth = consoleOptions.ModuleWidth,
+            ModuleHeight = consoleOptions.ModuleHeight,
+            Dark = consoleOptions.Dark,
+            Light = consoleOptions.Light,
+            NewLine = consoleOptions.NewLine,
+            UseHalfBlocks = consoleOptions.UseHalfBlocks,
+            HalfBlockUseBackground = consoleOptions.HalfBlockUseBackground,
+            UseUnicodeBlocks = consoleOptions.UseUnicodeBlocks,
+            UseAnsiColors = consoleOptions.UseAnsiColors,
+            UseTrueColor = consoleOptions.UseTrueColor,
+            ColorizeLight = consoleOptions.ColorizeLight,
+            CellAspectRatio = consoleOptions.CellAspectRatio,
+            DarkGradient = consoleOptions.DarkGradient,
+            DarkPalette = consoleOptions.DarkPalette,
+            PreferScanReliability = consoleOptions.PreferScanReliability,
+            EnsureDarkContrast = consoleOptions.EnsureDarkContrast,
+            MaxDarkLuminance = consoleOptions.MaxDarkLuminance,
+            DarkColor = consoleOptions.DarkColor,
+            LightColor = consoleOptions.LightColor,
+            OutputEncoding = consoleOptions.OutputEncoding,
+            Invert = consoleOptions.Invert
+        };
+    }
+}

--- a/CodeGlyphX/QrEasy.Render.Generic.cs
+++ b/CodeGlyphX/QrEasy.Render.Generic.cs
@@ -119,6 +119,10 @@ public static partial class QrEasy {
                 return RenderedOutput.FromText(format, eps, Encoding.ASCII);
             }
             case OutputFormat.Ascii: {
+                if (extras?.AsciiConsole is not null) {
+                    var fitOptions = MergeConsoleOptions(extras.AsciiConsole, opts.QuietZone);
+                    return RenderedOutput.FromText(format, AsciiConsole.Render(qr.Modules, fitOptions));
+                }
                 var asciiOptions = BuildAsciiOptions(extras?.MatrixAscii, opts);
                 return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(qr.Modules, asciiOptions));
             }

--- a/CodeGlyphX/Rendering/Ascii/AsciiColorOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/AsciiColorOptions.cs
@@ -1,0 +1,92 @@
+using System;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Gradient styles for ANSI coloring.
+/// </summary>
+public enum AsciiGradientType {
+    /// <summary>
+    /// Left-to-right gradient.
+    /// </summary>
+    Horizontal,
+    /// <summary>
+    /// Top-to-bottom gradient.
+    /// </summary>
+    Vertical,
+    /// <summary>
+    /// Top-left to bottom-right gradient.
+    /// </summary>
+    Diagonal,
+    /// <summary>
+    /// Radial gradient from a center point.
+    /// </summary>
+    Radial
+}
+
+/// <summary>
+/// Palette selection modes for ANSI coloring.
+/// </summary>
+public enum AsciiPaletteMode {
+    /// <summary>
+    /// Cycles palette entries per row.
+    /// </summary>
+    CycleRows,
+    /// <summary>
+    /// Cycles palette entries per column.
+    /// </summary>
+    CycleColumns,
+    /// <summary>
+    /// Cycles palette entries along diagonals.
+    /// </summary>
+    CycleDiagonal,
+    /// <summary>
+    /// Randomizes palette entries per module.
+    /// </summary>
+    Random
+}
+
+/// <summary>
+/// Gradient settings for ANSI coloring.
+/// </summary>
+public sealed class AsciiGradientOptions {
+    /// <summary>
+    /// Gradient type used for dark modules.
+    /// </summary>
+    public AsciiGradientType Type { get; set; } = AsciiGradientType.Horizontal;
+    /// <summary>
+    /// Gradient start color.
+    /// </summary>
+    public Rgba32 StartColor { get; set; } = new(0, 255, 255);
+    /// <summary>
+    /// Gradient end color.
+    /// </summary>
+    public Rgba32 EndColor { get; set; } = new(255, 0, 255);
+    /// <summary>
+    /// Horizontal gradient center for radial mode (0-1).
+    /// </summary>
+    public double CenterX { get; set; } = 0.5;
+    /// <summary>
+    /// Vertical gradient center for radial mode (0-1).
+    /// </summary>
+    public double CenterY { get; set; } = 0.5;
+}
+
+/// <summary>
+/// Palette settings for ANSI coloring.
+/// </summary>
+public sealed class AsciiPaletteOptions {
+    /// <summary>
+    /// Palette selection mode.
+    /// </summary>
+    public AsciiPaletteMode Mode { get; set; } = AsciiPaletteMode.CycleColumns;
+    /// <summary>
+    /// Palette colors used for dark modules.
+    /// </summary>
+    public Rgba32[] Colors { get; set; } = Array.Empty<Rgba32>();
+    /// <summary>
+    /// Seed used for random palette selection.
+    /// </summary>
+    public int Seed { get; set; } = 0;
+}

--- a/CodeGlyphX/Rendering/Ascii/AsciiConsole.cs
+++ b/CodeGlyphX/Rendering/Ascii/AsciiConsole.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Text;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Helpers for console-friendly ASCII rendering.
+/// </summary>
+public static class AsciiConsole {
+    /// <summary>
+    /// Builds ASCII render options that auto-fit a console window.
+    /// </summary>
+    public static MatrixAsciiRenderOptions Fit(BitMatrix modules, AsciiConsoleOptions? options = null) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        var opts = options ?? new AsciiConsoleOptions();
+
+        var windowWidth = opts.WindowWidth ?? GetConsoleWidth();
+        var windowHeight = opts.WindowHeight ?? GetConsoleHeight();
+        if (windowWidth <= 0) windowWidth = 120;
+        if (windowHeight <= 0) windowHeight = 40;
+        if (opts.TargetWidth.HasValue && opts.TargetWidth.Value > 0) {
+            windowWidth = opts.TargetWidth.Value + Math.Max(0, opts.PaddingColumns);
+        }
+        if (opts.TargetHeight.HasValue && opts.TargetHeight.Value > 0) {
+            windowHeight = opts.TargetHeight.Value + Math.Max(0, opts.PaddingRows);
+        }
+        if (opts.MaxWindowWidth.HasValue && opts.MaxWindowWidth.Value > 0 && windowWidth > opts.MaxWindowWidth.Value) {
+            windowWidth = opts.MaxWindowWidth.Value;
+        }
+        if (opts.MaxWindowHeight.HasValue && opts.MaxWindowHeight.Value > 0 && windowHeight > opts.MaxWindowHeight.Value) {
+            windowHeight = opts.MaxWindowHeight.Value;
+        }
+
+        var requestedHalfBlocks = opts.UseHalfBlocks;
+        var widthOverride = opts.ModuleWidth.HasValue;
+        var heightOverride = opts.ModuleHeight.HasValue;
+        var useAnsiColors = opts.UseAnsiColors ?? DetectAnsiSupport();
+        var useTrueColor = opts.UseTrueColor ?? DetectTrueColorSupport();
+        if (!useAnsiColors) {
+            useTrueColor = false;
+        }
+
+        var baseOptions = opts.UseHalfBlocks
+            ? AsciiPresets.ConsoleCompact(scale: 1, useAnsiColors: useAnsiColors, trueColor: useTrueColor, darkColor: opts.DarkColor, lightColor: opts.LightColor)
+            : AsciiPresets.Console(scale: 1, useAnsiColors: useAnsiColors, trueColor: useTrueColor, darkColor: opts.DarkColor, lightColor: opts.LightColor);
+
+        baseOptions.UseUnicodeBlocks = opts.UseUnicodeBlocks;
+        baseOptions.UseHalfBlocks = opts.UseHalfBlocks;
+        baseOptions.UseHalfBlockBackground = opts.HalfBlockUseBackground;
+        if (opts.DarkGradient is not null) baseOptions.AnsiDarkGradient = opts.DarkGradient;
+        if (opts.DarkPalette is not null) baseOptions.AnsiDarkPalette = opts.DarkPalette;
+        baseOptions.EnsureDarkContrast = opts.EnsureDarkContrast || opts.PreferScanReliability;
+        if (baseOptions.EnsureDarkContrast) {
+            baseOptions.MaxDarkLuminance = opts.MaxDarkLuminance;
+        }
+        if (opts.ModuleWidth.HasValue) baseOptions.ModuleWidth = Math.Max(1, opts.ModuleWidth.Value);
+        if (opts.ModuleHeight.HasValue) baseOptions.ModuleHeight = Math.Max(1, opts.ModuleHeight.Value);
+        if (!string.IsNullOrEmpty(opts.Dark)) baseOptions.Dark = opts.Dark!;
+        if (!string.IsNullOrEmpty(opts.Light)) baseOptions.Light = opts.Light!;
+        if (!string.IsNullOrEmpty(opts.NewLine)) baseOptions.NewLine = opts.NewLine!;
+
+        var outputEncoding = opts.OutputEncoding ?? GetConsoleEncoding();
+        if (outputEncoding is not null) {
+            var canBlocks = CanEncode(outputEncoding, "█");
+            var canHalfBlocks = CanEncode(outputEncoding, "▀") && CanEncode(outputEncoding, "▄");
+            if (baseOptions.UseHalfBlocks && !canHalfBlocks) {
+                baseOptions.UseHalfBlocks = false;
+            }
+            if (baseOptions.UseUnicodeBlocks && !canBlocks) {
+                baseOptions.UseUnicodeBlocks = false;
+            }
+        }
+
+        var useHalfBlocks = baseOptions.UseHalfBlocks;
+        if (!useHalfBlocks && requestedHalfBlocks && !widthOverride) {
+            if (baseOptions.ModuleWidth < 2) {
+                baseOptions.ModuleWidth = 2;
+            }
+            if (!heightOverride && baseOptions.ModuleHeight < 1) {
+                baseOptions.ModuleHeight = 1;
+            }
+        }
+        if (opts.PreferScanReliability) {
+            baseOptions.UseHalfBlockBackground = true;
+        }
+        if (!baseOptions.UseHalfBlockBackground) {
+            baseOptions.AnsiColorizeLight = false;
+        } else if (opts.ColorizeLight.HasValue) {
+            baseOptions.AnsiColorizeLight = opts.ColorizeLight.Value;
+        }
+        if (opts.PreferScanReliability) {
+            baseOptions.AnsiColorizeLight = true;
+        }
+        if (opts.Invert.HasValue) baseOptions.Invert = opts.Invert.Value;
+
+        var quiet = opts.QuietZone ?? baseOptions.QuietZone;
+        var minQuiet = Math.Max(0, opts.MinQuietZone);
+        if (opts.PreferScanReliability && minQuiet < 2) {
+            minQuiet = 2;
+        }
+        if (quiet < minQuiet) quiet = minQuiet;
+        var moduleWidth = Math.Max(1, baseOptions.ModuleWidth);
+        var moduleHeight = Math.Max(1, baseOptions.ModuleHeight);
+        var cellAspect = opts.CellAspectRatio;
+
+        if (!widthOverride && cellAspect.HasValue && cellAspect.Value > 0) {
+            moduleWidth = ComputeModuleWidthFromAspect(modules, quiet, moduleHeight, useHalfBlocks, cellAspect.Value);
+            baseOptions.ModuleWidth = moduleWidth;
+        }
+
+        var usableWidth = Math.Max(10, windowWidth - Math.Max(0, opts.PaddingColumns));
+        var usableHeight = Math.Max(5, windowHeight - Math.Max(0, opts.PaddingRows));
+
+        var quietChanged = false;
+        var allowQuietShrink = opts.AllowQuietZoneShrink && !opts.PreferScanReliability;
+        if (allowQuietShrink) {
+            var maxQuietWidth = (usableWidth / moduleWidth - modules.Width) / 2;
+            var maxQuietHeight = ((usableHeight * (useHalfBlocks ? 2 : 1)) / moduleHeight - modules.Height) / 2;
+            var maxQuiet = Math.Min(maxQuietWidth, maxQuietHeight);
+            if (maxQuiet < 0) maxQuiet = 0;
+            if (maxQuiet < quiet) {
+                quiet = maxQuiet < minQuiet ? maxQuiet : Math.Max(minQuiet, maxQuiet);
+                quietChanged = true;
+            }
+        }
+
+        if (quiet < 0) quiet = 0;
+        baseOptions.QuietZone = quiet;
+
+        if (!widthOverride && quietChanged && cellAspect.HasValue && cellAspect.Value > 0) {
+            moduleWidth = ComputeModuleWidthFromAspect(modules, quiet, moduleHeight, useHalfBlocks, cellAspect.Value);
+            baseOptions.ModuleWidth = moduleWidth;
+        }
+
+        var widthModules = modules.Width + quiet * 2;
+        var heightModules = modules.Height + quiet * 2;
+        var heightRows = useHalfBlocks ? (heightModules + 1) / 2 : heightModules;
+
+        if (!useHalfBlocks && !widthOverride && opts.AllowModuleWidthShrink && moduleWidth > 1) {
+            var scaleFitWidthShrink = usableWidth / Math.Max(1, widthModules * moduleWidth);
+            if (scaleFitWidthShrink < 1) {
+                moduleWidth = 1;
+                baseOptions.ModuleWidth = 1;
+            }
+        }
+
+        var scaleFitWidth = widthModules > 0 ? usableWidth / Math.Max(1, widthModules * moduleWidth) : 1;
+        var scaleFitHeight = heightRows > 0 ? usableHeight / Math.Max(1, heightRows * moduleHeight) : 1;
+        var scaleFit = Math.Min(scaleFitWidth, scaleFitHeight);
+        var minScale = Math.Max(1, opts.MinScale);
+        var maxScale = Math.Max(minScale, opts.MaxScale);
+        if (scaleFit < minScale) scaleFit = minScale;
+        if (scaleFit > maxScale) scaleFit = maxScale;
+        if (scaleFit < 1) scaleFit = 1;
+
+        baseOptions.Scale = scaleFit;
+        return baseOptions;
+    }
+
+    private static int ComputeModuleWidthFromAspect(BitMatrix modules, int quiet, int moduleHeight, bool useHalfBlocks, double cellAspect) {
+        var widthModules = modules.Width + quiet * 2;
+        var heightModules = modules.Height + quiet * 2;
+        if (widthModules <= 0 || heightModules <= 0) return 1;
+
+        var heightRows = useHalfBlocks ? (heightModules + 1) / 2.0 : heightModules;
+        var targetWidth = (heightRows * moduleHeight) / widthModules / cellAspect;
+        if (double.IsNaN(targetWidth) || double.IsInfinity(targetWidth)) return 1;
+        var rounded = (int)Math.Round(targetWidth, MidpointRounding.AwayFromZero);
+        if (rounded < 1) rounded = 1;
+        return rounded;
+    }
+
+    /// <summary>
+    /// Renders a matrix as console-friendly ASCII with auto-fit.
+    /// </summary>
+    public static string Render(BitMatrix modules, AsciiConsoleOptions? options = null) {
+        var renderOptions = Fit(modules, options);
+        return MatrixAsciiRenderer.Render(modules, renderOptions);
+    }
+
+    private static int GetConsoleWidth() {
+        try {
+            return Console.WindowWidth;
+        } catch {
+            return 0;
+        }
+    }
+
+    private static int GetConsoleHeight() {
+        try {
+            return Console.WindowHeight;
+        } catch {
+            return 0;
+        }
+    }
+
+    private static bool IsOutputRedirected() {
+        try {
+            return Console.IsOutputRedirected;
+        } catch {
+            return false;
+        }
+    }
+
+    private static bool DetectAnsiSupport() {
+        if (IsOutputRedirected()) return false;
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"))) return false;
+
+        var term = Environment.GetEnvironmentVariable("TERM");
+        if (string.IsNullOrEmpty(term)) return true;
+        if (string.Equals(term, "dumb", StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+    }
+
+    private static bool DetectTrueColorSupport() {
+        var colorTerm = Environment.GetEnvironmentVariable("COLORTERM");
+        if (!string.IsNullOrEmpty(colorTerm)) {
+            if (colorTerm.IndexOf("truecolor", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (colorTerm.IndexOf("24bit", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        }
+
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WT_SESSION"))) return true;
+
+        var termProgram = Environment.GetEnvironmentVariable("TERM_PROGRAM");
+        if (!string.IsNullOrEmpty(termProgram)) {
+            if (termProgram.IndexOf("vscode", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (termProgram.IndexOf("wezterm", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (termProgram.IndexOf("iterm", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        }
+
+        var term = Environment.GetEnvironmentVariable("TERM");
+        if (!string.IsNullOrEmpty(term)) {
+            if (term.IndexOf("truecolor", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            if (term.IndexOf("direct", StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        }
+
+        return false;
+    }
+
+    private static Encoding? GetConsoleEncoding() {
+        try {
+            return Console.OutputEncoding;
+        } catch {
+            return null;
+        }
+    }
+
+    private static bool CanEncode(Encoding encoding, string value) {
+        try {
+            var bytes = encoding.GetBytes(value);
+            var roundtrip = encoding.GetString(bytes);
+            return string.Equals(roundtrip, value, StringComparison.Ordinal);
+        } catch {
+            return false;
+        }
+    }
+}

--- a/CodeGlyphX/Rendering/Ascii/AsciiConsoleOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/AsciiConsoleOptions.cs
@@ -1,0 +1,184 @@
+using System.Text;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Options for console-friendly ASCII rendering with auto-fit.
+/// </summary>
+public sealed class AsciiConsoleOptions {
+    /// <summary>
+    /// Optional console window width override (columns).
+    /// </summary>
+    public int? WindowWidth { get; set; }
+
+    /// <summary>
+    /// Optional console window height override (rows).
+    /// </summary>
+    public int? WindowHeight { get; set; }
+
+    /// <summary>
+    /// Optional maximum console width to use for auto-fit (columns).
+    /// </summary>
+    public int? MaxWindowWidth { get; set; }
+
+    /// <summary>
+    /// Optional maximum console height to use for auto-fit (rows).
+    /// </summary>
+    public int? MaxWindowHeight { get; set; }
+
+    /// <summary>
+    /// Optional target output width (columns, excluding padding).
+    /// </summary>
+    public int? TargetWidth { get; set; }
+
+    /// <summary>
+    /// Optional target output height (rows, excluding padding).
+    /// </summary>
+    public int? TargetHeight { get; set; }
+
+    /// <summary>
+    /// Horizontal padding to keep around the QR when auto-fitting.
+    /// </summary>
+    public int PaddingColumns { get; set; } = 4;
+
+    /// <summary>
+    /// Vertical padding to keep around the QR when auto-fitting.
+    /// </summary>
+    public int PaddingRows { get; set; } = 2;
+
+    /// <summary>
+    /// Minimum scale applied when auto-fitting.
+    /// </summary>
+    public int MinScale { get; set; } = 1;
+
+    /// <summary>
+    /// Maximum scale applied when auto-fitting.
+    /// </summary>
+    public int MaxScale { get; set; } = 4;
+
+    /// <summary>
+    /// Minimum quiet zone size when shrinking to fit.
+    /// </summary>
+    public int MinQuietZone { get; set; } = 2;
+
+    /// <summary>
+    /// Overrides quiet zone size (modules).
+    /// </summary>
+    public int? QuietZone { get; set; }
+
+    /// <summary>
+    /// When true, allows reducing quiet zone to fit within console size.
+    /// </summary>
+    public bool AllowQuietZoneShrink { get; set; } = true;
+
+    /// <summary>
+    /// When true, allows shrinking module width to fit within console size.
+    /// </summary>
+    public bool AllowModuleWidthShrink { get; set; } = true;
+
+    /// <summary>
+    /// Optional module width override.
+    /// </summary>
+    public int? ModuleWidth { get; set; }
+
+    /// <summary>
+    /// Optional module height override.
+    /// </summary>
+    public int? ModuleHeight { get; set; }
+
+    /// <summary>
+    /// Optional dark glyph override.
+    /// </summary>
+    public string? Dark { get; set; }
+
+    /// <summary>
+    /// Optional light glyph override.
+    /// </summary>
+    public string? Light { get; set; }
+
+    /// <summary>
+    /// Optional line separator override.
+    /// </summary>
+    public string? NewLine { get; set; }
+
+    /// <summary>
+    /// When true, uses Unicode half-blocks to compress height.
+    /// </summary>
+    public bool UseHalfBlocks { get; set; } = true;
+
+    /// <summary>
+    /// When true, uses ANSI background colors for half-block rendering.
+    /// </summary>
+    public bool HalfBlockUseBackground { get; set; } = true;
+
+    /// <summary>
+    /// When true, prefers Unicode block glyphs.
+    /// </summary>
+    public bool UseUnicodeBlocks { get; set; } = true;
+
+    /// <summary>
+    /// Enables or disables ANSI colors (null = auto-detect).
+    /// </summary>
+    public bool? UseAnsiColors { get; set; }
+
+    /// <summary>
+    /// Enables or disables ANSI truecolor (null = default true).
+    /// </summary>
+    public bool? UseTrueColor { get; set; }
+
+    /// <summary>
+    /// Enables or disables ANSI colorization of light modules (null = keep preset default).
+    /// </summary>
+    public bool? ColorizeLight { get; set; }
+
+    /// <summary>
+    /// Character cell aspect ratio (width / height). Used to auto-tune module width.
+    /// </summary>
+    public double? CellAspectRatio { get; set; }
+
+    /// <summary>
+    /// Optional ANSI gradient for dark modules.
+    /// </summary>
+    public AsciiGradientOptions? DarkGradient { get; set; }
+
+    /// <summary>
+    /// Optional ANSI palette for dark modules.
+    /// </summary>
+    public AsciiPaletteOptions? DarkPalette { get; set; }
+
+    /// <summary>
+    /// When true, enables scan-friendly defaults (quiet zone, background fill, contrast clamp).
+    /// </summary>
+    public bool PreferScanReliability { get; set; }
+
+    /// <summary>
+    /// When true, clamps dark colors to a maximum luminance.
+    /// </summary>
+    public bool EnsureDarkContrast { get; set; }
+
+    /// <summary>
+    /// Maximum luminance allowed for dark modules (0-1).
+    /// </summary>
+    public double MaxDarkLuminance { get; set; } = 0.45;
+
+    /// <summary>
+    /// Optional ANSI color for dark modules.
+    /// </summary>
+    public Rgba32? DarkColor { get; set; }
+
+    /// <summary>
+    /// Optional ANSI color for light modules.
+    /// </summary>
+    public Rgba32? LightColor { get; set; }
+
+    /// <summary>
+    /// Optional output encoding override used for Unicode capability checks.
+    /// </summary>
+    public Encoding? OutputEncoding { get; set; }
+
+    /// <summary>
+    /// When true, swaps dark and light output.
+    /// </summary>
+    public bool? Invert { get; set; }
+}

--- a/CodeGlyphX/Rendering/Ascii/AsciiConsolePresets.cs
+++ b/CodeGlyphX/Rendering/Ascii/AsciiConsolePresets.cs
@@ -1,0 +1,109 @@
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Ascii;
+
+/// <summary>
+/// Ready-to-use console presets for auto-fit rendering.
+/// </summary>
+public static class AsciiConsolePresets {
+    /// <summary>
+    /// Square-ish output (no half-blocks).
+    /// </summary>
+    public static AsciiConsoleOptions Square() {
+        return new AsciiConsoleOptions {
+            UseHalfBlocks = false,
+            UseUnicodeBlocks = true,
+            QuietZone = 2,
+            MinScale = 1,
+            MaxScale = 2,
+            UseAnsiColors = true,
+            ColorizeLight = true,
+            CellAspectRatio = 0.5
+        };
+    }
+
+    /// <summary>
+    /// Compact output (half-blocks).
+    /// </summary>
+    public static AsciiConsoleOptions Compact() {
+        return new AsciiConsoleOptions {
+            UseHalfBlocks = true,
+            HalfBlockUseBackground = true,
+            UseUnicodeBlocks = true,
+            QuietZone = 2,
+            MinScale = 1,
+            MaxScale = 2,
+            UseAnsiColors = true,
+            ColorizeLight = true,
+            CellAspectRatio = 0.5
+        };
+    }
+
+    /// <summary>
+    /// Compact output with scan-friendly defaults.
+    /// </summary>
+    public static AsciiConsoleOptions ScanSafe() {
+        return new AsciiConsoleOptions {
+            UseHalfBlocks = true,
+            HalfBlockUseBackground = true,
+            UseUnicodeBlocks = true,
+            QuietZone = 2,
+            MinScale = 1,
+            MaxScale = 2,
+            UseAnsiColors = true,
+            ColorizeLight = true,
+            PreferScanReliability = true,
+            CellAspectRatio = 0.5
+        };
+    }
+
+    /// <summary>
+    /// Tiny output for tight layouts (may be less scan-friendly).
+    /// </summary>
+    public static AsciiConsoleOptions Tiny() {
+        return new AsciiConsoleOptions {
+            UseHalfBlocks = true,
+            HalfBlockUseBackground = true,
+            UseUnicodeBlocks = true,
+            QuietZone = 1,
+            MinScale = 1,
+            MaxScale = 1,
+            UseAnsiColors = true,
+            ColorizeLight = true,
+            TargetWidth = 24,
+            TargetHeight = 12,
+            CellAspectRatio = 0.45
+        };
+    }
+
+    /// <summary>
+    /// Compact output tuned for dark terminals (foreground only).
+    /// </summary>
+    /// <param name="lightColor">Optional foreground color for dark modules.</param>
+    public static AsciiConsoleOptions CompactDark(Rgba32? lightColor = null) {
+        return BuildCompactDark(lightColor);
+    }
+
+    /// <summary>
+    /// Compact output tuned for dark terminals (foreground only).
+    /// </summary>
+    /// <param name="foregroundColor">Optional foreground color for dark modules.</param>
+    public static AsciiConsoleOptions CompactDarkForeground(Rgba32? foregroundColor = null) {
+        return BuildCompactDark(foregroundColor);
+    }
+
+    private static AsciiConsoleOptions BuildCompactDark(Rgba32? foregroundColor) {
+        return new AsciiConsoleOptions {
+            UseHalfBlocks = true,
+            HalfBlockUseBackground = false,
+            UseUnicodeBlocks = true,
+            QuietZone = 2,
+            MinScale = 1,
+            MaxScale = 2,
+            UseAnsiColors = true,
+            ColorizeLight = false,
+            DarkColor = foregroundColor ?? new Rgba32(235, 235, 235),
+            CellAspectRatio = 0.5
+        };
+    }
+}

--- a/CodeGlyphX/Rendering/Ascii/AsciiPresets.cs
+++ b/CodeGlyphX/Rendering/Ascii/AsciiPresets.cs
@@ -14,11 +14,13 @@ public static class AsciiPresets {
     /// <param name="useAnsiColors">Whether to emit ANSI color escape codes.</param>
     /// <param name="trueColor">Whether to use ANSI truecolor (24-bit) output.</param>
     /// <param name="darkColor">Optional ANSI color for dark modules.</param>
+    /// <param name="lightColor">Optional ANSI color for light modules.</param>
     public static MatrixAsciiRenderOptions Console(
         int scale = 3,
         bool useAnsiColors = true,
         bool trueColor = true,
-        Rgba32? darkColor = null) {
+        Rgba32? darkColor = null,
+        Rgba32? lightColor = null) {
         if (scale <= 0) scale = 1;
 
         return new MatrixAsciiRenderOptions {
@@ -27,8 +29,41 @@ public static class AsciiPresets {
             UseAnsiColors = useAnsiColors,
             UseAnsiTrueColor = trueColor,
             AnsiDarkColor = darkColor ?? new Rgba32(16, 16, 16),
+            AnsiLightColor = lightColor ?? RenderDefaults.QrBackground,
+            AnsiColorizeLight = true,
             Scale = scale,
             ModuleWidth = 2,
+            ModuleHeight = 1,
+        };
+    }
+
+    /// <summary>
+    /// Creates a compact console preset that uses Unicode half-blocks.
+    /// </summary>
+    /// <param name="scale">Scale multiplier applied to module size (try 2-3 for screens).</param>
+    /// <param name="useAnsiColors">Whether to emit ANSI color escape codes.</param>
+    /// <param name="trueColor">Whether to use ANSI truecolor (24-bit) output.</param>
+    /// <param name="darkColor">Optional ANSI color for dark modules.</param>
+    /// <param name="lightColor">Optional ANSI color for light modules.</param>
+    public static MatrixAsciiRenderOptions ConsoleCompact(
+        int scale = 1,
+        bool useAnsiColors = true,
+        bool trueColor = true,
+        Rgba32? darkColor = null,
+        Rgba32? lightColor = null) {
+        if (scale <= 0) scale = 1;
+
+        return new MatrixAsciiRenderOptions {
+            QuietZone = RenderDefaults.QrQuietZone,
+            UseUnicodeBlocks = true,
+            UseHalfBlocks = true,
+            UseAnsiColors = useAnsiColors,
+            UseAnsiTrueColor = trueColor,
+            AnsiDarkColor = darkColor ?? new Rgba32(16, 16, 16),
+            AnsiLightColor = lightColor ?? RenderDefaults.QrBackground,
+            AnsiColorizeLight = true,
+            Scale = scale,
+            ModuleWidth = 1,
             ModuleHeight = 1,
         };
     }

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderOptions.cs
@@ -48,6 +48,36 @@ public sealed partial class MatrixAsciiRenderOptions {
     public bool UseUnicodeBlocks { get; set; }
 
     /// <summary>
+    /// When true, uses Unicode half-blocks to combine two module rows into one text row.
+    /// </summary>
+    public bool UseHalfBlocks { get; set; }
+
+    /// <summary>
+    /// When true, uses ANSI background colors for half-block rendering.
+    /// </summary>
+    public bool UseHalfBlockBackground { get; set; } = true;
+
+    /// <summary>
+    /// Optional ANSI gradient for dark modules.
+    /// </summary>
+    public AsciiGradientOptions? AnsiDarkGradient { get; set; }
+
+    /// <summary>
+    /// Optional ANSI palette for dark modules.
+    /// </summary>
+    public AsciiPaletteOptions? AnsiDarkPalette { get; set; }
+
+    /// <summary>
+    /// When true, clamps dark colors to a maximum luminance.
+    /// </summary>
+    public bool EnsureDarkContrast { get; set; }
+
+    /// <summary>
+    /// Maximum luminance allowed for dark modules (0-1).
+    /// </summary>
+    public double MaxDarkLuminance { get; set; } = 0.45;
+
+    /// <summary>
     /// When true, swaps dark and light output.
     /// </summary>
     public bool Invert { get; set; }

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -87,7 +87,7 @@ public static class MatrixAsciiRenderer {
                 var inBounds = (uint)mx < (uint)modules.Width && (uint)my < (uint)modules.Height;
                 var isDark = inBounds && modules[mx, my];
                 if (invert) isDark = !isDark;
-                if (perModuleColor && useAnsi && isDark && inBounds) {
+                if (perModuleColor && isDark && inBounds) {
                     var color = GetDarkColor(mx, my, modules.Width, modules.Height, opts, ansiDarkColor);
                     var prefix = BuildAnsiColorPrefix(CompositeOverWhite(color), ansiTrueColor);
                     row.Append(prefix).Append(darkContent).Append(AnsiReset);

--- a/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
+++ b/CodeGlyphX/Rendering/Ascii/MatrixAsciiRenderer.cs
@@ -27,6 +27,11 @@ public static class MatrixAsciiRenderer {
         var ansiDarkColor = opts.AnsiDarkColor;
         var ansiLightColor = opts.AnsiLightColor;
         var ansiColorizeLight = opts.AnsiColorizeLight;
+        var invert = opts.Invert;
+        var halfBlockBackground = opts.UseHalfBlockBackground;
+        var perModuleColor = useAnsi && (opts.AnsiDarkGradient is not null || (opts.AnsiDarkPalette?.Colors?.Length ?? 0) > 0);
+        var ensureDarkContrast = opts.EnsureDarkContrast;
+        var maxDarkLuminance = opts.MaxDarkLuminance;
 
         if (opts.UseUnicodeBlocks) {
             if (string.IsNullOrEmpty(opts.Dark) || string.Equals(opts.Dark, "#", StringComparison.Ordinal)) {
@@ -37,13 +42,16 @@ public static class MatrixAsciiRenderer {
             }
         }
 
-        if (opts.Invert) {
-            (dark, light) = (light, dark);
-            (ansiDarkColor, ansiLightColor) = (ansiLightColor, ansiDarkColor);
-        }
-
         if (useAnsi && (string.IsNullOrEmpty(opts.Dark) || string.Equals(opts.Dark, "#", StringComparison.Ordinal))) {
             dark = "█";
+        }
+
+        if (ensureDarkContrast) {
+            ansiDarkColor = ClampDarkColor(ansiDarkColor, maxDarkLuminance);
+        }
+
+        if (opts.UseHalfBlocks) {
+            return RenderHalfBlocks(modules, quiet, moduleWidth, moduleHeight, newline, useAnsi, ansiTrueColor, ansiDarkColor, ansiLightColor, invert, halfBlockBackground, opts, perModuleColor);
         }
 
         var widthModules = modules.Width + quiet * 2;
@@ -55,13 +63,16 @@ public static class MatrixAsciiRenderer {
 
         var darkCell = darkContent;
         var lightCell = lightContent;
+        var lightCellAnsi = lightContent;
         if (useAnsi) {
             var darkPrefix = BuildAnsiColorPrefix(CompositeOverWhite(ansiDarkColor), ansiTrueColor);
             darkCell = darkPrefix + darkContent + AnsiReset;
             if (ansiColorizeLight) {
-                var lightPrefix = BuildAnsiColorPrefix(CompositeOverWhite(ansiLightColor), ansiTrueColor);
+                var useBackground = IsWhitespaceOnly(lightContent);
+                var lightPrefix = BuildAnsiColorPrefix(CompositeOverWhite(ansiLightColor), ansiTrueColor, useBackground);
                 lightCell = lightPrefix + lightContent + AnsiReset;
             }
+            lightCellAnsi = lightCell;
         }
 
         var lineCapacity = widthModules * darkCell.Length;
@@ -73,14 +84,167 @@ public static class MatrixAsciiRenderer {
             var my = y - quiet;
             for (var x = 0; x < widthModules; x++) {
                 var mx = x - quiet;
-                var isDark = (uint)mx < (uint)modules.Width && (uint)my < (uint)modules.Height && modules[mx, my];
-                row.Append(isDark ? darkCell : lightCell);
+                var inBounds = (uint)mx < (uint)modules.Width && (uint)my < (uint)modules.Height;
+                var isDark = inBounds && modules[mx, my];
+                if (invert) isDark = !isDark;
+                if (perModuleColor && useAnsi && isDark && inBounds) {
+                    var color = GetDarkColor(mx, my, modules.Width, modules.Height, opts, ansiDarkColor);
+                    var prefix = BuildAnsiColorPrefix(CompositeOverWhite(color), ansiTrueColor);
+                    row.Append(prefix).Append(darkContent).Append(AnsiReset);
+                } else {
+                    row.Append(isDark ? darkCell : lightCellAnsi);
+                }
             }
 
             var rowText = row.ToString();
             for (var rep = 0; rep < moduleHeight; rep++) {
                 sb.Append(rowText);
                 if (y != heightModules - 1 || rep != moduleHeight - 1) {
+                    sb.Append(newline);
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string RenderHalfBlocks(
+        BitMatrix modules,
+        int quiet,
+        int moduleWidth,
+        int moduleHeight,
+        string newline,
+        bool useAnsi,
+        bool ansiTrueColor,
+        Rgba32 ansiDarkColor,
+        Rgba32 ansiLightColor,
+        bool invert,
+        bool useBackground,
+        MatrixAsciiRenderOptions opts,
+        bool perModuleColor) {
+        var widthModules = modules.Width + quiet * 2;
+        var heightModules = modules.Height + quiet * 2;
+        if (widthModules <= 0 || heightModules <= 0) return string.Empty;
+
+        var cellDarkDark = string.Empty;
+        var cellDarkLight = string.Empty;
+        var cellLightDark = string.Empty;
+        var cellLightLight = string.Empty;
+
+        if (useAnsi && !perModuleColor) {
+            var dark = CompositeOverWhite(ansiDarkColor);
+            var light = CompositeOverWhite(ansiLightColor);
+            var darkFg = BuildAnsiColorPrefix(dark, ansiTrueColor, background: false);
+            var lightFg = BuildAnsiColorPrefix(light, ansiTrueColor, background: false);
+
+            if (useBackground) {
+                var darkBg = BuildAnsiColorPrefix(dark, ansiTrueColor, background: true);
+                var lightBg = BuildAnsiColorPrefix(light, ansiTrueColor, background: true);
+                var glyph = Repeat('▀', moduleWidth);
+
+                cellDarkDark = darkFg + darkBg + glyph + AnsiReset;
+                cellDarkLight = darkFg + lightBg + glyph + AnsiReset;
+                cellLightDark = lightFg + darkBg + glyph + AnsiReset;
+                cellLightLight = lightFg + lightBg + glyph + AnsiReset;
+            } else {
+                var glyphDarkDark = Repeat('█', moduleWidth);
+                var glyphDarkLight = Repeat('▀', moduleWidth);
+                var glyphLightDark = Repeat('▄', moduleWidth);
+                var glyphLightLight = Repeat(' ', moduleWidth);
+
+                cellDarkDark = darkFg + glyphDarkDark + AnsiReset;
+                cellDarkLight = darkFg + glyphDarkLight + AnsiReset;
+                cellLightDark = darkFg + glyphLightDark + AnsiReset;
+                cellLightLight = glyphLightLight;
+            }
+        } else if (!useAnsi) {
+            cellDarkDark = Repeat('█', moduleWidth);
+            cellDarkLight = Repeat('▀', moduleWidth);
+            cellLightDark = Repeat('▄', moduleWidth);
+            cellLightLight = Repeat(' ', moduleWidth);
+        }
+
+        var glyphTop = string.Empty;
+        var glyphFull = string.Empty;
+        var glyphBottom = string.Empty;
+        var glyphSpace = string.Empty;
+        var lightComposite = default(Rgba32);
+        if (useAnsi && perModuleColor) {
+            glyphTop = Repeat('▀', moduleWidth);
+            glyphFull = Repeat('█', moduleWidth);
+            glyphBottom = Repeat('▄', moduleWidth);
+            glyphSpace = Repeat(' ', moduleWidth);
+            lightComposite = CompositeOverWhite(ansiLightColor);
+        }
+
+        var lineCapacity = widthModules * Math.Max(1, cellDarkDark.Length);
+        var sb = new StringBuilder((lineCapacity + newline.Length) * ((heightModules + 1) / 2) * moduleHeight);
+        var row = new StringBuilder(lineCapacity);
+
+        for (var y = 0; y < heightModules; y += 2) {
+            row.Clear();
+            var myTop = y - quiet;
+            var myBottom = y + 1 - quiet;
+            for (var x = 0; x < widthModules; x++) {
+                var mx = x - quiet;
+                var topInBounds = (uint)mx < (uint)modules.Width && (uint)myTop < (uint)modules.Height;
+                var bottomInBounds = (uint)mx < (uint)modules.Width && (uint)myBottom < (uint)modules.Height;
+                var topDark = topInBounds && modules[mx, myTop];
+                var bottomDark = bottomInBounds && modules[mx, myBottom];
+                if (invert) {
+                    topDark = !topDark;
+                    bottomDark = !bottomDark;
+                }
+
+                if (!useAnsi || !perModuleColor) {
+                    if (topDark) {
+                        row.Append(bottomDark ? cellDarkDark : cellDarkLight);
+                    } else {
+                        row.Append(bottomDark ? cellLightDark : cellLightLight);
+                    }
+                } else if (useBackground) {
+                    var topColor = topDark
+                        ? CompositeOverWhite(topInBounds ? GetDarkColor(mx, myTop, modules.Width, modules.Height, opts, ansiDarkColor) : ansiDarkColor)
+                        : lightComposite;
+                    var bottomColor = bottomDark
+                        ? CompositeOverWhite(bottomInBounds ? GetDarkColor(mx, myBottom, modules.Width, modules.Height, opts, ansiDarkColor) : ansiDarkColor)
+                        : lightComposite;
+                    var fg = BuildAnsiColorPrefix(topColor, ansiTrueColor, background: false);
+                    var bg = BuildAnsiColorPrefix(bottomColor, ansiTrueColor, background: true);
+                    row.Append(fg).Append(bg).Append(glyphTop).Append(AnsiReset);
+                } else {
+                    string glyph;
+                    Rgba32? color = null;
+                    if (topDark) {
+                        if (bottomDark) {
+                            var topColor = topInBounds ? GetDarkColor(mx, myTop, modules.Width, modules.Height, opts, ansiDarkColor) : ansiDarkColor;
+                            var bottomColor = bottomInBounds ? GetDarkColor(mx, myBottom, modules.Width, modules.Height, opts, ansiDarkColor) : ansiDarkColor;
+                            color = Lerp(topColor, bottomColor, 0.5);
+                            glyph = glyphFull;
+                        } else {
+                            color = topInBounds ? GetDarkColor(mx, myTop, modules.Width, modules.Height, opts, ansiDarkColor) : ansiDarkColor;
+                            glyph = glyphTop;
+                        }
+                    } else if (bottomDark) {
+                        color = bottomInBounds ? GetDarkColor(mx, myBottom, modules.Width, modules.Height, opts, ansiDarkColor) : ansiDarkColor;
+                        glyph = glyphBottom;
+                    } else {
+                        glyph = glyphSpace;
+                    }
+
+                    if (color.HasValue) {
+                        var prefix = BuildAnsiColorPrefix(CompositeOverWhite(color.Value), ansiTrueColor, background: false);
+                        row.Append(prefix).Append(glyph).Append(AnsiReset);
+                    } else {
+                        row.Append(glyph);
+                    }
+                }
+            }
+
+            var rowText = row.ToString();
+            for (var rep = 0; rep < moduleHeight; rep++) {
+                sb.Append(rowText);
+                if (y + 2 < heightModules || rep != moduleHeight - 1) {
                     sb.Append(newline);
                 }
             }
@@ -96,14 +260,20 @@ public static class MatrixAsciiRenderer {
         return sb.ToString();
     }
 
+    private static string Repeat(char ch, int count) {
+        if (count <= 1) return ch.ToString();
+        return new string(ch, count);
+    }
+
     private const string AnsiReset = "\u001b[0m";
 
-    private static string BuildAnsiColorPrefix(Rgba32 color, bool trueColor) {
+    private static string BuildAnsiColorPrefix(Rgba32 color, bool trueColor, bool background = false) {
+        var mode = background ? 48 : 38;
         if (trueColor) {
-            return $"\u001b[38;2;{color.R};{color.G};{color.B}m";
+            return $"\u001b[{mode};2;{color.R};{color.G};{color.B}m";
         }
         var index = MapRgbToAnsi256(color.R, color.G, color.B);
-        return $"\u001b[38;5;{index}m";
+        return $"\u001b[{mode};5;{index}m";
     }
 
     private static Rgba32 CompositeOverWhite(Rgba32 color) {
@@ -136,6 +306,105 @@ public static class MatrixAsciiRenderer {
         if (bi < 0) bi = 0;
         if (bi > 5) bi = 5;
         return 16 + 36 * ri + 6 * gi + bi;
+    }
+
+    private static bool IsWhitespaceOnly(string value) {
+        for (var i = 0; i < value.Length; i++) {
+            if (!char.IsWhiteSpace(value[i])) {
+                return false;
+            }
+        }
+        return value.Length > 0;
+    }
+
+    private static Rgba32 GetDarkColor(int mx, int my, int width, int height, MatrixAsciiRenderOptions opts, Rgba32 fallback) {
+        var gradient = opts.AnsiDarkGradient;
+        if (gradient is not null) {
+            var gx = width <= 1 ? 0.0 : mx / (double)(width - 1);
+            var gy = height <= 1 ? 0.0 : my / (double)(height - 1);
+            var t = gradient.Type switch {
+                AsciiGradientType.Vertical => gy,
+                AsciiGradientType.Diagonal => (gx + gy) * 0.5,
+                AsciiGradientType.Radial => ComputeRadialT(gx, gy, gradient.CenterX, gradient.CenterY),
+                _ => gx
+            };
+            t = Clamp01(t);
+            var color = Lerp(gradient.StartColor, gradient.EndColor, t);
+            return opts.EnsureDarkContrast ? ClampDarkColor(color, opts.MaxDarkLuminance) : color;
+        }
+
+        var palette = opts.AnsiDarkPalette;
+        if (palette is not null && palette.Colors.Length > 0) {
+            var count = palette.Colors.Length;
+            var index = palette.Mode switch {
+                AsciiPaletteMode.CycleRows => my,
+                AsciiPaletteMode.CycleDiagonal => mx + my,
+                AsciiPaletteMode.Random => Hash(mx, my, palette.Seed),
+                _ => mx
+            };
+            if (index < 0) index = -index;
+            index %= count;
+            var color = palette.Colors[index];
+            return opts.EnsureDarkContrast ? ClampDarkColor(color, opts.MaxDarkLuminance) : color;
+        }
+
+        return opts.EnsureDarkContrast ? ClampDarkColor(fallback, opts.MaxDarkLuminance) : fallback;
+    }
+
+    private static double ComputeRadialT(double gx, double gy, double cx, double cy) {
+        var dx = gx - cx;
+        var dy = gy - cy;
+        var dist = Math.Sqrt(dx * dx + dy * dy);
+        var maxDist = 0.0;
+        maxDist = Math.Max(maxDist, Math.Sqrt(cx * cx + cy * cy));
+        maxDist = Math.Max(maxDist, Math.Sqrt((1 - cx) * (1 - cx) + cy * cy));
+        maxDist = Math.Max(maxDist, Math.Sqrt(cx * cx + (1 - cy) * (1 - cy)));
+        maxDist = Math.Max(maxDist, Math.Sqrt((1 - cx) * (1 - cx) + (1 - cy) * (1 - cy)));
+        if (maxDist <= 0) return 0.0;
+        return dist / maxDist;
+    }
+
+    private static double Clamp01(double value) {
+        if (value <= 0) return 0;
+        if (value >= 1) return 1;
+        return value;
+    }
+
+    private static Rgba32 Lerp(Rgba32 a, Rgba32 b, double t) {
+        t = Clamp01(t);
+        var r = (byte)Math.Round(a.R + (b.R - a.R) * t);
+        var g = (byte)Math.Round(a.G + (b.G - a.G) * t);
+        var bch = (byte)Math.Round(a.B + (b.B - a.B) * t);
+        var aCh = (byte)Math.Round(a.A + (b.A - a.A) * t);
+        return new Rgba32(r, g, bch, aCh);
+    }
+
+    private static Rgba32 ClampDarkColor(Rgba32 color, double maxLuminance) {
+        if (maxLuminance <= 0) return color;
+        if (maxLuminance > 1) maxLuminance = 1;
+
+        var luminance = (0.2126 * color.R + 0.7152 * color.G + 0.0722 * color.B) / 255.0;
+        if (luminance <= maxLuminance) return color;
+
+        var scale = maxLuminance / luminance;
+        var r = (byte)Math.Round(color.R * scale);
+        var g = (byte)Math.Round(color.G * scale);
+        var b = (byte)Math.Round(color.B * scale);
+        return new Rgba32(r, g, b, color.A);
+    }
+
+    private static int Hash(int x, int y, int seed) {
+        unchecked {
+            var h = seed;
+            h = (h * 16777619) ^ x;
+            h = (h * 16777619) ^ y;
+            h ^= h >> 16;
+            h *= 0x7feb352d;
+            h ^= h >> 15;
+            h *= unchecked((int)0x846ca68b);
+            h ^= h >> 16;
+            return h & int.MaxValue;
+        }
     }
 
     private static string? NormalizeNewLine(string? value) {

--- a/CodeGlyphX/Rendering/Ascii/RenderOptions.Fluent.cs
+++ b/CodeGlyphX/Rendering/Ascii/RenderOptions.Fluent.cs
@@ -68,6 +68,54 @@ public sealed partial class MatrixAsciiRenderOptions {
     }
 
     /// <summary>
+    /// Enables or disables Unicode half-blocks (two module rows per text row).
+    /// </summary>
+    public MatrixAsciiRenderOptions WithHalfBlocks(bool enabled = true) {
+        UseHalfBlocks = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables ANSI background colors for half-block rendering.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithHalfBlockBackground(bool enabled = true) {
+        UseHalfBlockBackground = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets an ANSI gradient for dark modules.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiDarkGradient(AsciiGradientOptions gradient) {
+        AnsiDarkGradient = gradient;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets an ANSI palette for dark modules.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithAnsiDarkPalette(AsciiPaletteOptions palette) {
+        AnsiDarkPalette = palette;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables contrast clamping for dark modules.
+    /// </summary>
+    public MatrixAsciiRenderOptions WithEnsureDarkContrast(bool enabled = true) {
+        EnsureDarkContrast = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum luminance for dark modules (0-1).
+    /// </summary>
+    public MatrixAsciiRenderOptions WithMaxDarkLuminance(double value) {
+        MaxDarkLuminance = value;
+        return this;
+    }
+
+    /// <summary>
     /// Enables or disables inverted output (dark/light swapped).
     /// </summary>
     public MatrixAsciiRenderOptions WithInvert(bool enabled = true) {

--- a/CodeGlyphX/Rendering/RenderExtras.cs
+++ b/CodeGlyphX/Rendering/RenderExtras.cs
@@ -22,6 +22,11 @@ public sealed class RenderExtras {
     public MatrixAsciiRenderOptions? MatrixAscii { get; set; }
 
     /// <summary>
+    /// Console-friendly ASCII options (auto-fit).
+    /// </summary>
+    public AsciiConsoleOptions? AsciiConsole { get; set; }
+
+    /// <summary>
     /// ASCII render options for barcodes.
     /// </summary>
     public BarcodeAsciiRenderOptions? BarcodeAscii { get; set; }


### PR DESCRIPTION
## Summary
- add console auto-fit helpers (AsciiConsole), options, and presets (scan-safe/tiny)
- improve ASCII renderer with half-blocks, ANSI gradients/palettes, and dark contrast clamp
- add console examples + net472 smoke coverage for ASCII console
- make test TFMs OS-aware (net472 only on Windows)

## Testing
- dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release
- dotnet build CodeGlyphX.Examples/CodeGlyphX.Examples.csproj -c Release
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0

## Notes
- net472 tests run on Windows (requires .NET 4.7.2 targeting pack)