### PR TITLE
feat: expand managed jpeg encode/decode support

### DIFF
--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -261,7 +261,7 @@ internal static class QrDecodePackRunner {
         for (var run = 1; run < targetRuns; run++) {
             var res = DecodeOnce(engine, data, scenario.Options, scenario.ExpectedTexts);
             times.Add(res.ElapsedMilliseconds);
-            if (res.Info is { } infoEntry) infos.Add(infoEntry);
+            if (res.Info is { } runInfo) infos.Add(runInfo);
             if (res.Decoded) decodeSuccess++;
             if (res.ExpectedMatched) expectedMatch++;
             decodedCountSum += res.DecodedCount;

--- a/CodeGlyphX.Tests/JpegDecodeOptionsTests.cs
+++ b/CodeGlyphX.Tests/JpegDecodeOptionsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using CodeGlyphX.Rendering.Jpeg;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class JpegDecodeOptionsTests {
+    [Fact]
+    public void Decode_AllowTruncated_ReturnsImage() {
+        var rgba = CreateTestRgba(24, 24);
+        var jpeg = JpegWriter.WriteRgba(24, 24, rgba, 24 * 4, new JpegEncodeOptions { Quality = 80 });
+        var truncated = new byte[jpeg.Length - 10];
+        Array.Copy(jpeg, 0, truncated, 0, truncated.Length);
+
+        var decoded = JpegReader.DecodeRgba32(truncated, out var width, out var height, new JpegDecodeOptions(allowTruncated: true));
+        Assert.Equal(24, width);
+        Assert.Equal(24, height);
+        Assert.Equal(width * height * 4, decoded.Length);
+    }
+
+    [Fact]
+    public void Decode_HighQualityChroma_ReturnsImage() {
+        var rgba = CreateTestRgba(32, 16);
+        var jpeg = JpegWriter.WriteRgba(32, 16, rgba, 32 * 4, new JpegEncodeOptions {
+            Quality = 75,
+            Subsampling = JpegSubsampling.Y420
+        });
+
+        var decoded = JpegReader.DecodeRgba32(jpeg, out var width, out var height, new JpegDecodeOptions(highQualityChroma: true));
+        Assert.Equal(32, width);
+        Assert.Equal(16, height);
+        Assert.Equal(width * height * 4, decoded.Length);
+    }
+
+    private static byte[] CreateTestRgba(int width, int height) {
+        var rgba = new byte[width * height * 4];
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                var i = (y * width + x) * 4;
+                rgba[i + 0] = (byte)(x * 5);
+                rgba[i + 1] = (byte)(y * 11);
+                rgba[i + 2] = (byte)(255 - x * 3);
+                rgba[i + 3] = 255;
+            }
+        }
+        return rgba;
+    }
+}

--- a/CodeGlyphX.Tests/JpegEncodeOptionsTests.cs
+++ b/CodeGlyphX.Tests/JpegEncodeOptionsTests.cs
@@ -1,0 +1,136 @@
+using System;
+using CodeGlyphX.Rendering.Jpeg;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class JpegEncodeOptionsTests {
+    [Theory]
+    [InlineData(JpegSubsampling.Y444, 0x11)]
+    [InlineData(JpegSubsampling.Y422, 0x21)]
+    [InlineData(JpegSubsampling.Y420, 0x22)]
+    public void Encode_WithSubsampling_WritesSamplingFactors(JpegSubsampling subsampling, int expectedY) {
+        var rgba = CreateTestRgba(16, 16);
+        var jpeg = JpegWriter.WriteRgba(16, 16, rgba, 16 * 4, new JpegEncodeOptions {
+            Quality = 80,
+            Subsampling = subsampling
+        });
+
+        var sof = ReadSof(jpeg);
+        Assert.NotNull(sof);
+        Assert.Equal(expectedY, sof.Value.YSampling);
+        Assert.Equal(0x11, sof.Value.CbSampling);
+        Assert.Equal(0x11, sof.Value.CrSampling);
+    }
+
+    [Fact]
+    public void Encode_Progressive_WritesSof2AndMultipleScans() {
+        var rgba = CreateTestRgba(16, 16);
+        var jpeg = JpegWriter.WriteRgba(16, 16, rgba, 16 * 4, new JpegEncodeOptions {
+            Quality = 85,
+            Progressive = true
+        });
+
+        Assert.Contains((byte)0xC2, jpeg);
+        Assert.True(CountMarker(jpeg, 0xDA) >= 2);
+    }
+
+    [Fact]
+    public void Encode_OptimizedHuffman_DecodesRoundTrip() {
+        var rgba = CreateTestRgba(24, 24);
+        var jpeg = JpegWriter.WriteRgba(24, 24, rgba, 24 * 4, new JpegEncodeOptions {
+            Quality = 80,
+            OptimizeHuffman = true,
+            Subsampling = JpegSubsampling.Y420
+        });
+
+        var decoded = JpegReader.DecodeRgba32(jpeg, out var width, out var height);
+        Assert.Equal(24, width);
+        Assert.Equal(24, height);
+        Assert.Equal(width * height * 4, decoded.Length);
+    }
+
+    [Fact]
+    public void Encode_Metadata_WritesExifSegment() {
+        var rgba = CreateTestRgba(8, 8);
+        var jpeg = JpegWriter.WriteRgba(8, 8, rgba, 8 * 4, new JpegEncodeOptions {
+            Quality = 75,
+            Metadata = new JpegMetadata(exif: new byte[] { 1, 2, 3, 4 })
+        });
+
+        var exifPrefix = new byte[] { (byte)'E', (byte)'x', (byte)'i', (byte)'f', 0, 0 };
+        Assert.True(FindSequence(jpeg, exifPrefix) >= 0);
+    }
+
+    private static byte[] CreateTestRgba(int width, int height) {
+        var rgba = new byte[width * height * 4];
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                var i = (y * width + x) * 4;
+                rgba[i + 0] = (byte)(x * 7 + y * 3);
+                rgba[i + 1] = (byte)(255 - x * 5);
+                rgba[i + 2] = (byte)(y * 11);
+                rgba[i + 3] = 255;
+            }
+        }
+        return rgba;
+    }
+
+    private static (byte Marker, int YSampling, int CbSampling, int CrSampling)? ReadSof(byte[] jpeg) {
+        var i = 2;
+        while (i + 3 < jpeg.Length) {
+            if (jpeg[i] != 0xFF) {
+                i++;
+                continue;
+            }
+            var marker = jpeg[i + 1];
+            i += 2;
+            if (marker == 0xD8 || marker == 0xD9) continue;
+            if (marker == 0xDA) break;
+            if (i + 2 > jpeg.Length) break;
+            var len = (jpeg[i] << 8) | jpeg[i + 1];
+            if (len < 2 || i + len > jpeg.Length) break;
+            if (marker == 0xC0 || marker == 0xC2) {
+                var pos = i + 2;
+                var components = jpeg[pos + 5];
+                var compPos = pos + 6;
+                var ySample = 0;
+                var cbSample = 0;
+                var crSample = 0;
+                for (var c = 0; c < components; c++) {
+                    var id = jpeg[compPos];
+                    var sampling = jpeg[compPos + 1];
+                    if (id == 1) ySample = sampling;
+                    if (id == 2) cbSample = sampling;
+                    if (id == 3) crSample = sampling;
+                    compPos += 3;
+                }
+                return ((byte)marker, ySample, cbSample, crSample);
+            }
+            i += len;
+        }
+        return null;
+    }
+
+    private static int CountMarker(byte[] jpeg, byte marker) {
+        var count = 0;
+        for (var i = 0; i + 1 < jpeg.Length; i++) {
+            if (jpeg[i] == 0xFF && jpeg[i + 1] == marker) count++;
+        }
+        return count;
+    }
+
+    private static int FindSequence(byte[] data, byte[] needle) {
+        for (var i = 0; i <= data.Length - needle.Length; i++) {
+            var match = true;
+            for (var j = 0; j < needle.Length; j++) {
+                if (data[i + j] != needle[j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return i;
+        }
+        return -1;
+    }
+}

--- a/CodeGlyphX.Tests/JpegReaderTests.cs
+++ b/CodeGlyphX.Tests/JpegReaderTests.cs
@@ -33,7 +33,8 @@ public class JpegReaderTests {
         var data = File.ReadAllBytes(path);
         var (expectedWidth, expectedHeight) = JpegTestHelpers.ReadJpegSize(data);
 
-        var rgba = JpegReader.DecodeRgba32(data, out var width, out var height);
+        var options = new JpegDecodeOptions(allowTruncated: true);
+        var rgba = JpegReader.DecodeRgba32(data, out var width, out var height, options);
 
         Assert.Equal(expectedWidth, width);
         Assert.Equal(expectedHeight, height);
@@ -46,12 +47,14 @@ public class JpegReaderTests {
         var data = File.ReadAllBytes(path);
         var (expectedWidth, expectedHeight) = JpegTestHelpers.ReadJpegSize(data);
 
-        var rgba = JpegReader.DecodeRgba32(data, out var width, out var height);
+        var options = new JpegDecodeOptions(allowTruncated: true);
+        var rgba = JpegReader.DecodeRgba32(data, out var width, out var height, options);
 
         Assert.Equal(expectedWidth, width);
         Assert.Equal(expectedHeight, height);
         Assert.Equal(width * height * 4, rgba.Length);
     }
+
 
     [Fact]
     public void DecodeJpeg_ExifOrientation() {
@@ -59,25 +62,9 @@ public class JpegReaderTests {
         var data = File.ReadAllBytes(path);
         var (rawWidth, rawHeight) = JpegTestHelpers.ReadJpegSize(data);
         var orientation = JpegTestHelpers.ReadExifOrientation(data);
-
         var rgba = JpegReader.DecodeRgba32(data, out var width, out var height);
 
         Assert.Equal(6, orientation);
-        Assert.Equal(rawHeight, width);
-        Assert.Equal(rawWidth, height);
-        Assert.Equal(width * height * 4, rgba.Length);
-    }
-
-    [Fact]
-    public void DecodeJpeg_ExifOrientation_RotateLeft() {
-        var path = JpegTestHelpers.GetFixturePath("Landscape_8.jpg");
-        var data = File.ReadAllBytes(path);
-        var (rawWidth, rawHeight) = JpegTestHelpers.ReadJpegSize(data);
-        var orientation = JpegTestHelpers.ReadExifOrientation(data);
-
-        var rgba = JpegReader.DecodeRgba32(data, out var width, out var height);
-
-        Assert.Equal(8, orientation);
         Assert.Equal(rawHeight, width);
         Assert.Equal(rawWidth, height);
         Assert.Equal(width * height * 4, rgba.Length);

--- a/CodeGlyphX.Tests/JpegRendererTests.cs
+++ b/CodeGlyphX.Tests/JpegRendererTests.cs
@@ -6,7 +6,7 @@ namespace CodeGlyphX.Tests;
 
 public sealed class JpegRendererTests {
     [Fact]
-    public void Render_Qr_Jpeg_Has_Sof0_And_Dimensions() {
+    public void Render_Qr_Jpeg_Has_Sof_And_Dimensions() {
         var qr = QrCodeEncoder.EncodeText("HELLO");
         var opts = new QrPngRenderOptions { ModuleSize = 4, QuietZone = 4 };
         var jpg = QrJpegRenderer.Render(qr.Modules, opts, quality: 80);
@@ -17,13 +17,13 @@ public sealed class JpegRendererTests {
         Assert.Equal(0xFF, jpg[^2]);
         Assert.Equal(0xD9, jpg[^1]);
 
-        var (w, h) = ReadSof0(jpg);
+        var (w, h) = ReadSof(jpg);
         var expected = (qr.Modules.Width + opts.QuietZone * 2) * opts.ModuleSize;
         Assert.Equal(expected, w);
         Assert.Equal(expected, h);
     }
 
-    private static (int width, int height) ReadSof0(byte[] jpeg) {
+    private static (int width, int height) ReadSof(byte[] jpeg) {
         var i = 2;
         while (i + 3 < jpeg.Length) {
             if (jpeg[i] != 0xFF) {
@@ -37,7 +37,7 @@ public sealed class JpegRendererTests {
             if (i + 2 > jpeg.Length) break;
             var len = (jpeg[i] << 8) | jpeg[i + 1];
             if (len < 2 || i + len > jpeg.Length) break;
-            if (marker == 0xC0) {
+            if (marker == 0xC0 || marker == 0xC2) {
                 var height = (jpeg[i + 3] << 8) | jpeg[i + 4];
                 var width = (jpeg[i + 5] << 8) | jpeg[i + 6];
                 return (width, height);

--- a/CodeGlyphX.Website/wwwroot/api-docs/CodeGlyphX.xml
+++ b/CodeGlyphX.Website/wwwroot/api-docs/CodeGlyphX.xml
@@ -1160,6 +1160,11 @@
             Sets JPEG quality.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Barcode.BarcodeBuilder.WithJpegOptions(CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Sets JPEG encoding options.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Barcode.BarcodeBuilder.WithLabel(System.String)">
             <summary>
             Sets label text rendered under bars.
@@ -2774,6 +2779,12 @@
             JPEG quality (1..100).
             </summary>
         </member>
+        <member name="P:CodeGlyphX.BarcodeOptions.JpegOptions">
+            <summary>
+            Optional JPEG encoding options (subsampling/progressive/metadata/etc).
+            When set, overrides <see cref="P:CodeGlyphX.BarcodeOptions.JpegQuality"/> where applicable.
+            </summary>
+        </member>
         <member name="P:CodeGlyphX.BarcodeOptions.WebpQuality">
             <summary>
             WebP quality (0..100). A value of 100 uses lossless VP8L.
@@ -3750,6 +3761,28 @@
             Configures image decode options fluently.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.CodeGlyphDecodeOptions.WithJpegOptions(CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions)">
+            <summary>
+            Sets JPEG decoding options on the image decode options.
+            </summary>
+            <example>
+            <code>
+            var options = new CodeGlyphDecodeOptions()
+                .WithJpegOptions(highQualityChroma: true, allowTruncated: true);
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.CodeGlyphDecodeOptions.WithJpegOptions(System.Boolean,System.Boolean)">
+            <summary>
+            Sets JPEG decoding options on the image decode options.
+            </summary>
+            <example>
+            <code>
+            var options = new CodeGlyphDecodeOptions()
+                .WithJpegOptions(highQualityChroma: true);
+            </code>
+            </example>
+        </member>
         <member name="M:CodeGlyphX.CodeGlyphDecodeOptions.WithExpectedBarcode(System.Nullable{CodeGlyphX.BarcodeType})">
             <summary>
             Sets the expected barcode type.
@@ -4085,6 +4118,11 @@
         <member name="M:CodeGlyphX.DataMatrixCode.DataMatrixBuilder.WithJpegQuality(System.Int32)">
             <summary>
             Sets JPEG quality (1..100).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.DataMatrixCode.DataMatrixBuilder.WithJpegOptions(CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Sets JPEG encoding options.
             </summary>
         </member>
         <member name="M:CodeGlyphX.DataMatrixCode.DataMatrixBuilder.WithHtmlEmailSafeTable(System.Boolean)">
@@ -5730,6 +5768,11 @@
             Maximum milliseconds to spend decoding (best effort). Set to 0 to disable.
             </summary>
         </member>
+        <member name="P:CodeGlyphX.ImageDecodeOptions.JpegOptions">
+            <summary>
+            Optional JPEG decoding options (chroma upsampling, truncated handling).
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.ImageDecodeOptions.Screen(System.Int32,System.Int32)">
             <summary>
             Screen preset (budgeted decode for UI capture scenarios).
@@ -5749,6 +5792,28 @@
             <summary>
             Sets the time+dimension budget in one call.
             </summary>
+        </member>
+        <member name="M:CodeGlyphX.ImageDecodeOptions.WithJpegOptions(CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions)">
+            <summary>
+            Sets JPEG decoding options.
+            </summary>
+            <example>
+            <code>
+            var options = new ImageDecodeOptions()
+                .WithJpegOptions(highQualityChroma: true, allowTruncated: true);
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.ImageDecodeOptions.WithJpegOptions(System.Boolean,System.Boolean)">
+            <summary>
+            Sets JPEG decoding options.
+            </summary>
+            <example>
+            <code>
+            var options = new ImageDecodeOptions()
+                .WithJpegOptions(highQualityChroma: true);
+            </code>
+            </example>
         </member>
         <member name="M:CodeGlyphX.Internal.RegexCache.DigitsOptional">
             <remarks>
@@ -6099,6 +6164,12 @@
         <member name="P:CodeGlyphX.MatrixOptions.JpegQuality">
             <summary>
             JPEG quality (1..100).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.MatrixOptions.JpegOptions">
+            <summary>
+            Optional JPEG encoding options (subsampling/progressive/metadata/etc).
+            When set, overrides <see cref="P:CodeGlyphX.MatrixOptions.JpegQuality"/> where applicable.
             </summary>
         </member>
         <member name="P:CodeGlyphX.MatrixOptions.WebpQuality">
@@ -9147,6 +9218,11 @@
             Sets JPEG quality (1..100).
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Pdf417Code.Pdf417Builder.WithJpegOptions(CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Sets JPEG encoding options.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Pdf417Code.Pdf417Builder.WithHtmlEmailSafeTable(System.Boolean)">
             <summary>
             Enables HTML email-safe table rendering.
@@ -11389,9 +11465,19 @@
             Renders ASCII text.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.QR.QrBuilder.AsciiConsole(CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions)">
+            <summary>
+            Renders console-friendly ASCII text with auto-fit.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.QR.QrBuilder.SaveAscii(System.String,CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions)">
             <summary>
             Saves ASCII to a file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.QR.QrBuilder.SaveAsciiConsole(System.String,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions)">
+            <summary>
+            Saves console-friendly ASCII to a file.
             </summary>
         </member>
         <member name="M:CodeGlyphX.QR.QrBuilder.Save(System.String,System.String)">
@@ -11704,14 +11790,29 @@
             Renders a QR code as ASCII text.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.QR.AsciiConsole(System.String,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions,CodeGlyphX.QrEasyOptions)">
+            <summary>
+            Renders a QR code as console-friendly ASCII text with auto-fit.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.QR.AsciiAuto(System.String,CodeGlyphX.Payloads.QrPayloadDetectOptions,CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions,CodeGlyphX.QrEasyOptions)">
             <summary>
             Detects a payload type and renders a QR code as ASCII text.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.QR.AsciiConsoleAuto(System.String,CodeGlyphX.Payloads.QrPayloadDetectOptions,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions,CodeGlyphX.QrEasyOptions)">
+            <summary>
+            Detects a payload type and renders a QR code as console-friendly ASCII text with auto-fit.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.QR.Ascii(CodeGlyphX.Payloads.QrPayloadData,CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions,CodeGlyphX.QrEasyOptions)">
             <summary>
             Renders a QR code as ASCII text for a payload with embedded defaults.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.QR.AsciiConsole(CodeGlyphX.Payloads.QrPayloadData,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions,CodeGlyphX.QrEasyOptions)">
+            <summary>
+            Renders a QR code as console-friendly ASCII text with auto-fit for a payload with embedded defaults.
             </summary>
         </member>
         <member name="M:CodeGlyphX.QR.TryDecodePng(System.Byte[],CodeGlyphX.QrDecoded@)">
@@ -13409,6 +13510,21 @@
             Evaluates QR art safety for a payload with embedded defaults.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.QrEasy.RenderAsciiConsole(System.String,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions,CodeGlyphX.QrEasyOptions)">
+            <summary>
+            Renders a QR code as console-friendly ASCII with auto-fit.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.QrEasy.RenderAsciiConsoleAuto(System.String,CodeGlyphX.Payloads.QrPayloadDetectOptions,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions,CodeGlyphX.QrEasyOptions)">
+            <summary>
+            Detects a payload type and renders a QR code as console-friendly ASCII with auto-fit.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.QrEasy.RenderAsciiConsole(CodeGlyphX.Payloads.QrPayloadData,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions,CodeGlyphX.QrEasyOptions)">
+            <summary>
+            Renders a QR code as console-friendly ASCII with auto-fit for a payload with embedded defaults.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.QrEasy.RenderPng(System.String,CodeGlyphX.QrEasyOptions)">
             <summary>
             Renders a QR code as PNG.
@@ -14337,6 +14453,12 @@
             JPEG quality (1..100).
             </summary>
         </member>
+        <member name="P:CodeGlyphX.QrEasyOptions.JpegOptions">
+            <summary>
+            Optional JPEG encoding options (subsampling/progressive/metadata/etc).
+            When set, overrides <see cref="P:CodeGlyphX.QrEasyOptions.JpegQuality"/> where applicable.
+            </summary>
+        </member>
         <member name="P:CodeGlyphX.QrEasyOptions.WebpQuality">
             <summary>
             WebP quality (0..100). A value of 100 uses lossless VP8L.
@@ -15132,12 +15254,344 @@
             Shift-JIS (JIS X 0208 + halfwidth katakana).
             </summary>
         </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiGradientType">
+            <summary>
+            Gradient styles for ANSI coloring.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiGradientType.Horizontal">
+            <summary>
+            Left-to-right gradient.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiGradientType.Vertical">
+            <summary>
+            Top-to-bottom gradient.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiGradientType.Diagonal">
+            <summary>
+            Top-left to bottom-right gradient.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiGradientType.Radial">
+            <summary>
+            Radial gradient from a center point.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiPaletteMode">
+            <summary>
+            Palette selection modes for ANSI coloring.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiPaletteMode.CycleRows">
+            <summary>
+            Cycles palette entries per row.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiPaletteMode.CycleColumns">
+            <summary>
+            Cycles palette entries per column.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiPaletteMode.CycleDiagonal">
+            <summary>
+            Cycles palette entries along diagonals.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Ascii.AsciiPaletteMode.Random">
+            <summary>
+            Randomizes palette entries per module.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiGradientOptions">
+            <summary>
+            Gradient settings for ANSI coloring.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiGradientOptions.Type">
+            <summary>
+            Gradient type used for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiGradientOptions.StartColor">
+            <summary>
+            Gradient start color.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiGradientOptions.EndColor">
+            <summary>
+            Gradient end color.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiGradientOptions.CenterX">
+            <summary>
+            Horizontal gradient center for radial mode (0-1).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiGradientOptions.CenterY">
+            <summary>
+            Vertical gradient center for radial mode (0-1).
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiPaletteOptions">
+            <summary>
+            Palette settings for ANSI coloring.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiPaletteOptions.Mode">
+            <summary>
+            Palette selection mode.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiPaletteOptions.Colors">
+            <summary>
+            Palette colors used for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiPaletteOptions.Seed">
+            <summary>
+            Seed used for random palette selection.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiConsole">
+            <summary>
+            Helpers for console-friendly ASCII rendering.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsole.Fit(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions)">
+            <summary>
+            Builds ASCII render options that auto-fit a console window.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsole.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions)">
+            <summary>
+            Renders a matrix as console-friendly ASCII with auto-fit.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions">
+            <summary>
+            Options for console-friendly ASCII rendering with auto-fit.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.WindowWidth">
+            <summary>
+            Optional console window width override (columns).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.WindowHeight">
+            <summary>
+            Optional console window height override (rows).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.MaxWindowWidth">
+            <summary>
+            Optional maximum console width to use for auto-fit (columns).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.MaxWindowHeight">
+            <summary>
+            Optional maximum console height to use for auto-fit (rows).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.TargetWidth">
+            <summary>
+            Optional target output width (columns, excluding padding).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.TargetHeight">
+            <summary>
+            Optional target output height (rows, excluding padding).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.PaddingColumns">
+            <summary>
+            Horizontal padding to keep around the QR when auto-fitting.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.PaddingRows">
+            <summary>
+            Vertical padding to keep around the QR when auto-fitting.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.MinScale">
+            <summary>
+            Minimum scale applied when auto-fitting.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.MaxScale">
+            <summary>
+            Maximum scale applied when auto-fitting.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.MinQuietZone">
+            <summary>
+            Minimum quiet zone size when shrinking to fit.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.QuietZone">
+            <summary>
+            Overrides quiet zone size (modules).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.AllowQuietZoneShrink">
+            <summary>
+            When true, allows reducing quiet zone to fit within console size.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.AllowModuleWidthShrink">
+            <summary>
+            When true, allows shrinking module width to fit within console size.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.ModuleWidth">
+            <summary>
+            Optional module width override.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.ModuleHeight">
+            <summary>
+            Optional module height override.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.Dark">
+            <summary>
+            Optional dark glyph override.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.Light">
+            <summary>
+            Optional light glyph override.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.NewLine">
+            <summary>
+            Optional line separator override.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.UseHalfBlocks">
+            <summary>
+            When true, uses Unicode half-blocks to compress height.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.HalfBlockUseBackground">
+            <summary>
+            When true, uses ANSI background colors for half-block rendering.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.UseUnicodeBlocks">
+            <summary>
+            When true, prefers Unicode block glyphs.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.UseAnsiColors">
+            <summary>
+            Enables or disables ANSI colors (null = auto-detect).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.UseTrueColor">
+            <summary>
+            Enables or disables ANSI truecolor (null = default true).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.ColorizeLight">
+            <summary>
+            Enables or disables ANSI colorization of light modules (null = keep preset default).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.CellAspectRatio">
+            <summary>
+            Character cell aspect ratio (width / height). Used to auto-tune module width.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.DarkGradient">
+            <summary>
+            Optional ANSI gradient for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.DarkPalette">
+            <summary>
+            Optional ANSI palette for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.PreferScanReliability">
+            <summary>
+            When true, enables scan-friendly defaults (quiet zone, background fill, contrast clamp).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.EnsureDarkContrast">
+            <summary>
+            When true, clamps dark colors to a maximum luminance.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.MaxDarkLuminance">
+            <summary>
+            Maximum luminance allowed for dark modules (0-1).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.DarkColor">
+            <summary>
+            Optional ANSI color for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.LightColor">
+            <summary>
+            Optional ANSI color for light modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.OutputEncoding">
+            <summary>
+            Optional output encoding override used for Unicode capability checks.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.AsciiConsoleOptions.Invert">
+            <summary>
+            When true, swaps dark and light output.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets">
+            <summary>
+            Ready-to-use console presets for auto-fit rendering.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets.Square">
+            <summary>
+            Square-ish output (no half-blocks).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets.Compact">
+            <summary>
+            Compact output (half-blocks).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets.ScanSafe">
+            <summary>
+            Compact output with scan-friendly defaults.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets.Tiny">
+            <summary>
+            Tiny output for tight layouts (may be less scan-friendly).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets.CompactDark(System.Nullable{CodeGlyphX.Rendering.Png.Rgba32})">
+            <summary>
+            Compact output tuned for dark terminals (foreground only).
+            </summary>
+            <param name="lightColor">Optional foreground color for dark modules.</param>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiConsolePresets.CompactDarkForeground(System.Nullable{CodeGlyphX.Rendering.Png.Rgba32})">
+            <summary>
+            Compact output tuned for dark terminals (foreground only).
+            </summary>
+            <param name="foregroundColor">Optional foreground color for dark modules.</param>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Ascii.AsciiPresets">
             <summary>
             Ready-to-use ASCII render presets tuned for console readability.
             </summary>
         </member>
-        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiPresets.Console(System.Int32,System.Boolean,System.Boolean,System.Nullable{CodeGlyphX.Rendering.Png.Rgba32})">
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiPresets.Console(System.Int32,System.Boolean,System.Boolean,System.Nullable{CodeGlyphX.Rendering.Png.Rgba32},System.Nullable{CodeGlyphX.Rendering.Png.Rgba32})">
             <summary>
             Creates a console-friendly preset that is much easier to scan from a terminal.
             </summary>
@@ -15145,6 +15599,17 @@
             <param name="useAnsiColors">Whether to emit ANSI color escape codes.</param>
             <param name="trueColor">Whether to use ANSI truecolor (24-bit) output.</param>
             <param name="darkColor">Optional ANSI color for dark modules.</param>
+            <param name="lightColor">Optional ANSI color for light modules.</param>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.AsciiPresets.ConsoleCompact(System.Int32,System.Boolean,System.Boolean,System.Nullable{CodeGlyphX.Rendering.Png.Rgba32},System.Nullable{CodeGlyphX.Rendering.Png.Rgba32})">
+            <summary>
+            Creates a compact console preset that uses Unicode half-blocks.
+            </summary>
+            <param name="scale">Scale multiplier applied to module size (try 2-3 for screens).</param>
+            <param name="useAnsiColors">Whether to emit ANSI color escape codes.</param>
+            <param name="trueColor">Whether to use ANSI truecolor (24-bit) output.</param>
+            <param name="darkColor">Optional ANSI color for dark modules.</param>
+            <param name="lightColor">Optional ANSI color for light modules.</param>
         </member>
         <member name="T:CodeGlyphX.Rendering.Ascii.BarcodeAsciiRenderer">
             <summary>
@@ -15276,6 +15741,36 @@
             When true, prefers Unicode block glyphs (for example, █) when defaults are used.
             </summary>
         </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.UseHalfBlocks">
+            <summary>
+            When true, uses Unicode half-blocks to combine two module rows into one text row.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.UseHalfBlockBackground">
+            <summary>
+            When true, uses ANSI background colors for half-block rendering.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.AnsiDarkGradient">
+            <summary>
+            Optional ANSI gradient for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.AnsiDarkPalette">
+            <summary>
+            Optional ANSI palette for dark modules.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.EnsureDarkContrast">
+            <summary>
+            When true, clamps dark colors to a maximum luminance.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.MaxDarkLuminance">
+            <summary>
+            Maximum luminance allowed for dark modules (0-1).
+            </summary>
+        </member>
         <member name="P:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.Invert">
             <summary>
             When true, swaps dark and light output.
@@ -15344,6 +15839,36 @@
         <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithUnicodeBlocks(System.Boolean)">
             <summary>
             Enables or disables Unicode block glyphs when defaults are used.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithHalfBlocks(System.Boolean)">
+            <summary>
+            Enables or disables Unicode half-blocks (two module rows per text row).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithHalfBlockBackground(System.Boolean)">
+            <summary>
+            Enables or disables ANSI background colors for half-block rendering.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithAnsiDarkGradient(CodeGlyphX.Rendering.Ascii.AsciiGradientOptions)">
+            <summary>
+            Sets an ANSI gradient for dark modules.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithAnsiDarkPalette(CodeGlyphX.Rendering.Ascii.AsciiPaletteOptions)">
+            <summary>
+            Sets an ANSI palette for dark modules.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithEnsureDarkContrast(System.Boolean)">
+            <summary>
+            Enables or disables contrast clamping for dark modules.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithMaxDarkLuminance(System.Double)">
+            <summary>
+            Sets the maximum luminance for dark modules (0-1).
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Ascii.MatrixAsciiRenderOptions.WithInvert(System.Boolean)">
@@ -15596,14 +16121,359 @@
             Renders the QR module matrix to an EPS file under the specified directory.
             </summary>
         </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer">
+            <summary>
+            Renders 1D barcodes to a GIF image (indexed color).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.Render(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions)">
+            <summary>
+            Renders the barcode to a GIF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream)">
+            <summary>
+            Renders the barcode to a GIF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String)">
+            <summary>
+            Renders the barcode to a GIF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String)">
+            <summary>
+            Renders the barcode to a GIF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimation(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF from multiple barcode frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimation(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF from multiple barcode frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimationToStream(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a stream from multiple barcode frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimationToStream(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a stream from multiple barcode frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file from multiple barcode frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file from multiple barcode frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.String,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.BarcodeGifRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],System.String,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file under the specified directory with per-frame durations.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.GifAnimationFrame">
+            <summary>
+            Describes a single RGBA32 frame for animated GIF decoding.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifAnimationFrame.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Gif.GifDisposalMethod)">
+            <summary>
+            Creates a GIF animation frame backed by an RGBA32 buffer.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifAnimationFrame.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32,System.Int32,System.Boolean)">
+            <summary>
+            Creates a GIF animation frame backed by an RGBA32 buffer with a convenience disposal flag.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.Rgba">
+            <summary>
+            RGBA32 pixel buffer.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.Width">
+            <summary>
+            Frame width in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.Height">
+            <summary>
+            Frame height in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.Stride">
+            <summary>
+            Frame stride in bytes.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.DurationMs">
+            <summary>
+            Frame duration in milliseconds.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.X">
+            <summary>
+            Frame X offset on the canvas.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.Y">
+            <summary>
+            Frame Y offset on the canvas.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationFrame.DisposalMethod">
+            <summary>
+            Disposal method for the frame.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.GifDisposalMethod">
+            <summary>
+            GIF disposal methods.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Gif.GifDisposalMethod.None">
+            <summary>
+            No disposal specified.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Gif.GifDisposalMethod.DoNotDispose">
+            <summary>
+            Do not dispose (keep frame).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Gif.GifDisposalMethod.RestoreBackground">
+            <summary>
+            Restore to background.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Gif.GifDisposalMethod.RestorePrevious">
+            <summary>
+            Restore to previous.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.GifAnimationOptions">
+            <summary>
+            Options extracted from an animated GIF.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifAnimationOptions.#ctor(System.Int32,System.UInt32)">
+            <summary>
+            Creates animation options.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationOptions.LoopCount">
+            <summary>
+            Loop count (0 = infinite).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Gif.GifAnimationOptions.BackgroundRgba">
+            <summary>
+            Background color in RGBA byte order.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Gif.GifReader">
             <summary>
-            Decodes GIF images to RGBA buffers (first frame only).
+            Decodes GIF images to RGBA buffers and animation frames.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Gif.GifReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
             <summary>
             Decodes a GIF image to an RGBA buffer.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifReader.TryDecodeAnimationFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames (frame rectangles only).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifReader.DecodeAnimationFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Decodes GIF animation frames (frame rectangles only).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifReader.TryDecodeAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames composited onto the canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifReader.DecodeAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Decodes GIF animation frames composited onto the canvas.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.GifWriter">
+            <summary>
+            Writes GIF images from RGBA buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifWriter.WriteRgba32(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a GIF byte array from an RGBA buffer (single frame).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a GIF to a stream from an RGBA buffer (single frame).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifWriter.WriteAnimation(System.Int32,System.Int32,CodeGlyphX.Rendering.Gif.GifAnimationFrame[],CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Writes a GIF animation byte array from RGBA frame buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifWriter.WriteAnimationRgba32(System.Int32,System.Int32,CodeGlyphX.Rendering.Gif.GifAnimationFrame[],CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Writes a GIF animation byte array from RGBA frame buffers (compatibility alias).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.GifWriter.WriteAnimation(System.IO.Stream,System.Int32,System.Int32,CodeGlyphX.Rendering.Gif.GifAnimationFrame[],CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Writes a GIF animation to a stream from RGBA frame buffers.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.MatrixGifRenderer">
+            <summary>
+            Renders matrix codes to a GIF image (indexed color).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions)">
+            <summary>
+            Renders the module matrix to a GIF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream)">
+            <summary>
+            Renders the module matrix to a GIF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String)">
+            <summary>
+            Renders the module matrix to a GIF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String)">
+            <summary>
+            Renders the module matrix to a GIF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF from multiple module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF from multiple module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a stream from multiple module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a stream from multiple module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file from multiple module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file from multiple module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.String,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.MatrixGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],System.String,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file under the specified directory with per-frame durations.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Gif.QrGifRenderer">
+            <summary>
+            Renders QR modules to a GIF image (indexed color).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions)">
+            <summary>
+            Renders the QR module matrix to a GIF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.IO.Stream)">
+            <summary>
+            Renders the QR module matrix to a GIF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String)">
+            <summary>
+            Renders the QR module matrix to a GIF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,System.String)">
+            <summary>
+            Renders the QR module matrix to a GIF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF from multiple QR module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF from multiple QR module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a stream from multiple QR module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a stream from multiple QR module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file from multiple QR module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file from multiple QR module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,System.String,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Gif.QrGifRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],System.String,System.String,CodeGlyphX.Rendering.Gif.GifAnimationOptions)">
+            <summary>
+            Renders an animated GIF to a file under the specified directory with per-frame durations.
             </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.Html.BarcodeHtmlRenderOptions">
@@ -16172,9 +17042,114 @@
             Renders the QR module matrix to an ICO file under the specified directory.
             </summary>
         </member>
+        <member name="T:CodeGlyphX.Rendering.ImageAnimationFrame">
+            <summary>
+            Describes a single RGBA32 animation frame.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageAnimationFrame.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Creates an animation frame backed by an RGBA32 buffer.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.Rgba">
+            <summary>
+            RGBA32 pixel buffer.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.Width">
+            <summary>
+            Frame width in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.Height">
+            <summary>
+            Frame height in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.Stride">
+            <summary>
+            Frame stride in bytes.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.DurationMs">
+            <summary>
+            Frame duration in milliseconds.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.X">
+            <summary>
+            Frame X offset on the canvas.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationFrame.Y">
+            <summary>
+            Frame Y offset on the canvas.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.ImageAnimationOptions">
+            <summary>
+            Options for decoded animations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageAnimationOptions.#ctor(System.Int32,System.UInt32)">
+            <summary>
+            Creates animation options.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationOptions.LoopCount">
+            <summary>
+            Loop count (0 = infinite).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationOptions.BackgroundRgba">
+            <summary>
+            Background color in RGBA byte order.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.ImageAnimationInfo">
+            <summary>
+            Basic animation metadata returned by ImageReader.TryReadAnimationInfo.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationInfo.Format">
+            <summary>
+            Image format.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationInfo.Width">
+            <summary>
+            Canvas width in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationInfo.Height">
+            <summary>
+            Canvas height in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationInfo.FrameCount">
+            <summary>
+            Number of frames in the animation.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationInfo.Options">
+            <summary>
+            Animation options such as loop count and background color.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.ImageAnimationInfo.IsValid">
+            <summary>
+            Indicates whether the info looks valid.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageAnimationInfo.#ctor(CodeGlyphX.Rendering.ImageFormat,System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.ImageAnimationOptions)">
+            <summary>
+            Creates a new <see cref="T:CodeGlyphX.Rendering.ImageAnimationInfo"/>.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.ImageFormat">
             <summary>
-            Known image formats supported by <see cref="T:CodeGlyphX.Rendering.ImageReader"/>.
+            Known image formats detected by <see cref="T:CodeGlyphX.Rendering.ImageReader"/>.
             </summary>
         </member>
         <member name="F:CodeGlyphX.Rendering.ImageFormat.Unknown">
@@ -16252,6 +17227,36 @@
             WebP image (managed VP8/VP8L stills; first-frame decode for animations).
             </summary>
         </member>
+        <member name="F:CodeGlyphX.Rendering.ImageFormat.Avif">
+            <summary>
+            AVIF image (ISOBMFF).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.ImageFormat.Heic">
+            <summary>
+            HEIC/HEIF image (ISOBMFF).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.ImageFormat.Jpeg2000">
+            <summary>
+            JPEG2000 image.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.ImageFormat.Psd">
+            <summary>
+            Photoshop PSD image.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.ImageFormat.Pdf">
+            <summary>
+            PDF document.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.ImageFormat.Ps">
+            <summary>
+            PostScript document.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.ImageInfo">
             <summary>
             Basic image metadata returned by ImageReader.TryReadInfo.
@@ -16292,19 +17297,225 @@
             Decodes an image to an RGBA buffer (auto-detected).
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.Byte[],CodeGlyphX.ImageDecodeOptions,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image to an RGBA buffer (auto-detected) with decode options.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.Byte[],System.Int32,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes a multipage image to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32Composite(System.Byte[],System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32Composite(System.Byte[],CodeGlyphX.ImageDecodeOptions,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available, with decode options.
+            </summary>
+            <example>
+            <code>
+            var options = new ImageDecodeOptions()
+                .WithJpegOptions(highQualityChroma: true, allowTruncated: true);
+            var rgba = ImageReader.DecodeRgba32Composite(bytes, options, out var width, out var height);
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeAnimationFrames(System.Byte[],System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Decodes animation frames (non-composited) (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeAnimationCanvasFrames(System.Byte[],System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Decodes animation frames composited onto a full canvas (auto-detected).
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
             <summary>
             Decodes an image to an RGBA buffer (auto-detected).
             </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},CodeGlyphX.ImageDecodeOptions,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image to an RGBA buffer (auto-detected) with decode options.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeAnimationFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Decodes animation frames (non-composited) (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes a multipage image to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Decodes animation frames composited onto a full canvas (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32Composite(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32Composite(System.ReadOnlySpan{System.Byte},CodeGlyphX.ImageDecodeOptions,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available, with decode options.
+            </summary>
+            <example>
+            <code>
+            var options = new ImageDecodeOptions()
+                .WithJpegOptions(highQualityChroma: true);
+            var rgba = ImageReader.DecodeRgba32Composite(data, options, out var width, out var height);
+            </code>
+            </example>
         </member>
         <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.IO.Stream,System.Int32@,System.Int32@)">
             <summary>
             Decodes an image stream to an RGBA buffer (auto-detected).
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.IO.Stream,CodeGlyphX.ImageDecodeOptions,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image stream to an RGBA buffer (auto-detected) with decode options.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32(System.IO.Stream,System.Int32,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes a multipage image stream to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32Composite(System.IO.Stream,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image stream to an RGBA buffer (auto-detected), returning the first composited animation frame when available.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeRgba32Composite(System.IO.Stream,CodeGlyphX.ImageDecodeOptions,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image stream to an RGBA buffer (auto-detected), returning the first composited animation frame when available, with decode options.
+            </summary>
+            <example>
+            <code>
+            using var stream = File.OpenRead("image.jpg");
+            var options = new ImageDecodeOptions().WithJpegOptions(highQualityChroma: true);
+            var rgba = ImageReader.DecodeRgba32Composite(stream, options, out var width, out var height);
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeAnimationCanvasFrames(System.IO.Stream,System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Decodes animation frames composited onto a full canvas from a stream (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeAnimationFrames(System.IO.Stream,System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Decodes animation frames (non-composited) from a stream (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.Byte[],System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.Byte[],CodeGlyphX.ImageDecodeOptions,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected) with decode options.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.IO.Stream,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image stream to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.IO.Stream,CodeGlyphX.ImageDecodeOptions,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image stream to an RGBA buffer (auto-detected) with decode options.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.ReadOnlySpan{System.Byte},System.Byte[]@,System.Int32@,System.Int32@)">
             <summary>
             Attempts to decode an image to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.ReadOnlySpan{System.Byte},CodeGlyphX.ImageDecodeOptions,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected) with decode options.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode a multipage image to an RGBA buffer (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32Composite(System.Byte[],System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32Composite(System.Byte[],CodeGlyphX.ImageDecodeOptions,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available, with decode options.
+            </summary>
+            <example>
+            <code>
+            var options = new ImageDecodeOptions().WithJpegOptions(allowTruncated: true);
+            if (ImageReader.TryDecodeRgba32Composite(bytes, options, out var rgba, out var width, out var height)) {
+                Console.WriteLine($\"{width}x{height}\");
+            }
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32Composite(System.IO.Stream,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image stream to an RGBA buffer (auto-detected), returning the first composited animation frame when available.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32Composite(System.IO.Stream,CodeGlyphX.ImageDecodeOptions,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image stream to an RGBA buffer (auto-detected), returning the first composited animation frame when available, with decode options.
+            </summary>
+            <example>
+            <code>
+            using var stream = File.OpenRead("image.jpg");
+            var options = new ImageDecodeOptions().WithJpegOptions(highQualityChroma: true);
+            if (ImageReader.TryDecodeRgba32Composite(stream, options, out var rgba, out var width, out var height)) {
+                Console.WriteLine($\"{width}x{height}\");
+            }
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32Composite(System.ReadOnlySpan{System.Byte},System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeRgba32Composite(System.ReadOnlySpan{System.Byte},CodeGlyphX.ImageDecodeOptions,System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image to an RGBA buffer (auto-detected), returning the first composited animation frame when available, with decode options.
+            </summary>
+            <example>
+            <code>
+            var options = new ImageDecodeOptions().WithJpegOptions(highQualityChroma: true);
+            if (ImageReader.TryDecodeRgba32Composite(data, options, out var rgba, out var width, out var height)) {
+                Console.WriteLine($\"{width}x{height}\");
+            }
+            </code>
+            </example>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.ImageAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Attempts to decode animation frames composited onto a full canvas (auto-detected).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeAnimationFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.ImageAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.ImageAnimationOptions@)">
+            <summary>
+            Attempts to decode animation frames (non-composited) (auto-detected).
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.ImageReader.DetectFormat(System.ReadOnlySpan{System.Byte})">
@@ -16322,9 +17533,19 @@
             Attempts to read image format and dimensions without decoding pixels.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadInfo(System.Byte[],System.Int32,CodeGlyphX.Rendering.ImageInfo@)">
+            <summary>
+            Attempts to read image format and dimensions for a given page without decoding pixels.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadInfo(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.ImageInfo@)">
             <summary>
             Attempts to read image format and dimensions without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadInfo(System.ReadOnlySpan{System.Byte},System.Int32,CodeGlyphX.Rendering.ImageInfo@)">
+            <summary>
+            Attempts to read image format and dimensions for a given page without decoding pixels.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadInfo(System.IO.Stream,CodeGlyphX.Rendering.ImageInfo@)">
@@ -16332,12 +17553,182 @@
             Attempts to read image format and dimensions from a stream without decoding pixels.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadAnimationInfo(System.Byte[],CodeGlyphX.Rendering.ImageAnimationInfo@)">
+            <summary>
+            Attempts to read animation format info without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadAnimationInfo(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.ImageAnimationInfo@)">
+            <summary>
+            Attempts to read animation format info without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadAnimationInfo(System.IO.Stream,CodeGlyphX.Rendering.ImageAnimationInfo@)">
+            <summary>
+            Attempts to read animation format info from a stream without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadInfo(System.IO.Stream,System.Int32,CodeGlyphX.Rendering.ImageInfo@)">
+            <summary>
+            Attempts to read image format and dimensions for a given page from a stream without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadPageCount(System.ReadOnlySpan{System.Byte},System.Int32@)">
+            <summary>
+            Attempts to read page count for multipage images (TIFF).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadPageCount(System.Byte[],System.Int32@)">
+            <summary>
+            Attempts to read page count for multipage images (TIFF) from a byte buffer.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryReadPageCount(System.IO.Stream,System.Int32@)">
+            <summary>
+            Attempts to read page count for multipage images (TIFF) from a stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeGifAnimationFrames(System.Byte[],CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeGifAnimationFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeGifAnimationFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Decodes GIF animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeGifAnimationFrames(System.Byte[],System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Decodes GIF animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeGifAnimationCanvasFrames(System.Byte[],CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeGifAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeGifAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Decodes GIF animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeGifAnimationCanvasFrames(System.Byte[],System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Decodes GIF animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeGifAnimationFrames(System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation frames from a stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeGifAnimationCanvasFrames(System.IO.Stream,CodeGlyphX.Rendering.Gif.GifAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Gif.GifAnimationOptions@)">
+            <summary>
+            Attempts to decode GIF animation canvas frames from a stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeWebpAnimationFrames(System.Byte[],CodeGlyphX.Rendering.Webp.WebpAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Attempts to decode WebP animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeWebpAnimationFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Webp.WebpAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Attempts to decode WebP animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeWebpAnimationFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Decodes WebP animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeWebpAnimationFrames(System.Byte[],System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Decodes WebP animation frames into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeWebpAnimationCanvasFrames(System.Byte[],CodeGlyphX.Rendering.Webp.WebpAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Attempts to decode WebP animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeWebpAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Webp.WebpAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Attempts to decode WebP animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeWebpAnimationCanvasFrames(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Decodes WebP animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeWebpAnimationCanvasFrames(System.Byte[],System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Decodes WebP animation frames composited onto the full canvas.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeWebpAnimationFrames(System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Attempts to decode WebP animation frames from a stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeWebpAnimationCanvasFrames(System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationFrame[]@,System.Int32@,System.Int32@,CodeGlyphX.Rendering.Webp.WebpAnimationOptions@)">
+            <summary>
+            Attempts to decode WebP animation canvas frames from a stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeTiffPagesRgba32(System.Byte[],CodeGlyphX.Rendering.Tiff.TiffRgba32Page[]@)">
+            <summary>
+            Attempts to decode all TIFF pages into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeTiffPagesRgba32(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Tiff.TiffRgba32Page[]@)">
+            <summary>
+            Attempts to decode all TIFF pages into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.TryDecodeTiffPagesRgba32(System.IO.Stream,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[]@)">
+            <summary>
+            Attempts to decode all TIFF pages into RGBA32 buffers from a stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeTiffPagesRgba32(System.Byte[])">
+            <summary>
+            Decodes all TIFF pages into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeTiffPagesRgba32(System.IO.Stream)">
+            <summary>
+            Decodes all TIFF pages into RGBA32 buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.ImageReader.DecodeTiffPagesRgba32(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Decodes all TIFF pages into RGBA32 buffers.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer">
             <summary>
-            Renders 1D barcodes to a JPEG image (baseline, 4:4:4).
+            Renders 1D barcodes to a JPEG image.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.Render(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32)">
+            <summary>
+            Renders the barcode to a JPEG byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.Render(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
             <summary>
             Renders the barcode to a JPEG byte array.
             </summary>
@@ -16351,6 +17742,15 @@
             <param name="stream">Target stream.</param>
             <param name="quality">JPEG quality (1-100).</param>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.RenderToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the barcode to a JPEG stream.
+            </summary>
+            <param name="barcode">Barcode to render.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="stream">Target stream.</param>
+            <param name="options">JPEG encoding options.</param>
+        </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.Int32)">
             <summary>
             Renders the barcode to a JPEG file.
@@ -16359,6 +17759,16 @@
             <param name="opts">Rendering options.</param>
             <param name="path">Output file path.</param>
             <param name="quality">JPEG quality (1-100).</param>
+            <returns>The output file path.</returns>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the barcode to a JPEG file.
+            </summary>
+            <param name="barcode">Barcode to render.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="path">Output file path.</param>
+            <param name="options">JPEG encoding options.</param>
             <returns>The output file path.</returns>
         </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String,System.Int32)">
@@ -16371,6 +17781,108 @@
             <param name="fileName">Output file name.</param>
             <param name="quality">JPEG quality (1-100).</param>
             <returns>The output file path.</returns>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.BarcodeJpegRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the barcode to a JPEG file under the specified directory.
+            </summary>
+            <param name="barcode">Barcode to render.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="directory">Output directory.</param>
+            <param name="fileName">Output file name.</param>
+            <param name="options">JPEG encoding options.</param>
+            <returns>The output file path.</returns>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions">
+            <summary>
+            JPEG decoding options.
+            </summary>
+            <example>
+            <code>
+            var options = new JpegDecodeOptions(highQualityChroma: true, allowTruncated: true);
+            var rgba = JpegReader.DecodeRgba32(data, out var width, out var height, options);
+            </code>
+            </example>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions.HighQualityChroma">
+            <summary>
+            Enables higher-quality chroma upsampling when components are subsampled.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions.AllowTruncated">
+            <summary>
+            Allows truncated scan data (best-effort decode).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions.#ctor(System.Boolean,System.Boolean)">
+            <summary>
+            Creates JPEG decode options.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions">
+            <summary>
+            JPEG encoding options.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions.Quality">
+            <summary>
+            JPEG quality (1..100).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions.Subsampling">
+            <summary>
+            Chroma subsampling mode.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions.Progressive">
+            <summary>
+            Enables progressive JPEG encoding.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions.OptimizeHuffman">
+            <summary>
+            Enables optimized Huffman tables.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions.Metadata">
+            <summary>
+            Optional metadata segments (EXIF/XMP/ICC).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions.WriteJfifHeader">
+            <summary>
+            Writes a JFIF APP0 header when true.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Jpeg.JpegMetadata">
+            <summary>
+            Optional JPEG metadata payloads (EXIF/XMP/ICC).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegMetadata.Exif">
+            <summary>
+            EXIF payload (TIFF data, optional "Exif\0\0" header).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegMetadata.Xmp">
+            <summary>
+            XMP payload (RDF/XML, optional XMP namespace header).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegMetadata.Icc">
+            <summary>
+            ICC profile payload.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Jpeg.JpegMetadata.HasData">
+            <summary>
+            Indicates whether any metadata is present.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.JpegMetadata.#ctor(System.Byte[],System.Byte[],System.Byte[])">
+            <summary>
+            Creates metadata with optional EXIF/XMP/ICC payloads.
+            </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.Jpeg.JpegReader">
             <summary>
@@ -16387,12 +17899,42 @@
             Decodes a JPEG image to an RGBA buffer.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.JpegReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@,CodeGlyphX.Rendering.Jpeg.JpegDecodeOptions)">
+            <summary>
+            Decodes a JPEG image to an RGBA buffer.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Jpeg.JpegSubsampling">
+            <summary>
+            JPEG chroma subsampling selection.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Jpeg.JpegSubsampling.Y444">
+            <summary>
+            4:4:4 (no subsampling).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Jpeg.JpegSubsampling.Y422">
+            <summary>
+            4:2:2 (half horizontal chroma resolution).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Jpeg.JpegSubsampling.Y420">
+            <summary>
+            4:2:0 (half horizontal + vertical chroma resolution).
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer">
             <summary>
-            Renders generic 2D matrices to a JPEG image (baseline, 4:4:4).
+            Renders generic 2D matrices to a JPEG image.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32)">
+            <summary>
+            Renders the matrix to a JPEG byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
             <summary>
             Renders the matrix to a JPEG byte array.
             </summary>
@@ -16406,6 +17948,15 @@
             <param name="stream">Target stream.</param>
             <param name="quality">JPEG quality (1-100).</param>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.RenderToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the matrix to a JPEG stream.
+            </summary>
+            <param name="modules">Matrix modules.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="stream">Target stream.</param>
+            <param name="options">JPEG encoding options.</param>
+        </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.Int32)">
             <summary>
             Renders the matrix to a JPEG file.
@@ -16414,6 +17965,16 @@
             <param name="opts">Rendering options.</param>
             <param name="path">Output file path.</param>
             <param name="quality">JPEG quality (1-100).</param>
+            <returns>The output file path.</returns>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the matrix to a JPEG file.
+            </summary>
+            <param name="modules">Matrix modules.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="path">Output file path.</param>
+            <param name="options">JPEG encoding options.</param>
             <returns>The output file path.</returns>
         </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,System.Int32)">
@@ -16427,12 +17988,28 @@
             <param name="quality">JPEG quality (1-100).</param>
             <returns>The output file path.</returns>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.MatrixJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the matrix to a JPEG file under the specified directory.
+            </summary>
+            <param name="modules">Matrix modules.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="directory">Output directory.</param>
+            <param name="fileName">Output file name.</param>
+            <param name="options">JPEG encoding options.</param>
+            <returns>The output file path.</returns>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer">
             <summary>
-            Renders QR modules to a JPEG image (baseline, 4:4:4).
+            Renders QR modules to a JPEG image.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32)">
+            <summary>
+            Renders the QR module matrix to a JPEG byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
             <summary>
             Renders the QR module matrix to a JPEG byte array.
             </summary>
@@ -16446,6 +18023,15 @@
             <param name="stream">Target stream.</param>
             <param name="quality">JPEG quality (1-100).</param>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.RenderToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.IO.Stream,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the QR module matrix to a JPEG stream.
+            </summary>
+            <param name="modules">QR modules.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="stream">Target stream.</param>
+            <param name="options">JPEG encoding options.</param>
+        </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,System.Int32)">
             <summary>
             Renders the QR module matrix to a JPEG file.
@@ -16454,6 +18040,16 @@
             <param name="opts">Rendering options.</param>
             <param name="path">Output file path.</param>
             <param name="quality">JPEG quality (1-100).</param>
+            <returns>The output file path.</returns>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the QR module matrix to a JPEG file.
+            </summary>
+            <param name="modules">QR modules.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="path">Output file path.</param>
+            <param name="options">JPEG encoding options.</param>
             <returns>The output file path.</returns>
         </member>
         <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,System.String,System.Int32)">
@@ -16465,6 +18061,17 @@
             <param name="directory">Output directory.</param>
             <param name="fileName">Output file name.</param>
             <param name="quality">JPEG quality (1-100).</param>
+            <returns>The output file path.</returns>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Jpeg.QrJpegRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,System.String,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions)">
+            <summary>
+            Renders the QR module matrix to a JPEG file under the specified directory.
+            </summary>
+            <param name="modules">QR modules.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="directory">Output directory.</param>
+            <param name="fileName">Output file name.</param>
+            <param name="options">JPEG encoding options.</param>
             <returns>The output file path.</returns>
         </member>
         <member name="T:CodeGlyphX.Rendering.LogoBuilder">
@@ -16592,6 +18199,16 @@
         <member name="F:CodeGlyphX.Rendering.OutputFormat.Ascii">
             <summary>
             ASCII art (text).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.OutputFormat.Gif">
+            <summary>
+            GIF image.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.OutputFormat.Tiff">
+            <summary>
+            TIFF image.
             </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.OutputFormatInfo">
@@ -16937,6 +18554,31 @@
         <member name="M:CodeGlyphX.Rendering.Pdf.MatrixPdfRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,CodeGlyphX.Rendering.RenderMode)">
             <summary>
             Renders the matrix to a PDF file under the specified directory.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Pdf.PdfReader">
+            <summary>
+            Minimal PDF image decoder (image-only PDFs with embedded JPEG/Flate XObjects).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Pdf.PdfReader.IsPdf(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Returns true when the buffer looks like a PDF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Pdf.PdfReader.TryReadDimensions(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to read PDF image dimensions without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Pdf.PdfReader.TryDecodeRgba32(System.ReadOnlySpan{System.Byte},System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode an image-only PDF to RGBA (embedded JPEG or Flate image XObject).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Pdf.PdfReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
+            <summary>
+            Decodes an image-only PDF to RGBA (embedded JPEG or Flate image XObject).
             </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.Pdf.PdfVectorWriter">
@@ -19408,6 +21050,26 @@
             Renders the QR module matrix to a PPM file under the specified directory.
             </summary>
         </member>
+        <member name="T:CodeGlyphX.Rendering.Psd.PsdReader">
+            <summary>
+            Minimal PSD decoder (flattened image only).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Psd.PsdReader.IsPsd(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Returns true when the data looks like a PSD file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Psd.PsdReader.TryReadDimensions(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to read PSD dimensions without decoding pixels.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Psd.PsdReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
+            <summary>
+            Decodes a PSD image to an RGBA buffer (flattened, 8-bit RGB/Grayscale only).
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.QrLogoOptions">
             <summary>
             Options for embedding a PNG logo inside a QR render (SVG/HTML).
@@ -19690,6 +21352,16 @@
             Encodes WebP bytes as a Base64 data URI.
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.RenderExtensions.ToGifDataUri(System.Byte[])">
+            <summary>
+            Encodes GIF bytes as a Base64 data URI.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.RenderExtensions.ToTiffDataUri(System.Byte[])">
+            <summary>
+            Encodes TIFF bytes as a Base64 data URI.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.RenderExtensions.ToSvgDataUri(System.String,System.Text.Encoding)">
             <summary>
             Encodes SVG content as a Base64 data URI.
@@ -19715,9 +21387,59 @@
             ASCII render options for matrix codes.
             </summary>
         </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.AsciiConsole">
+            <summary>
+            Console-friendly ASCII options (auto-fit).
+            </summary>
+        </member>
         <member name="P:CodeGlyphX.Rendering.RenderExtras.BarcodeAscii">
             <summary>
             ASCII render options for barcodes.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.GifFrames">
+            <summary>
+            Optional GIF animation frames for matrix outputs.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.WebpFrames">
+            <summary>
+            Optional WebP animation frames for matrix outputs.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.BarcodeGifFrames">
+            <summary>
+            Optional GIF animation frames for barcode outputs.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.BarcodeWebpFrames">
+            <summary>
+            Optional WebP animation frames for barcode outputs.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.AnimationDurationsMs">
+            <summary>
+            Optional per-frame durations (ms) for GIF/WebP animations.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.AnimationDurationMs">
+            <summary>
+            Optional constant frame duration (ms) for GIF/WebP animations.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.GifAnimationOptions">
+            <summary>
+            Optional GIF animation options.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.WebpAnimationOptions">
+            <summary>
+            Optional WebP animation options.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.RenderExtras.TiffCompression">
+            <summary>
+            TIFF compression selection for TIFF outputs.
             </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.RenderIO">
@@ -20489,9 +22211,602 @@
             Writes a TGA stream from an RGBA buffer (32-bit BGRA).
             </summary>
         </member>
+        <member name="T:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer">
+            <summary>
+            Renders 1D barcodes to a TIFF image (baseline, uncompressed).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.Render(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions)">
+            <summary>
+            Renders the barcode to a TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.Render(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Renders the barcode to a TIFF byte array with compression selection.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevel(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelFromBars(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF byte array using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiled(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledFromBars(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF byte array using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream)">
+            <summary>
+            Renders the barcode to a TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelFromBarsToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF stream using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledFromBarsToStream(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.IO.Stream,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF stream using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String)">
+            <summary>
+            Renders the barcode to a TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelFromBarsToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF file using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledFromBarsToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF file using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String)">
+            <summary>
+            Renders the barcode to a TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelFromBarsToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) TIFF file under the specified directory using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer.RenderBilevelTiledFromBarsToFile(CodeGlyphX.Barcode1D,CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.String,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the barcode to a bilevel (1-bit) tiled TIFF file under the specified directory using direct bar packing (label is ignored).
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer">
+            <summary>
+            Renders matrix codes to a TIFF image (baseline, uncompressed).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions)">
+            <summary>
+            Renders the module matrix to a TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Renders the module matrix to a TIFF byte array with compression selection.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevel(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelFromModules(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF byte array using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiled(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledFromModules(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF byte array using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream)">
+            <summary>
+            Renders the module matrix to a TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelFromModulesToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF stream using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledFromModulesToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.IO.Stream,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF stream using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String)">
+            <summary>
+            Renders the module matrix to a TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelFromModulesToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF file using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledFromModulesToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF file using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String)">
+            <summary>
+            Renders the module matrix to a TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelFromModulesToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) TIFF file under the specified directory using direct module packing.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer.RenderBilevelTiledFromModulesToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.String,System.String,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Renders the module matrix to a bilevel (1-bit) tiled TIFF file under the specified directory using direct module packing.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Tiff.QrTiffRenderer">
+            <summary>
+            Renders QR modules to a TIFF image.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.QrTiffRenderer.Render(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Renders the QR module matrix to a TIFF byte array.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.QrTiffRenderer.RenderToStream(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.IO.Stream,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Renders the QR module matrix to a TIFF stream.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.QrTiffRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Renders the QR module matrix to a TIFF file.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.QrTiffRenderer.RenderToFile(CodeGlyphX.BitMatrix,CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.String,System.String,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Renders the QR module matrix to a TIFF file under the specified directory.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Tiff.TiffCompression">
+            <summary>
+            TIFF compression options supported by the writer.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Tiff.TiffCompression.None">
+            <summary>
+            No compression.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Tiff.TiffCompression.Lzw">
+            <summary>
+            Deflate compression (zlib).
+            </summary>
+            <summary>
+            LZW compression.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Tiff.TiffCompression.Deflate">
+            <summary>
+            Deflate compression (zlib).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Tiff.TiffCompression.PackBits">
+            <summary>
+            PackBits compression.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Tiff.TiffReader">
             <summary>
-            Minimal TIFF decoder for uncompressed baseline images.
+            Minimal TIFF decoder for baseline images (strips/tiles).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffReader.IsTiff(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Returns true when the buffer looks like a TIFF file header.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffReader.TryDecodePagesRgba32(System.ReadOnlySpan{System.Byte},CodeGlyphX.Rendering.Tiff.TiffRgba32Page[]@)">
+            <summary>
+            Attempts to decode all TIFF pages to RGBA buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffReader.DecodePagesRgba32(System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Decodes all TIFF pages to RGBA buffers.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32@,System.Int32@)">
+            <summary>
+            Decodes the first TIFF page into an RGBA buffer.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffReader.TryDecodeRgba32(System.ReadOnlySpan{System.Byte},System.Byte[]@,System.Int32@,System.Int32@)">
+            <summary>
+            Attempts to decode the first TIFF page into an RGBA buffer.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffReader.DecodeRgba32(System.ReadOnlySpan{System.Byte},System.Int32,System.Int32@,System.Int32@)">
+            <summary>
+            Decodes a specific TIFF page into an RGBA buffer.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Tiff.TiffRgba32Page">
+            <summary>
+            Describes a single RGBA32 page for TIFF encoding.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Creates a TIFF page backed by an RGBA32 buffer.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.#ctor(System.Byte[],System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.TiffCompressionMode,System.Int32)">
+            <summary>
+            Creates a TIFF page backed by an RGBA32 buffer with explicit rows-per-strip.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.Rgba">
+            <summary>
+            RGBA32 pixel buffer.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.Width">
+            <summary>
+            Page width in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.Height">
+            <summary>
+            Page height in pixels.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.Stride">
+            <summary>
+            Page stride in bytes.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.Compression">
+            <summary>
+            Compression to use for the page.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Tiff.TiffRgba32Page.RowsPerStrip">
+            <summary>
+            Rows per strip (0 = single strip).
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.Tiff.TiffWriter">
+            <summary>
+            Writes TIFF images from RGBA buffers (baseline RGBA, optional PackBits/Deflate/LZW).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Writes a TIFF byte array from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,CodeGlyphX.Rendering.TiffCompressionMode,System.Int32)">
+            <summary>
+            Writes a TIFF byte array from an RGBA buffer (single page) with configurable rows per strip.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,CodeGlyphX.Rendering.TiffCompressionMode)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,CodeGlyphX.Rendering.TiffCompressionMode,System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a TIFF byte array from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip and compression.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip, compression, and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevel(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a TIFF byte array from a packed 1-bit buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevel(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Writes a bilevel (1-bit) TIFF byte array with configurable rows-per-strip, compression, and photometric.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevel(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from a packed 1-bit buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevel(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from a packed 1-bit buffer (single page) with configurable rows per strip.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevel(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Writes a TIFF to a stream from a packed 1-bit buffer (single page) with configurable rows per strip and compression.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelFromRgba(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a TIFF byte array from an RGBA buffer (single page) as a 1-bit bilevel image.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelFromRgba(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) as a 1-bit bilevel image.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelFromRgba(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) as a 1-bit bilevel image with configurable rows per strip, compression, and threshold.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelTiled(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Writes a TIFF byte array from a packed 1-bit buffer (single page) as tiled data.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelTiled(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Writes a TIFF byte array from a packed 1-bit buffer (single page) as tiled data with compression.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelTiled(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Writes a TIFF to a stream from a packed 1-bit buffer (single page) as tiled data.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelTiled(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.UInt16)">
+            <summary>
+            Writes a TIFF to a stream from a packed 1-bit buffer (single page) as tiled data with compression.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelTiledFromRgba(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Writes a TIFF byte array from an RGBA buffer (single page) as tiled bilevel data.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteBilevelTiledFromRgba(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Byte,System.UInt16)">
+            <summary>
+            Writes a TIFF to a stream from an RGBA buffer (single page) as tiled bilevel data.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Tiled(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Writes a tiled TIFF byte array from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Tiled(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a tiled TIFF byte array from an RGBA buffer (single page) with compression and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Tiled(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Writes a tiled TIFF to a stream from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Tiled(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a tiled TIFF to a stream from an RGBA buffer (single page) with compression and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Planar(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a planar TIFF byte array from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Planar(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a planar TIFF byte array from an RGBA buffer (single page) with rows per strip, compression, and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Planar(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32)">
+            <summary>
+            Writes a planar TIFF to a stream from an RGBA buffer (single page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Planar(System.IO.Stream,System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a planar TIFF to a stream from an RGBA buffer with rows per strip, compression, and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a TIFF byte array from RGBA buffers (multi-page) using per-page settings.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32(System.IO.Stream,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a TIFF to a stream from RGBA buffers (multi-page) using per-page settings.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Pages(CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a TIFF byte array from RGBA buffers (multi-page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Pages(System.IO.Stream,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a TIFF to a stream from RGBA buffers (multi-page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Pages(CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a TIFF byte array from RGBA buffers (multi-page) with compression and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Pages(System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a TIFF byte array from RGBA buffers (multi-page) with rows per strip, compression, and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Pages(System.IO.Stream,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[],CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a TIFF to a stream from RGBA buffers (multi-page) with compression and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32Pages(System.IO.Stream,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[],System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a TIFF to a stream from RGBA buffers (multi-page) with rows per strip, compression, and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32PagesTiled(System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a tiled TIFF byte array from RGBA buffers (multi-page).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32PagesTiled(System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[])">
+            <summary>
+            Writes a tiled TIFF byte array from RGBA buffers (multi-page) with compression and predictor.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Tiff.TiffWriter.WriteRgba32PagesTiled(System.IO.Stream,CodeGlyphX.Rendering.Tiff.TiffRgba32Page[],System.Int32,System.Int32,CodeGlyphX.Rendering.Tiff.TiffCompression,System.Boolean)">
+            <summary>
+            Writes a tiled TIFF to a stream from RGBA buffers (multi-page) with compression and predictor.
+            </summary>
+        </member>
+        <member name="T:CodeGlyphX.Rendering.TiffCompressionMode">
+            <summary>
+            TIFF compression selection for writers.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.TiffCompressionMode.Auto">
+            <summary>
+            Picks the smallest output (current default).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.TiffCompressionMode.None">
+            <summary>
+            Writes uncompressed strips.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.TiffCompressionMode.PackBits">
+            <summary>
+            Forces PackBits compression.
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.TiffCompressionMode.Deflate">
+            <summary>
+            Forces Deflate compression (zlib).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.TiffCompressionMode.Lzw">
+            <summary>
+            Forces LZW compression.
             </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer">
@@ -20557,6 +22872,46 @@
             <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
             <returns>The output file path.</returns>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimation(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP from multiple barcode frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimation(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP from multiple barcode frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimationToStream(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a stream from multiple barcode frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimationToStream(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a stream from multiple barcode frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file from multiple barcode frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file from multiple barcode frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32,System.String,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.BarcodeWebpRenderer.RenderAnimationToFile(CodeGlyphX.Barcode1D[],CodeGlyphX.Rendering.Png.BarcodePngRenderOptions,System.Int32[],System.String,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file under the specified directory with per-frame durations.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer">
             <summary>
             Renders generic 2D matrices to WebP images.
@@ -20620,6 +22975,46 @@
             <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
             <returns>The output file path.</returns>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP from multiple matrix frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP from multiple matrix frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a stream from multiple matrix frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a stream from multiple matrix frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file from multiple matrix frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file from multiple matrix frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32,System.String,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.MatrixWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.MatrixPngRenderOptions,System.Int32[],System.String,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file under the specified directory with per-frame durations.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Webp.QrWebpRenderer">
             <summary>
             Renders QR modules to WebP images.
@@ -20682,6 +23077,51 @@
             <param name="fileName">Output file name.</param>
             <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
             <returns>The output file path.</returns>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP from multiple QR module frames.
+            </summary>
+            <param name="frames">QR module frames.</param>
+            <param name="opts">Rendering options.</param>
+            <param name="durationMs">Per-frame duration in milliseconds.</param>
+            <param name="options">Animation options.</param>
+            <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimation(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP from multiple QR module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a stream from multiple QR module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimationToStream(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],System.IO.Stream,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a stream from multiple QR module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file from multiple QR module frames.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file from multiple QR module frames with per-frame durations.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32,System.String,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file under the specified directory.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.QrWebpRenderer.RenderAnimationToFile(CodeGlyphX.BitMatrix[],CodeGlyphX.Rendering.Png.QrPngRenderOptions,System.Int32[],System.String,System.String,CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
+            <summary>
+            Renders an animated WebP to a file under the specified directory with per-frame durations.
+            </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.Webp.WebpAnimationFrame">
             <summary>
@@ -20814,6 +23254,36 @@
             The call site prefers this path and does not fall back to native decoding.
             </remarks>
         </member>
+        <member name="T:CodeGlyphX.Rendering.Webp.WebpMetadata">
+            <summary>
+            Optional WebP metadata chunks (ICCP/EXIF/XMP).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Webp.WebpMetadata.Icc">
+            <summary>
+            ICC profile payload.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Webp.WebpMetadata.Exif">
+            <summary>
+            EXIF payload.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Webp.WebpMetadata.Xmp">
+            <summary>
+            XMP payload.
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Webp.WebpMetadata.HasData">
+            <summary>
+            Indicates whether any metadata is present.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpMetadata.#ctor(System.Byte[],System.Byte[],System.Byte[])">
+            <summary>
+            Creates metadata with optional ICC/EXIF/XMP payloads.
+            </summary>
+        </member>
         <member name="T:CodeGlyphX.Rendering.Webp.WebpPrefixCode">
             <summary>
             Canonical prefix code with LSB-first decoding support.
@@ -20837,6 +23307,16 @@
         <member name="T:CodeGlyphX.Rendering.Webp.WebpReader">
             <summary>
             Minimal WebP container parsing plus managed decode (VP8/VP8L stills).
+            </summary>
+        </member>
+        <member name="F:CodeGlyphX.Rendering.Webp.WebpReader.DefaultMaxWebpBytes">
+            <summary>
+            Default maximum managed WebP payload size (in bytes).
+            </summary>
+        </member>
+        <member name="P:CodeGlyphX.Rendering.Webp.WebpReader.MaxWebpBytes">
+            <summary>
+            Maximum managed WebP payload size (in bytes).
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpReader.IsWebp(System.ReadOnlySpan{System.Byte})">
@@ -20923,13 +23403,17 @@
             Current limitations:
             - VP8L lossless is a managed subset; single prefix-code group (no entropy tiling).
             - Limited LZ77/back-reference search; favors short distances.
-            - Color indexing is limited to palettes up to 16 colors.
-            - Metadata chunks (VP8X/ICCP/EXIF/XMP) are not written.
+            - Color indexing is limited to palettes up to 256 colors.
             </remarks>
         </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteRgba32(System.Int32,System.Int32,System.Byte[],System.Int32)">
             <summary>
             Encodes an RGBA32 buffer as WebP lossless (managed VP8L subset).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteRgba32(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an RGBA32 buffer as WebP lossless (managed VP8L subset) with metadata chunks.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteRgba32Lossy(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32)">
@@ -20940,9 +23424,19 @@
             Falls back to VP8L with pre-quantized RGB when VP8 lossy encoding is unavailable.
             </remarks>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteRgba32Lossy(System.Int32,System.Int32,System.ReadOnlySpan{System.Byte},System.Int32,System.Int32,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an RGBA32 buffer as a lossy WebP using a managed VP8 (lossy) bitstream when possible, with metadata.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteRgba32Lossy(System.Int32,System.Int32,System.Byte[],System.Int32,System.Int32)">
             <summary>
             Encodes an RGBA32 buffer as a lossy WebP by quantizing pixels and using VP8L.
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteRgba32Lossy(System.Int32,System.Int32,System.Byte[],System.Int32,System.Int32,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an RGBA32 buffer as a lossy WebP by quantizing pixels and using VP8L, with metadata.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32(System.Int32,System.Int32,System.ReadOnlySpan{CodeGlyphX.Rendering.Webp.WebpAnimationFrame},CodeGlyphX.Rendering.Webp.WebpAnimationOptions)">
@@ -20950,9 +23444,19 @@
             Encodes an animated WebP from RGBA32 frames (VP8L frames).
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32(System.Int32,System.Int32,System.ReadOnlySpan{CodeGlyphX.Rendering.Webp.WebpAnimationFrame},CodeGlyphX.Rendering.Webp.WebpAnimationOptions,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an animated WebP from RGBA32 frames (VP8L frames) with metadata chunks.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32(System.Int32,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationFrame[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions)">
             <summary>
             Encodes an animated WebP from RGBA32 frames (VP8L frames).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32(System.Int32,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationFrame[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an animated WebP from RGBA32 frames (VP8L frames) with metadata chunks.
             </summary>
         </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32Lossy(System.Int32,System.Int32,System.ReadOnlySpan{CodeGlyphX.Rendering.Webp.WebpAnimationFrame},CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
@@ -20960,9 +23464,19 @@
             Encodes an animated WebP from RGBA32 frames (managed VP8 lossy intra, with VP8L fallback).
             </summary>
         </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32Lossy(System.Int32,System.Int32,System.ReadOnlySpan{CodeGlyphX.Rendering.Webp.WebpAnimationFrame},CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an animated WebP from RGBA32 frames (managed VP8 lossy intra, with VP8L fallback) with metadata.
+            </summary>
+        </member>
         <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32Lossy(System.Int32,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationFrame[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32)">
             <summary>
             Encodes an animated WebP from RGBA32 frames (managed VP8 lossy intra, with VP8L fallback).
+            </summary>
+        </member>
+        <member name="M:CodeGlyphX.Rendering.Webp.WebpWriter.WriteAnimationRgba32Lossy(System.Int32,System.Int32,CodeGlyphX.Rendering.Webp.WebpAnimationFrame[],CodeGlyphX.Rendering.Webp.WebpAnimationOptions,System.Int32,CodeGlyphX.Rendering.Webp.WebpMetadata)">
+            <summary>
+            Encodes an animated WebP from RGBA32 frames (managed VP8 lossy intra, with VP8L fallback) with metadata.
             </summary>
         </member>
         <member name="T:CodeGlyphX.Rendering.Xbm.BarcodeXbmRenderer">

--- a/CodeGlyphX/AztecCode.Decode.cs
+++ b/CodeGlyphX/AztecCode.Decode.cs
@@ -366,7 +366,7 @@ public static partial class AztecCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return AztecDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -424,7 +424,7 @@ public static partial class AztecCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return AztecDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -455,7 +455,7 @@ public static partial class AztecCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; diagnostics.Failure = FailureCancelled; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 text = string.Empty;
                 diagnostics.Failure ??= "Unsupported image format.";
                 return false;
@@ -509,7 +509,7 @@ public static partial class AztecCode {
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
             var data = RenderIO.ReadBinary(stream);
-            if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(data, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return AztecDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -561,7 +561,7 @@ public static partial class AztecCode {
             if (token.IsCancellationRequested) {
                 return new DecodeResult<string>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 var imageFailure = DecodeResultHelpers.FailureForImageRead(image, formatKnown, token);
                 return new DecodeResult<string>(imageFailure, info, stopwatch.Elapsed);
             }
@@ -707,7 +707,7 @@ public static partial class AztecCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; diagnostics.Failure = FailureCancelled; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 text = string.Empty;
                 diagnostics.Failure ??= "Unsupported image format.";
                 return false;
@@ -737,7 +737,7 @@ public static partial class AztecCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) return false;
             var original = rgba;
             var originalWidth = width;
             var originalHeight = height;

--- a/CodeGlyphX/AztecCode.Render.cs
+++ b/CodeGlyphX/AztecCode.Render.cs
@@ -53,8 +53,13 @@ public static partial class AztecCode {
                 }
                 return RenderedOutput.FromText(format, html);
             }
-            case OutputFormat.Jpeg:
-                return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
+            case OutputFormat.Jpeg: {
+                var jpegOptions = renderOptions?.JpegOptions;
+                var data = jpegOptions is null
+                    ? MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85)
+                    : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
+                return RenderedOutput.FromBinary(format, data);
+            }
             case OutputFormat.Webp: {
                 var quality = renderOptions?.WebpQuality ?? 100;
                 if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {

--- a/CodeGlyphX/AztecCode.cs
+++ b/CodeGlyphX/AztecCode.cs
@@ -135,7 +135,9 @@ public static partial class AztecCode {
     public static byte[] Jpeg(string text, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = ToPngOptions(renderOptions);
-        return MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85);
+        return renderOptions?.JpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, renderOptions.JpegOptions);
     }
 
     /// <summary>
@@ -155,7 +157,9 @@ public static partial class AztecCode {
     public static byte[] Jpeg(ReadOnlySpan<byte> data, AztecEncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(data, encodeOptions);
         var opts = ToPngOptions(renderOptions);
-        return MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85);
+        return renderOptions?.JpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, renderOptions.JpegOptions);
     }
 
     /// <summary>

--- a/CodeGlyphX/Barcode.Builder.cs
+++ b/CodeGlyphX/Barcode.Builder.cs
@@ -116,6 +116,14 @@ public static partial class Barcode {
         }
 
         /// <summary>
+        /// Sets JPEG encoding options.
+        /// </summary>
+        public BarcodeBuilder WithJpegOptions(JpegEncodeOptions options) {
+            Options.JpegOptions = options ?? throw new ArgumentNullException(nameof(options));
+            return this;
+        }
+
+        /// <summary>
         /// Sets label text rendered under bars.
         /// </summary>
         public BarcodeBuilder WithLabel(string? text) {

--- a/CodeGlyphX/Barcode.Decode.cs
+++ b/CodeGlyphX/Barcode.Decode.cs
@@ -163,7 +163,7 @@ public static partial class Barcode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) return false;
             var original = rgba;
             var originalWidth = width;
             var originalHeight = height;
@@ -216,7 +216,7 @@ public static partial class Barcode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) return false;
             var original = rgba;
             var originalWidth = width;
             var originalHeight = height;
@@ -295,7 +295,7 @@ public static partial class Barcode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
-            var rgba = ImageReader.DecodeRgba32(stream, out var width, out var height);
+            var rgba = ImageReader.DecodeRgba32(stream, options, out var width, out var height);
             var original = rgba;
             var originalWidth = width;
             var originalHeight = height;
@@ -331,7 +331,7 @@ public static partial class Barcode {
             if (token.IsCancellationRequested) {
                 return new DecodeResult<BarcodeDecoded>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 var imageFailure = DecodeResultHelpers.FailureForImageRead(image, formatKnown, token);
                 return new DecodeResult<BarcodeDecoded>(imageFailure, info, stopwatch.Elapsed);
             }

--- a/CodeGlyphX/Barcode.Render.cs
+++ b/CodeGlyphX/Barcode.Render.cs
@@ -55,8 +55,13 @@ public static partial class Barcode {
                 }
                 return RenderedOutput.FromText(format, html);
             }
-            case OutputFormat.Jpeg:
-                return RenderedOutput.FromBinary(format, BarcodeJpegRenderer.Render(barcode, opts, options?.JpegQuality ?? 90));
+            case OutputFormat.Jpeg: {
+                var jpegOptions = options?.JpegOptions;
+                var data = jpegOptions is null
+                    ? BarcodeJpegRenderer.Render(barcode, opts, options?.JpegQuality ?? 90)
+                    : BarcodeJpegRenderer.Render(barcode, opts, jpegOptions);
+                return RenderedOutput.FromBinary(format, data);
+            }
             case OutputFormat.Webp: {
                 var quality = options?.WebpQuality ?? 100;
                 if (RenderAnimationHelpers.TryRenderBarcodeWebp(extras, opts, quality, out var webp)) {

--- a/CodeGlyphX/Barcode.Save.cs
+++ b/CodeGlyphX/Barcode.Save.cs
@@ -101,8 +101,12 @@ public static partial class Barcode {
     public static void SaveJpeg(BarcodeType type, string content, Stream stream, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 90;
-        BarcodeJpegRenderer.RenderToStream(barcode, opts, stream, quality);
+        var jpegOptions = options?.JpegOptions;
+        if (jpegOptions is null) {
+            BarcodeJpegRenderer.RenderToStream(barcode, opts, stream, options?.JpegQuality ?? 90);
+        } else {
+            BarcodeJpegRenderer.RenderToStream(barcode, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>

--- a/CodeGlyphX/Barcode.cs
+++ b/CodeGlyphX/Barcode.cs
@@ -87,8 +87,10 @@ public static partial class Barcode {
     public static byte[] Jpeg(BarcodeType type, string content, BarcodeOptions? options = null) {
         var barcode = Encode(type, content);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 90;
-        return BarcodeJpegRenderer.Render(barcode, opts, quality);
+        var jpegOptions = options?.JpegOptions;
+        return jpegOptions is null
+            ? BarcodeJpegRenderer.Render(barcode, opts, options?.JpegQuality ?? 90)
+            : BarcodeJpegRenderer.Render(barcode, opts, jpegOptions);
     }
 
     /// <summary>

--- a/CodeGlyphX/BarcodeOptions.cs
+++ b/CodeGlyphX/BarcodeOptions.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX;
@@ -37,6 +38,12 @@ public sealed class BarcodeOptions {
     /// JPEG quality (1..100).
     /// </summary>
     public int JpegQuality { get; set; } = 90;
+
+    /// <summary>
+    /// Optional JPEG encoding options (subsampling/progressive/metadata/etc).
+    /// When set, overrides <see cref="JpegQuality"/> where applicable.
+    /// </summary>
+    public JpegEncodeOptions? JpegOptions { get; set; }
 
     /// <summary>
     /// WebP quality (0..100). A value of 100 uses lossless VP8L.

--- a/CodeGlyphX/CodeGlyph.Auto.cs
+++ b/CodeGlyphX/CodeGlyph.Auto.cs
@@ -12,7 +12,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeAuto(byte[] image, out CodeGlyphDecoded decoded, CodeGlyphDecodeOptions? options = null) {
         decoded = null!;
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) return false;
         return TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -22,7 +22,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeAllAuto(byte[] image, out CodeGlyphDecoded[] decoded, CodeGlyphDecodeOptions? options = null) {
         decoded = Array.Empty<CodeGlyphDecoded>();
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) return false;
         return TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 

--- a/CodeGlyphX/CodeGlyph.IO.cs
+++ b/CodeGlyphX/CodeGlyph.IO.cs
@@ -966,4 +966,3 @@ public static partial class CodeGlyph {
 
 }
 
-

--- a/CodeGlyphX/CodeGlyphDecodeOptions.Fluent.cs
+++ b/CodeGlyphX/CodeGlyphDecodeOptions.Fluent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using CodeGlyphX.Rendering.Jpeg;
 
 namespace CodeGlyphX;
 
@@ -28,6 +29,34 @@ public sealed partial class CodeGlyphDecodeOptions {
     public CodeGlyphDecodeOptions WithImage(Action<ImageDecodeOptions> configure) {
         if (configure is null) throw new ArgumentNullException(nameof(configure));
         configure(EnsureImage());
+        return this;
+    }
+
+    /// <summary>
+    /// Sets JPEG decoding options on the image decode options.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new CodeGlyphDecodeOptions()
+    ///     .WithJpegOptions(highQualityChroma: true, allowTruncated: true);
+    /// </code>
+    /// </example>
+    public CodeGlyphDecodeOptions WithJpegOptions(JpegDecodeOptions options) {
+        EnsureImage().JpegOptions = options;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets JPEG decoding options on the image decode options.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new CodeGlyphDecodeOptions()
+    ///     .WithJpegOptions(highQualityChroma: true);
+    /// </code>
+    /// </example>
+    public CodeGlyphDecodeOptions WithJpegOptions(bool highQualityChroma = false, bool allowTruncated = false) {
+        EnsureImage().JpegOptions = new JpegDecodeOptions(highQualityChroma, allowTruncated);
         return this;
     }
 

--- a/CodeGlyphX/DataMatrixCode.Builder.cs
+++ b/CodeGlyphX/DataMatrixCode.Builder.cs
@@ -96,6 +96,14 @@ public static partial class DataMatrixCode {
         }
 
         /// <summary>
+        /// Sets JPEG encoding options.
+        /// </summary>
+        public DataMatrixBuilder WithJpegOptions(JpegEncodeOptions options) {
+            _options.JpegOptions = options ?? throw new ArgumentNullException(nameof(options));
+            return this;
+        }
+
+        /// <summary>
         /// Enables HTML email-safe table rendering.
         /// </summary>
         public DataMatrixBuilder WithHtmlEmailSafeTable(bool enabled = true) {

--- a/CodeGlyphX/DataMatrixCode.Decode.cs
+++ b/CodeGlyphX/DataMatrixCode.Decode.cs
@@ -300,7 +300,7 @@ public static partial class DataMatrixCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return DataMatrixDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -352,7 +352,7 @@ public static partial class DataMatrixCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; diagnostics.Failure = FailureCancelled; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 text = string.Empty;
                 diagnostics.Failure ??= "Unsupported image format.";
                 return false;
@@ -404,7 +404,7 @@ public static partial class DataMatrixCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return DataMatrixDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -443,7 +443,7 @@ public static partial class DataMatrixCode {
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
             var data = RenderIO.ReadBinary(stream);
-            if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(data, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return DataMatrixDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -495,7 +495,7 @@ public static partial class DataMatrixCode {
             if (token.IsCancellationRequested) {
                 return new DecodeResult<string>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 var imageFailure = DecodeResultHelpers.FailureForImageRead(image, formatKnown, token);
                 return new DecodeResult<string>(imageFailure, info, stopwatch.Elapsed);
             }
@@ -614,7 +614,7 @@ public static partial class DataMatrixCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; diagnostics.Failure = FailureCancelled; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 text = string.Empty;
                 diagnostics.Failure ??= "Unsupported image format.";
                 return false;
@@ -644,7 +644,7 @@ public static partial class DataMatrixCode {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) return false;
             var original = rgba;
             var originalWidth = width;
             var originalHeight = height;

--- a/CodeGlyphX/DataMatrixCode.Render.cs
+++ b/CodeGlyphX/DataMatrixCode.Render.cs
@@ -71,8 +71,13 @@ public static partial class DataMatrixCode {
                 }
                 return RenderedOutput.FromText(format, html);
             }
-            case OutputFormat.Jpeg:
-                return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85));
+            case OutputFormat.Jpeg: {
+                var jpegOptions = options?.JpegOptions;
+                var data = jpegOptions is null
+                    ? MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85)
+                    : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
+                return RenderedOutput.FromBinary(format, data);
+            }
             case OutputFormat.Webp: {
                 var quality = options?.WebpQuality ?? 100;
                 if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {

--- a/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Bytes.cs
@@ -229,8 +229,12 @@ public static partial class DataMatrixCode {
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 85;
-        MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+        var jpegOptions = options?.JpegOptions;
+        if (jpegOptions is null) {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, options?.JpegQuality ?? 85);
+        } else {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>

--- a/CodeGlyphX/DataMatrixCode.Save.Text.Stream.cs
+++ b/CodeGlyphX/DataMatrixCode.Save.Text.Stream.cs
@@ -107,8 +107,12 @@ public static partial class DataMatrixCode {
     public static void SaveJpeg(string text, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 85;
-        MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+        var jpegOptions = options?.JpegOptions;
+        if (jpegOptions is null) {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, options?.JpegQuality ?? 85);
+        } else {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>
@@ -238,8 +242,12 @@ public static partial class DataMatrixCode {
     public static void SaveJpeg(byte[] data, Stream stream, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 85;
-        MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+        var jpegOptions = options?.JpegOptions;
+        if (jpegOptions is null) {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, options?.JpegQuality ?? 85);
+        } else {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>

--- a/CodeGlyphX/DataMatrixCode.cs
+++ b/CodeGlyphX/DataMatrixCode.cs
@@ -113,8 +113,10 @@ public static partial class DataMatrixCode {
     public static byte[] Jpeg(ReadOnlySpan<byte> data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = options?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, options?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>
@@ -325,8 +327,10 @@ public static partial class DataMatrixCode {
     public static byte[] Jpeg(string text, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = Encode(text, mode);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = options?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, options?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>
@@ -463,8 +467,10 @@ public static partial class DataMatrixCode {
     public static byte[] Jpeg(byte[] data, DataMatrixEncodingMode mode = DataMatrixEncodingMode.Auto, MatrixOptions? options = null) {
         var modules = EncodeBytes(data, mode);
         var opts = BuildPngOptions(options);
-        var quality = options?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = options?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, options?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>

--- a/CodeGlyphX/ImageDecodeOptions.Fluent.cs
+++ b/CodeGlyphX/ImageDecodeOptions.Fluent.cs
@@ -1,3 +1,5 @@
+using CodeGlyphX.Rendering.Jpeg;
+
 namespace CodeGlyphX;
 
 public sealed partial class ImageDecodeOptions {
@@ -25,6 +27,34 @@ public sealed partial class ImageDecodeOptions {
         if (maxDimension > 0) {
             MaxDimension = maxDimension;
         }
+        return this;
+    }
+
+    /// <summary>
+    /// Sets JPEG decoding options.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new ImageDecodeOptions()
+    ///     .WithJpegOptions(highQualityChroma: true, allowTruncated: true);
+    /// </code>
+    /// </example>
+    public ImageDecodeOptions WithJpegOptions(JpegDecodeOptions options) {
+        JpegOptions = options;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets JPEG decoding options.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new ImageDecodeOptions()
+    ///     .WithJpegOptions(highQualityChroma: true);
+    /// </code>
+    /// </example>
+    public ImageDecodeOptions WithJpegOptions(bool highQualityChroma = false, bool allowTruncated = false) {
+        JpegOptions = new JpegDecodeOptions(highQualityChroma, allowTruncated);
         return this;
     }
 }

--- a/CodeGlyphX/ImageDecodeOptions.cs
+++ b/CodeGlyphX/ImageDecodeOptions.cs
@@ -1,3 +1,5 @@
+using CodeGlyphX.Rendering.Jpeg;
+
 namespace CodeGlyphX;
 
 /// <summary>
@@ -14,6 +16,11 @@ public sealed partial class ImageDecodeOptions {
     /// Maximum milliseconds to spend decoding (best effort). Set to 0 to disable.
     /// </summary>
     public int MaxMilliseconds { get; set; } = 0;
+
+    /// <summary>
+    /// Optional JPEG decoding options (chroma upsampling, truncated handling).
+    /// </summary>
+    public JpegDecodeOptions? JpegOptions { get; set; }
 
     /// <summary>
     /// Screen preset (budgeted decode for UI capture scenarios).

--- a/CodeGlyphX/MatrixOptions.cs
+++ b/CodeGlyphX/MatrixOptions.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX;
@@ -32,6 +33,12 @@ public sealed class MatrixOptions {
     /// JPEG quality (1..100).
     /// </summary>
     public int JpegQuality { get; set; } = 85;
+
+    /// <summary>
+    /// Optional JPEG encoding options (subsampling/progressive/metadata/etc).
+    /// When set, overrides <see cref="JpegQuality"/> where applicable.
+    /// </summary>
+    public JpegEncodeOptions? JpegOptions { get; set; }
 
     /// <summary>
     /// WebP quality (0..100). A value of 100 uses lossless VP8L.

--- a/CodeGlyphX/Pdf417Code.Builder.cs
+++ b/CodeGlyphX/Pdf417Code.Builder.cs
@@ -98,6 +98,14 @@ public static partial class Pdf417Code {
         }
 
         /// <summary>
+        /// Sets JPEG encoding options.
+        /// </summary>
+        public Pdf417Builder WithJpegOptions(JpegEncodeOptions options) {
+            _renderOptions.JpegOptions = options ?? throw new ArgumentNullException(nameof(options));
+            return this;
+        }
+
+        /// <summary>
         /// Enables HTML email-safe table rendering.
         /// </summary>
         public Pdf417Builder WithHtmlEmailSafeTable(bool enabled = true) {

--- a/CodeGlyphX/Pdf417Code.Decode.cs
+++ b/CodeGlyphX/Pdf417Code.Decode.cs
@@ -302,7 +302,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return Pdf417Decoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -354,7 +354,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; diagnostics.Failure = FailureCancelled; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 text = string.Empty;
                 diagnostics.Failure ??= "Unsupported image format.";
                 return false;
@@ -406,7 +406,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return Pdf417Decoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -490,7 +490,7 @@ public static partial class Pdf417Code {
         try {
             if (token.IsCancellationRequested) { text = string.Empty; return false; }
             var data = RenderIO.ReadBinary(stream);
-            if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
+            if (!ImageReader.TryDecodeRgba32(data, options, out var rgba, out var width, out var height)) { text = string.Empty; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { text = string.Empty; return false; }
             return Pdf417Decoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out text);
         } finally {
@@ -542,7 +542,7 @@ public static partial class Pdf417Code {
             if (token.IsCancellationRequested) {
                 return new DecodeResult<string>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 var imageFailure = DecodeResultHelpers.FailureForImageRead(image, formatKnown, token);
                 return new DecodeResult<string>(imageFailure, info, stopwatch.Elapsed);
             }
@@ -616,7 +616,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { text = string.Empty; diagnostics.Failure = FailureCancelled; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) {
                 text = string.Empty;
                 diagnostics.Failure ??= "Unsupported image format.";
                 return false;
@@ -646,7 +646,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) return false;
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) return false;
             var original = rgba;
             var originalWidth = width;
             var originalHeight = height;

--- a/CodeGlyphX/Pdf417Code.Macro.Decode.cs
+++ b/CodeGlyphX/Pdf417Code.Macro.Decode.cs
@@ -167,7 +167,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { decoded = null!; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { decoded = null!; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { decoded = null!; return false; }
             return Pdf417Decoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out decoded);
         } finally {
@@ -204,7 +204,7 @@ public static partial class Pdf417Code {
         var token = ImageDecodeHelper.ApplyBudget(cancellationToken, options, out var budgetCts, out var budgetScope);
         try {
             if (token.IsCancellationRequested) { decoded = null!; return false; }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
+            if (!ImageReader.TryDecodeRgba32(image, options, out var rgba, out var width, out var height)) { decoded = null!; return false; }
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, options, token)) { decoded = null!; return false; }
             return Pdf417Decoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, token, out decoded);
         } finally {

--- a/CodeGlyphX/Pdf417Code.Macro.cs
+++ b/CodeGlyphX/Pdf417Code.Macro.cs
@@ -65,8 +65,10 @@ public static partial class Pdf417Code {
     public static byte[] JpegMacro(string text, Pdf417MacroOptions macro, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeMacro(text, macro, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>

--- a/CodeGlyphX/Pdf417Code.Render.cs
+++ b/CodeGlyphX/Pdf417Code.Render.cs
@@ -79,8 +79,13 @@ public static partial class Pdf417Code {
                 }
                 return RenderedOutput.FromText(format, html);
             }
-            case OutputFormat.Jpeg:
-                return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
+            case OutputFormat.Jpeg: {
+                var jpegOptions = renderOptions?.JpegOptions;
+                var data = jpegOptions is null
+                    ? MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85)
+                    : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
+                return RenderedOutput.FromBinary(format, data);
+            }
             case OutputFormat.Webp: {
                 var quality = renderOptions?.WebpQuality ?? 100;
                 if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {

--- a/CodeGlyphX/Pdf417Code.Save.Bytes.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Bytes.cs
@@ -239,8 +239,12 @@ public static partial class Pdf417Code {
     public static void SaveJpeg(ReadOnlySpan<byte> data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        if (jpegOptions is null) {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, renderOptions?.JpegQuality ?? 85);
+        } else {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>

--- a/CodeGlyphX/Pdf417Code.Save.Text.Stream.cs
+++ b/CodeGlyphX/Pdf417Code.Save.Text.Stream.cs
@@ -108,8 +108,12 @@ public static partial class Pdf417Code {
     public static void SaveJpeg(string text, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        if (jpegOptions is null) {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, renderOptions?.JpegQuality ?? 85);
+        } else {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>
@@ -239,8 +243,12 @@ public static partial class Pdf417Code {
     public static void SaveJpeg(byte[] data, Stream stream, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        MatrixJpegRenderer.RenderToStream(modules, opts, stream, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        if (jpegOptions is null) {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, renderOptions?.JpegQuality ?? 85);
+        } else {
+            MatrixJpegRenderer.RenderToStream(modules, opts, stream, jpegOptions);
+        }
     }
 
     /// <summary>

--- a/CodeGlyphX/Pdf417Code.cs
+++ b/CodeGlyphX/Pdf417Code.cs
@@ -121,8 +121,10 @@ public static partial class Pdf417Code {
     public static byte[] Jpeg(ReadOnlySpan<byte> data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>
@@ -333,8 +335,10 @@ public static partial class Pdf417Code {
     public static byte[] Jpeg(string text, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = Encode(text, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>
@@ -471,8 +475,10 @@ public static partial class Pdf417Code {
     public static byte[] Jpeg(byte[] data, Pdf417EncodeOptions? encodeOptions = null, MatrixOptions? renderOptions = null) {
         var modules = EncodeBytes(data, encodeOptions);
         var opts = BuildPngOptions(renderOptions);
-        var quality = renderOptions?.JpegQuality ?? 85;
-        return MatrixJpegRenderer.Render(modules, opts, quality);
+        var jpegOptions = renderOptions?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, opts, renderOptions?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, opts, jpegOptions);
     }
 
     /// <summary>

--- a/CodeGlyphX/Qr/QrPixelDecoder.Part6.cs
+++ b/CodeGlyphX/Qr/QrPixelDecoder.Part6.cs
@@ -38,6 +38,7 @@ internal static partial class QrPixelDecoder {
     }
 
     private static int Score(global::CodeGlyphX.QrDecodeDiagnostics d) {
+        if (d.Failure == global::CodeGlyphX.QrDecodeFailure.None && d.Version == 0) return 0;
         return d.Failure switch {
             global::CodeGlyphX.QrDecodeFailure.None => 5,
             global::CodeGlyphX.QrDecodeFailure.Payload => 4,

--- a/CodeGlyphX/QrEasy.Helpers.cs
+++ b/CodeGlyphX/QrEasy.Helpers.cs
@@ -259,11 +259,31 @@ public static partial class QrEasy {
             LogoBackground = opts.LogoBackground,
             LogoCornerRadiusPx = opts.LogoCornerRadiusPx,
             JpegQuality = opts.JpegQuality,
+            JpegOptions = CloneJpegOptions(opts.JpegOptions),
             WebpQuality = opts.WebpQuality,
             IcoSizes = opts.IcoSizes is null ? null : (int[])opts.IcoSizes.Clone(),
             IcoPreserveAspectRatio = opts.IcoPreserveAspectRatio,
             HtmlEmailSafeTable = opts.HtmlEmailSafeTable,
         };
+    }
+
+    private static JpegEncodeOptions? CloneJpegOptions(JpegEncodeOptions? options) {
+        if (options is null) return null;
+        return new JpegEncodeOptions {
+            Quality = options.Quality,
+            Subsampling = options.Subsampling,
+            Progressive = options.Progressive,
+            OptimizeHuffman = options.OptimizeHuffman,
+            WriteJfifHeader = options.WriteJfifHeader,
+            Metadata = CloneJpegMetadata(options.Metadata)
+        };
+    }
+
+    private static JpegMetadata CloneJpegMetadata(JpegMetadata metadata) {
+        return new JpegMetadata(
+            metadata.Exif is null ? null : (byte[])metadata.Exif.Clone(),
+            metadata.Xmp is null ? null : (byte[])metadata.Xmp.Clone(),
+            metadata.Icc is null ? null : (byte[])metadata.Icc.Clone());
     }
 
     private static QrPngGradientOptions? CloneGradient(QrPngGradientOptions? gradient) {

--- a/CodeGlyphX/QrEasy.Render.Core.cs
+++ b/CodeGlyphX/QrEasy.Render.Core.cs
@@ -283,7 +283,9 @@ public static partial class QrEasy {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, qr);
-        return QrJpegRenderer.Render(qr.Modules, render, opts.JpegQuality);
+        return opts.JpegOptions is null
+            ? QrJpegRenderer.Render(qr.Modules, render, opts.JpegQuality)
+            : QrJpegRenderer.Render(qr.Modules, render, opts.JpegOptions);
     }
 
     /// <summary>
@@ -325,7 +327,11 @@ public static partial class QrEasy {
         var opts = options is null ? new QrEasyOptions() : CloneOptions(options);
         var qr = Encode(payload, opts);
         var render = BuildPngOptions(opts, qr);
-        QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+        if (opts.JpegOptions is null) {
+            QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+        } else {
+            QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegOptions);
+        }
     }
 
     /// <summary>
@@ -400,7 +406,9 @@ public static partial class QrEasy {
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, qr);
-        return QrJpegRenderer.Render(qr.Modules, render, opts.JpegQuality);
+        return opts.JpegOptions is null
+            ? QrJpegRenderer.Render(qr.Modules, render, opts.JpegQuality)
+            : QrJpegRenderer.Render(qr.Modules, render, opts.JpegOptions);
     }
 
     /// <summary>
@@ -424,7 +432,11 @@ public static partial class QrEasy {
         var opts = MergeOptions(payload, options);
         var qr = Encode(payload.Text, opts);
         var render = BuildPngOptions(opts, qr);
-        QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+        if (opts.JpegOptions is null) {
+            QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegQuality);
+        } else {
+            QrJpegRenderer.RenderToStream(qr.Modules, render, stream, opts.JpegOptions);
+        }
     }
 
     /// <summary>

--- a/CodeGlyphX/QrEasy.Render.Generic.cs
+++ b/CodeGlyphX/QrEasy.Render.Generic.cs
@@ -67,8 +67,11 @@ public static partial class QrEasy {
             }
             case OutputFormat.Jpeg: {
                 var render = BuildPngOptions(opts, qr);
-                var quality = opts.JpegQuality;
-                return RenderedOutput.FromBinary(format, QrJpegRenderer.Render(qr.Modules, render, quality));
+                var jpegOptions = opts.JpegOptions;
+                var data = jpegOptions is null
+                    ? QrJpegRenderer.Render(qr.Modules, render, opts.JpegQuality)
+                    : QrJpegRenderer.Render(qr.Modules, render, jpegOptions);
+                return RenderedOutput.FromBinary(format, data);
             }
             case OutputFormat.Webp: {
                 var render = BuildPngOptions(opts, qr);

--- a/CodeGlyphX/QrEasyOptions.cs
+++ b/CodeGlyphX/QrEasyOptions.cs
@@ -1,5 +1,6 @@
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX;
@@ -229,6 +230,12 @@ public sealed class QrEasyOptions {
     /// JPEG quality (1..100).
     /// </summary>
     public int JpegQuality { get; set; } = 85;
+
+    /// <summary>
+    /// Optional JPEG encoding options (subsampling/progressive/metadata/etc).
+    /// When set, overrides <see cref="JpegQuality"/> where applicable.
+    /// </summary>
+    public JpegEncodeOptions? JpegOptions { get; set; }
 
     /// <summary>
     /// WebP quality (0..100). A value of 100 uses lossless VP8L.

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -665,7 +665,7 @@ public static class QrImageDecoder {
             if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
                 return TryDecodeImageFallback(image, imageOptions, options, token, out decoded, out _);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, imageOptions, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out decoded);
         } finally {
@@ -684,7 +684,7 @@ public static class QrImageDecoder {
             if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
                 return TryDecodeImageFallback(image, imageOptions, options, token, out decoded, out info);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, imageOptions, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options, token);
         } finally {
@@ -701,7 +701,7 @@ public static class QrImageDecoder {
             if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
                 return TryDecodeImageFallback(image.ToArray(), imageOptions, options, token, out decoded, out _);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, imageOptions, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out decoded);
         } finally {
@@ -719,7 +719,7 @@ public static class QrImageDecoder {
             if (CodeGlyphXFeatures.ForceQrFallbackForTests) {
                 return TryDecodeImageFallback(image.ToArray(), imageOptions, options, token, out decoded, out info);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, imageOptions, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return QrDecoder.TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, out info, options, token);
         } finally {
@@ -739,7 +739,7 @@ public static class QrImageDecoder {
                 decoded = new[] { single };
                 return true;
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) return false;
+            if (!ImageReader.TryDecodeRgba32(image, imageOptions, out var rgba, out var width, out var height)) return false;
             if (!ImageDecodeHelper.TryDownscale(ref rgba, ref width, ref height, imageOptions, token)) return false;
             return global::CodeGlyphX.Qr.QrPixelDecoder.TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, options, token, out decoded);
         } finally {
@@ -775,7 +775,7 @@ public static class QrImageDecoder {
                 decoded = Array.Empty<QrDecoded>();
                 return false;
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, imageOptions, out var rgba, out var width, out var height)) {
                 decoded = Array.Empty<QrDecoded>();
                 return false;
             }

--- a/CodeGlyphX/Rendering/ImageReader.cs
+++ b/CodeGlyphX/Rendering/ImageReader.cs
@@ -128,14 +128,6 @@ public static partial class ImageReader {
     }
 
     /// <summary>
-    /// Decodes an image to an RGBA buffer (auto-detected).
-    /// </summary>
-    public static byte[] DecodeRgba32(ReadOnlySpan<byte> data, ImageDecodeOptions? options, out int width, out int height) {
-        _ = options;
-        return DecodeRgba32(data, out width, out height);
-    }
-
-    /// <summary>
     /// Decodes animation frames (non-composited) (auto-detected).
     /// </summary>
     public static ImageAnimationFrame[] DecodeAnimationFrames(ReadOnlySpan<byte> data, out int width, out int height, out ImageAnimationOptions options) {

--- a/CodeGlyphX/Rendering/Jpeg/BarcodeJpegRenderer.cs
+++ b/CodeGlyphX/Rendering/Jpeg/BarcodeJpegRenderer.cs
@@ -7,7 +7,7 @@ using CodeGlyphX.Rendering.Png;
 namespace CodeGlyphX.Rendering.Jpeg;
 
 /// <summary>
-/// Renders 1D barcodes to a JPEG image (baseline, 4:4:4).
+/// Renders 1D barcodes to a JPEG image.
 /// </summary>
 public static class BarcodeJpegRenderer {
     /// <summary>
@@ -19,6 +19,20 @@ public static class BarcodeJpegRenderer {
         try {
             BarcodePngRenderer.RenderScanlines(barcode, opts, out width, out height, out stride, scanlines);
             return JpegWriter.WriteRgbaScanlines(width, height, scanlines, stride, quality);
+        } finally {
+            ArrayPool<byte>.Shared.Return(scanlines);
+        }
+    }
+
+    /// <summary>
+    /// Renders the barcode to a JPEG byte array.
+    /// </summary>
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts, JpegEncodeOptions options) {
+        var length = BarcodePngRenderer.GetScanlineLength(barcode, opts, out var width, out var height, out var stride);
+        var scanlines = ArrayPool<byte>.Shared.Rent(length);
+        try {
+            BarcodePngRenderer.RenderScanlines(barcode, opts, out width, out height, out stride, scanlines);
+            return JpegWriter.WriteRgbaScanlines(width, height, scanlines, stride, options);
         } finally {
             ArrayPool<byte>.Shared.Return(scanlines);
         }
@@ -43,6 +57,24 @@ public static class BarcodeJpegRenderer {
     }
 
     /// <summary>
+    /// Renders the barcode to a JPEG stream.
+    /// </summary>
+    /// <param name="barcode">Barcode to render.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="stream">Target stream.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream, JpegEncodeOptions options) {
+        var length = BarcodePngRenderer.GetScanlineLength(barcode, opts, out var width, out var height, out var stride);
+        var scanlines = ArrayPool<byte>.Shared.Rent(length);
+        try {
+            BarcodePngRenderer.RenderScanlines(barcode, opts, out width, out height, out stride, scanlines);
+            JpegWriter.WriteRgbaScanlines(stream, width, height, scanlines, stride, options);
+        } finally {
+            ArrayPool<byte>.Shared.Return(scanlines);
+        }
+    }
+
+    /// <summary>
     /// Renders the barcode to a JPEG file.
     /// </summary>
     /// <param name="barcode">Barcode to render.</param>
@@ -52,6 +84,19 @@ public static class BarcodeJpegRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path, int quality = 85) {
         var jpeg = Render(barcode, opts, quality);
+        return RenderIO.WriteBinary(path, jpeg);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a JPEG file.
+    /// </summary>
+    /// <param name="barcode">Barcode to render.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path, JpegEncodeOptions options) {
+        var jpeg = Render(barcode, opts, options);
         return RenderIO.WriteBinary(path, jpeg);
     }
 
@@ -66,6 +111,20 @@ public static class BarcodeJpegRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName, int quality = 85) {
         var jpeg = Render(barcode, opts, quality);
+        return RenderIO.WriteBinary(directory, fileName, jpeg);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a JPEG file under the specified directory.
+    /// </summary>
+    /// <param name="barcode">Barcode to render.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="directory">Output directory.</param>
+    /// <param name="fileName">Output file name.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName, JpegEncodeOptions options) {
+        var jpeg = Render(barcode, opts, options);
         return RenderIO.WriteBinary(directory, fileName, jpeg);
     }
 

--- a/CodeGlyphX/Rendering/Jpeg/JpegDecodeOptions.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegDecodeOptions.cs
@@ -1,0 +1,30 @@
+namespace CodeGlyphX.Rendering.Jpeg;
+
+/// <summary>
+/// JPEG decoding options.
+/// </summary>
+/// <example>
+/// <code>
+/// var options = new JpegDecodeOptions(highQualityChroma: true, allowTruncated: true);
+/// var rgba = JpegReader.DecodeRgba32(data, out var width, out var height, options);
+/// </code>
+/// </example>
+public readonly struct JpegDecodeOptions {
+    /// <summary>
+    /// Enables higher-quality chroma upsampling when components are subsampled.
+    /// </summary>
+    public bool HighQualityChroma { get; }
+
+    /// <summary>
+    /// Allows truncated scan data (best-effort decode).
+    /// </summary>
+    public bool AllowTruncated { get; }
+
+    /// <summary>
+    /// Creates JPEG decode options.
+    /// </summary>
+    public JpegDecodeOptions(bool highQualityChroma = false, bool allowTruncated = false) {
+        HighQualityChroma = highQualityChroma;
+        AllowTruncated = allowTruncated;
+    }
+}

--- a/CodeGlyphX/Rendering/Jpeg/JpegEncodeOptions.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegEncodeOptions.cs
@@ -1,0 +1,36 @@
+namespace CodeGlyphX.Rendering.Jpeg;
+
+/// <summary>
+/// JPEG encoding options.
+/// </summary>
+public sealed class JpegEncodeOptions {
+    /// <summary>
+    /// JPEG quality (1..100).
+    /// </summary>
+    public int Quality { get; set; } = 85;
+
+    /// <summary>
+    /// Chroma subsampling mode.
+    /// </summary>
+    public JpegSubsampling Subsampling { get; set; } = JpegSubsampling.Y444;
+
+    /// <summary>
+    /// Enables progressive JPEG encoding.
+    /// </summary>
+    public bool Progressive { get; set; }
+
+    /// <summary>
+    /// Enables optimized Huffman tables.
+    /// </summary>
+    public bool OptimizeHuffman { get; set; }
+
+    /// <summary>
+    /// Optional metadata segments (EXIF/XMP/ICC).
+    /// </summary>
+    public JpegMetadata Metadata { get; set; } = default;
+
+    /// <summary>
+    /// Writes a JFIF APP0 header when true.
+    /// </summary>
+    public bool WriteJfifHeader { get; set; } = true;
+}

--- a/CodeGlyphX/Rendering/Jpeg/JpegMetadata.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegMetadata.cs
@@ -1,0 +1,35 @@
+namespace CodeGlyphX.Rendering.Jpeg;
+
+/// <summary>
+/// Optional JPEG metadata payloads (EXIF/XMP/ICC).
+/// </summary>
+public readonly struct JpegMetadata {
+    /// <summary>
+    /// EXIF payload (TIFF data, optional "Exif\0\0" header).
+    /// </summary>
+    public byte[]? Exif { get; }
+
+    /// <summary>
+    /// XMP payload (RDF/XML, optional XMP namespace header).
+    /// </summary>
+    public byte[]? Xmp { get; }
+
+    /// <summary>
+    /// ICC profile payload.
+    /// </summary>
+    public byte[]? Icc { get; }
+
+    /// <summary>
+    /// Indicates whether any metadata is present.
+    /// </summary>
+    public bool HasData => (Exif is { Length: > 0 }) || (Xmp is { Length: > 0 }) || (Icc is { Length: > 0 });
+
+    /// <summary>
+    /// Creates metadata with optional EXIF/XMP/ICC payloads.
+    /// </summary>
+    public JpegMetadata(byte[]? exif = null, byte[]? xmp = null, byte[]? icc = null) {
+        Exif = exif;
+        Xmp = xmp;
+        Icc = icc;
+    }
+}

--- a/CodeGlyphX/Rendering/Jpeg/JpegReader.Decode.Helpers.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegReader.Decode.Helpers.cs
@@ -527,6 +527,8 @@ public static partial class JpegReader {
         var width = ReadUInt16BE(data, 3);
         var components = data[5];
         if (width == 0 || height == 0) throw new FormatException("Invalid JPEG dimensions.");
+        const long maxPixels = 100_000_000;
+        if ((long)width * height > maxPixels) throw new FormatException("JPEG dimensions exceed limits.");
         if (components == 0) throw new FormatException("Invalid JPEG component count.");
         if (data.Length < 6 + components * 3) throw new FormatException("Invalid JPEG SOF segment.");
 

--- a/CodeGlyphX/Rendering/Jpeg/JpegReader.Decode.Scan.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegReader.Decode.Scan.cs
@@ -121,7 +121,7 @@ public static partial class JpegReader {
         bool allowTruncated) {
         EnsureStandardHuffmanTables(dcTables, acTables);
         // Progressive scans are lenient to match historical behavior.
-        var reader = new JpegBitReader(scanData, allowTruncated: true);
+        var reader = new JpegBitReader(scanData, allowTruncated);
         var mcuIndex = 0;
         var eobRun = 0;
         var isSingle = scan.ComponentIndices.Length == 1;

--- a/CodeGlyphX/Rendering/Jpeg/JpegSubsampling.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegSubsampling.cs
@@ -1,0 +1,19 @@
+namespace CodeGlyphX.Rendering.Jpeg;
+
+/// <summary>
+/// JPEG chroma subsampling selection.
+/// </summary>
+public enum JpegSubsampling {
+    /// <summary>
+    /// 4:4:4 (no subsampling).
+    /// </summary>
+    Y444,
+    /// <summary>
+    /// 4:2:2 (half horizontal chroma resolution).
+    /// </summary>
+    Y422,
+    /// <summary>
+    /// 4:2:0 (half horizontal + vertical chroma resolution).
+    /// </summary>
+    Y420
+}

--- a/CodeGlyphX/Rendering/Jpeg/JpegWriter.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegWriter.cs
@@ -765,6 +765,8 @@ internal static class JpegWriter {
         (byte)'I', (byte)'C', (byte)'C', (byte)'_', (byte)'P', (byte)'R', (byte)'O', (byte)'F', (byte)'I', (byte)'L', (byte)'E', 0
     };
 
+    private const int MaxAppSegmentPayload = 0xFFFD;
+
     private static void WriteMetadata(Stream s, JpegMetadata metadata) {
         if (!metadata.HasData) return;
 
@@ -785,12 +787,12 @@ internal static class JpegWriter {
 
     private static byte[] EnsurePrefix(byte[] data, byte[] prefix) {
         if (StartsWith(data, prefix)) {
-            if (data.Length > 0xFFFD) {
+            if (data.Length > MaxAppSegmentPayload) {
                 throw new ArgumentOutOfRangeException(nameof(data), "APP segment payload too large.");
             }
             return data;
         }
-        if (prefix.Length + data.Length > 0xFFFD) {
+        if (prefix.Length + data.Length > MaxAppSegmentPayload) {
             throw new ArgumentOutOfRangeException(nameof(data), "APP segment payload too large.");
         }
         var combined = new byte[prefix.Length + data.Length];
@@ -808,7 +810,7 @@ internal static class JpegWriter {
     }
 
     private static void WriteAppSegment(Stream s, int marker, byte[] payload) {
-        if (payload.Length > 0xFFFD) {
+        if (payload.Length > MaxAppSegmentPayload) {
             throw new ArgumentOutOfRangeException(nameof(payload), "APP segment payload too large.");
         }
         WriteMarker(s, marker);
@@ -817,7 +819,7 @@ internal static class JpegWriter {
     }
 
     private static void WriteIccSegments(Stream s, byte[] icc) {
-        const int maxPayload = 0xFFFD;
+        const int maxPayload = MaxAppSegmentPayload;
         var headerSize = IccPrefix.Length + 2;
         var maxData = maxPayload - headerSize;
         var totalSegments = (icc.Length + maxData - 1) / maxData;

--- a/CodeGlyphX/Rendering/Jpeg/JpegWriter.cs
+++ b/CodeGlyphX/Rendering/Jpeg/JpegWriter.cs
@@ -90,63 +90,306 @@ internal static class JpegWriter {
         return ms.ToArray();
     }
 
+    public static byte[] WriteRgba(int width, int height, byte[] rgba, int stride, JpegEncodeOptions options) {
+        using var ms = new MemoryStream();
+        WriteRgba(ms, width, height, rgba, stride, options);
+        return ms.ToArray();
+    }
+
+    public static byte[] WriteRgbaScanlines(int width, int height, byte[] scanlines, int stride, JpegEncodeOptions options) {
+        using var ms = new MemoryStream();
+        WriteRgbaScanlines(ms, width, height, scanlines, stride, options);
+        return ms.ToArray();
+    }
+
     public static void WriteRgba(Stream stream, int width, int height, byte[] rgba, int stride, int quality) {
-        WriteRgbaCore(stream, width, height, rgba, stride, rowOffset: 0, rowStride: stride, quality, nameof(rgba), "RGBA buffer too small.");
+        WriteRgbaCore(stream, width, height, rgba, stride, rowOffset: 0, rowStride: stride, BuildOptions(quality), nameof(rgba), "RGBA buffer too small.");
     }
 
     public static void WriteRgbaScanlines(Stream stream, int width, int height, byte[] scanlines, int stride, int quality) {
-        WriteRgbaCore(stream, width, height, scanlines, stride, rowOffset: 1, rowStride: stride + 1, quality, nameof(scanlines), "Scanline buffer too small.");
+        WriteRgbaCore(stream, width, height, scanlines, stride, rowOffset: 1, rowStride: stride + 1, BuildOptions(quality), nameof(scanlines), "Scanline buffer too small.");
     }
 
-    private static void WriteRgbaCore(Stream stream, int width, int height, byte[] rgba, int stride, int rowOffset, int rowStride, int quality, string bufferName, string bufferMessage) {
+    public static void WriteRgba(Stream stream, int width, int height, byte[] rgba, int stride, JpegEncodeOptions options) {
+        WriteRgbaCore(stream, width, height, rgba, stride, rowOffset: 0, rowStride: stride, options, nameof(rgba), "RGBA buffer too small.");
+    }
+
+    public static void WriteRgbaScanlines(Stream stream, int width, int height, byte[] scanlines, int stride, JpegEncodeOptions options) {
+        WriteRgbaCore(stream, width, height, scanlines, stride, rowOffset: 1, rowStride: stride + 1, options, nameof(scanlines), "Scanline buffer too small.");
+    }
+
+    private static void WriteRgbaCore(Stream stream, int width, int height, byte[] rgba, int stride, int rowOffset, int rowStride, JpegEncodeOptions options, string bufferName, string bufferMessage) {
         if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
         if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
         if (rgba is null) throw new ArgumentNullException(bufferName);
         if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
         if (rowStride < rowOffset + stride) throw new ArgumentOutOfRangeException(nameof(rowStride));
         if (rgba.Length < height * rowStride) throw new ArgumentException(bufferMessage, bufferName);
-        if (quality is < 1 or > 100) throw new ArgumentOutOfRangeException(nameof(quality));
         if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (options is null) throw new ArgumentNullException(nameof(options));
+
+        var quality = options.Quality;
+        if (quality is < 1 or > 100) throw new ArgumentOutOfRangeException(nameof(options.Quality));
 
         var qY = ScaleQuantTable(StdLumaQuant, quality);
         var qC = ScaleQuantTable(StdChromaQuant, quality);
 
-        var dcLuma = DcLumaTable;
-        var acLuma = AcLumaTable;
-        var dcChroma = DcChromaTable;
-        var acChroma = AcChromaTable;
-
         var grayscale = IsGrayscale(rgba, width, height, stride, rowOffset, rowStride);
+        var sampling = grayscale ? JpegSubsampling.Y444 : options.Subsampling;
+
+        BuildComponents(sampling, grayscale, out var components, out var maxH, out var maxV);
+        var coeffs = BuildCoefficients(
+            rgba,
+            width,
+            height,
+            stride,
+            rowOffset,
+            rowStride,
+            components,
+            maxH,
+            maxV,
+            qY,
+            qC);
+
+        var tables = BuildHuffmanTables(coeffs, components, options.OptimizeHuffman);
 
         WriteMarker(stream, 0xFFD8);
-        WriteApp0(stream);
+        if (options.WriteJfifHeader) {
+            WriteApp0(stream);
+        }
+        WriteMetadata(stream, options.Metadata);
         WriteDqt(stream, 0, qY);
         if (!grayscale) {
             WriteDqt(stream, 1, qC);
         }
-        if (grayscale) {
-            WriteSof0Gray(stream, width, height);
-            WriteDht(stream, 0, 0, DcLumaBits, DcValues);
-            WriteDht(stream, 1, 0, AcLumaBits, AcLumaValues);
-            WriteSosGray(stream);
-        } else {
-            WriteSof0(stream, width, height);
-            WriteDht(stream, 0, 0, DcLumaBits, DcValues);
-            WriteDht(stream, 1, 0, AcLumaBits, AcLumaValues);
-            WriteDht(stream, 0, 1, DcChromaBits, DcValues);
-            WriteDht(stream, 1, 1, AcChromaBits, AcChromaValues);
-            WriteSos(stream);
+
+        WriteSof(stream, options.Progressive, width, height, components);
+
+        WriteDht(stream, 0, 0, tables.DcLuma.Bits, tables.DcLuma.Values);
+        WriteDht(stream, 1, 0, tables.AcLuma.Bits, tables.AcLuma.Values);
+        if (!grayscale) {
+            WriteDht(stream, 0, 1, tables.DcChroma.Bits, tables.DcChroma.Values);
+            WriteDht(stream, 1, 1, tables.AcChroma.Bits, tables.AcChroma.Values);
         }
 
-        var bw = new BitWriter(stream);
-        if (grayscale) {
-            EncodeImageGray(bw, width, height, rgba, stride, rowOffset, rowStride, qY, dcLuma, acLuma);
+        if (options.Progressive) {
+            EncodeProgressive(stream, components, coeffs, tables);
         } else {
-            EncodeImage(bw, width, height, rgba, stride, rowOffset, rowStride, qY, qC, dcLuma, acLuma, dcChroma, acChroma);
+            EncodeBaseline(stream, components, coeffs, tables);
         }
-        bw.Flush();
 
         WriteMarker(stream, 0xFFD9);
+    }
+
+    private static JpegEncodeOptions BuildOptions(int quality) {
+        return new JpegEncodeOptions {
+            Quality = quality
+        };
+    }
+
+    private sealed class ComponentSpec {
+        public byte Id;
+        public byte H;
+        public byte V;
+        public byte QuantId;
+        public byte DcTable;
+        public byte AcTable;
+    }
+
+    private readonly struct ComponentCoefficients {
+        public readonly ComponentSpec Spec;
+        public readonly int BlocksPerRow;
+        public readonly int BlocksPerCol;
+        public readonly int[] Data;
+
+        public ComponentCoefficients(ComponentSpec spec, int blocksPerRow, int blocksPerCol, int[] data) {
+            Spec = spec;
+            BlocksPerRow = blocksPerRow;
+            BlocksPerCol = blocksPerCol;
+            Data = data;
+        }
+    }
+
+    private readonly struct HuffmanSpec {
+        public readonly byte[] Bits;
+        public readonly byte[] Values;
+        public readonly HuffmanTable Table;
+
+        public HuffmanSpec(byte[] bits, byte[] values, HuffmanTable table) {
+            Bits = bits;
+            Values = values;
+            Table = table;
+        }
+    }
+
+    private readonly struct HuffmanTableSet {
+        public readonly HuffmanSpec DcLuma;
+        public readonly HuffmanSpec AcLuma;
+        public readonly HuffmanSpec DcChroma;
+        public readonly HuffmanSpec AcChroma;
+
+        public HuffmanTableSet(HuffmanSpec dcLuma, HuffmanSpec acLuma, HuffmanSpec dcChroma, HuffmanSpec acChroma) {
+            DcLuma = dcLuma;
+            AcLuma = acLuma;
+            DcChroma = dcChroma;
+            AcChroma = acChroma;
+        }
+    }
+
+    private static void BuildComponents(JpegSubsampling subsampling, bool grayscale, out ComponentSpec[] components, out int maxH, out int maxV) {
+        if (grayscale) {
+            components = new[] {
+                new ComponentSpec { Id = 1, H = 1, V = 1, QuantId = 0, DcTable = 0, AcTable = 0 }
+            };
+            maxH = 1;
+            maxV = 1;
+            return;
+        }
+
+        byte yH;
+        byte yV;
+        byte cH;
+        byte cV;
+        switch (subsampling) {
+            case JpegSubsampling.Y422:
+                yH = 2;
+                yV = 1;
+                cH = 1;
+                cV = 1;
+                break;
+            case JpegSubsampling.Y420:
+                yH = 2;
+                yV = 2;
+                cH = 1;
+                cV = 1;
+                break;
+            case JpegSubsampling.Y444:
+            default:
+                yH = 1;
+                yV = 1;
+                cH = 1;
+                cV = 1;
+                break;
+        }
+
+        maxH = yH;
+        maxV = yV;
+        components = new[] {
+            new ComponentSpec { Id = 1, H = yH, V = yV, QuantId = 0, DcTable = 0, AcTable = 0 },
+            new ComponentSpec { Id = 2, H = cH, V = cV, QuantId = 1, DcTable = 1, AcTable = 1 },
+            new ComponentSpec { Id = 3, H = cH, V = cV, QuantId = 1, DcTable = 1, AcTable = 1 }
+        };
+    }
+
+    private static ComponentCoefficients[] BuildCoefficients(
+        byte[] rgba,
+        int width,
+        int height,
+        int stride,
+        int rowOffset,
+        int rowStride,
+        ComponentSpec[] components,
+        int maxH,
+        int maxV,
+        int[] qY,
+        int[] qC) {
+        var mcuWidth = maxH * 8;
+        var mcuHeight = maxV * 8;
+        var mcuCols = (width + mcuWidth - 1) / mcuWidth;
+        var mcuRows = (height + mcuHeight - 1) / mcuHeight;
+
+        var result = new ComponentCoefficients[components.Length];
+        for (var i = 0; i < components.Length; i++) {
+            var comp = components[i];
+            var blocksPerRow = mcuCols * comp.H;
+            var blocksPerCol = mcuRows * comp.V;
+            result[i] = new ComponentCoefficients(comp, blocksPerRow, blocksPerCol, new int[blocksPerRow * blocksPerCol * 64]);
+        }
+
+        var yBlock = new int[64];
+        var cbBlock = new int[64];
+        var crBlock = new int[64];
+        var temp = new int[64];
+
+        ComponentCoefficients? yCoeffs = null;
+        ComponentCoefficients? cbCoeffs = null;
+        ComponentCoefficients? crCoeffs = null;
+
+        for (var i = 0; i < result.Length; i++) {
+            var comp = result[i];
+            if (comp.Spec.Id == 1) yCoeffs = comp;
+            else if (comp.Spec.Id == 2) cbCoeffs = comp;
+            else if (comp.Spec.Id == 3) crCoeffs = comp;
+        }
+
+        var hasChroma = cbCoeffs.HasValue && crCoeffs.HasValue;
+
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuCols; mx++) {
+                if (yCoeffs.HasValue) {
+                    var yc = yCoeffs.Value;
+                    for (var vy = 0; vy < yc.Spec.V; vy++) {
+                        for (var vx = 0; vx < yc.Spec.H; vx++) {
+                            var blockX = mx * yc.Spec.H + vx;
+                            var blockY = my * yc.Spec.V + vy;
+                            var x0 = blockX * 8;
+                            var y0 = blockY * 8;
+                            LoadBlockLuma(rgba, stride, rowOffset, rowStride, width, height, x0, y0, yBlock);
+                            ForwardDctQuantize(yBlock, qY, temp);
+                            var offset = (blockY * yc.BlocksPerRow + blockX) * 64;
+                            Array.Copy(temp, 0, yc.Data, offset, 64);
+                        }
+                    }
+                }
+
+                if (hasChroma) {
+                    var cb = cbCoeffs!.Value;
+                    var cr = crCoeffs!.Value;
+                    var sampleW = maxH / cb.Spec.H;
+                    var sampleH = maxV / cb.Spec.V;
+                    var blockX = mx * cb.Spec.H;
+                    var blockY = my * cb.Spec.V;
+                    var x0 = blockX * 8 * sampleW;
+                    var y0 = blockY * 8 * sampleH;
+
+                    LoadBlockChroma(rgba, stride, rowOffset, rowStride, width, height, x0, y0, sampleW, sampleH, cbBlock, crBlock);
+
+                    ForwardDctQuantize(cbBlock, qC, temp);
+                    var offsetCb = (blockY * cb.BlocksPerRow + blockX) * 64;
+                    Array.Copy(temp, 0, cb.Data, offsetCb, 64);
+
+                    ForwardDctQuantize(crBlock, qC, temp);
+                    var offsetCr = (blockY * cr.BlocksPerRow + blockX) * 64;
+                    Array.Copy(temp, 0, cr.Data, offsetCr, 64);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static HuffmanTableSet BuildHuffmanTables(ComponentCoefficients[] coeffs, ComponentSpec[] components, bool optimize) {
+        if (!optimize) {
+            var dcLuma = new HuffmanSpec(DcLumaBits, DcValues, DcLumaTable);
+            var acLuma = new HuffmanSpec(AcLumaBits, AcLumaValues, AcLumaTable);
+            var dcChroma = new HuffmanSpec(DcChromaBits, DcValues, DcChromaTable);
+            var acChroma = new HuffmanSpec(AcChromaBits, AcChromaValues, AcChromaTable);
+            return new HuffmanTableSet(dcLuma, acLuma, dcChroma, acChroma);
+        }
+
+        var freqDcLuma = new int[256];
+        var freqAcLuma = new int[256];
+        var freqDcChroma = new int[256];
+        var freqAcChroma = new int[256];
+
+        AccumulateFrequencies(coeffs, components, freqDcLuma, freqAcLuma, freqDcChroma, freqAcChroma);
+
+        var dcL = BuildOptimizedHuffman(freqDcLuma);
+        var acL = BuildOptimizedHuffman(freqAcLuma);
+        var dcC = BuildOptimizedHuffman(freqDcChroma);
+        var acC = BuildOptimizedHuffman(freqAcChroma);
+
+        return new HuffmanTableSet(dcL, acL, dcC, acC);
     }
 
     private static void EncodeImage(
@@ -287,6 +530,67 @@ internal static class JpegWriter {
         }
     }
 
+    private static void LoadBlockChroma(
+        byte[] rgba,
+        int stride,
+        int rowOffset,
+        int rowStride,
+        int width,
+        int height,
+        int bx,
+        int by,
+        int sampleW,
+        int sampleH,
+        int[] cbBlock,
+        int[] crBlock) {
+        var i = 0;
+        var count = sampleW * sampleH;
+        for (var y = 0; y < 8; y++) {
+            var baseY = by + y * sampleH;
+            for (var x = 0; x < 8; x++) {
+                var baseX = bx + x * sampleW;
+                var sumR = 0;
+                var sumG = 0;
+                var sumB = 0;
+
+                for (var sy = 0; sy < sampleH; sy++) {
+                    var py = baseY + sy;
+                    if (py >= height) py = height - 1;
+                    var row = py * rowStride + rowOffset;
+                    for (var sx = 0; sx < sampleW; sx++) {
+                        var px = baseX + sx;
+                        if (px >= width) px = width - 1;
+                        var p = row + px * 4;
+                        var r = rgba[p + 0];
+                        var g = rgba[p + 1];
+                        var b = rgba[p + 2];
+                        var a = rgba[p + 3];
+                        if (a != 255) {
+                            var inv = 255 - a;
+                            r = (byte)((r * a + 255 * inv + 127) / 255);
+                            g = (byte)((g * a + 255 * inv + 127) / 255);
+                            b = (byte)((b * a + 255 * inv + 127) / 255);
+                        }
+                        sumR += r;
+                        sumG += g;
+                        sumB += b;
+                    }
+                }
+
+                var rAvg = (sumR + count / 2) / count;
+                var gAvg = (sumG + count / 2) / count;
+                var bAvg = (sumB + count / 2) / count;
+
+                var cb = ((-43 * rAvg - 85 * gAvg + 128 * bAvg + 128) >> 8) + 128;
+                var cr = ((128 * rAvg - 107 * gAvg - 21 * bAvg + 128) >> 8) + 128;
+
+                cbBlock[i] = cb - 128;
+                crBlock[i] = cr - 128;
+                i++;
+            }
+        }
+    }
+
     private static void EncodeBlock(
         BitWriter bw,
         int[] input,
@@ -309,6 +613,62 @@ internal static class JpegWriter {
         var zeroRun = 0;
         for (var i = 1; i < 64; i++) {
             var v = temp[ZigZag[i]];
+            if (v == 0) {
+                zeroRun++;
+                continue;
+            }
+
+            while (zeroRun >= 16) {
+                bw.WriteBits(acTable.Codes[0xF0], acTable.Sizes[0xF0]);
+                zeroRun -= 16;
+            }
+
+            var cat = BitCount(v);
+            var symbol = (zeroRun << 4) | cat;
+            bw.WriteBits(acTable.Codes[symbol], acTable.Sizes[symbol]);
+            bw.WriteBits(EncodeValue(v, cat), cat);
+            zeroRun = 0;
+        }
+
+        if (zeroRun > 0) {
+            bw.WriteBits(acTable.Codes[0x00], acTable.Sizes[0x00]);
+        }
+    }
+
+    private static void EncodeBlockFromQuantized(
+        BitWriter bw,
+        int[] coeffs,
+        int offset,
+        HuffmanTable dcTable,
+        HuffmanTable acTable,
+        ref int prevDc) {
+        var dc = coeffs[offset];
+        var diff = dc - prevDc;
+        prevDc = dc;
+        var dcCat = BitCount(diff);
+        bw.WriteBits(dcTable.Codes[dcCat], dcTable.Sizes[dcCat]);
+        if (dcCat > 0) {
+            bw.WriteBits(EncodeValue(diff, dcCat), dcCat);
+        }
+
+        EncodeAcFromQuantized(bw, coeffs, offset, acTable, 1, 63);
+    }
+
+    private static void EncodeDcFromQuantized(BitWriter bw, int[] coeffs, int offset, HuffmanTable dcTable, ref int prevDc) {
+        var dc = coeffs[offset];
+        var diff = dc - prevDc;
+        prevDc = dc;
+        var dcCat = BitCount(diff);
+        bw.WriteBits(dcTable.Codes[dcCat], dcTable.Sizes[dcCat]);
+        if (dcCat > 0) {
+            bw.WriteBits(EncodeValue(diff, dcCat), dcCat);
+        }
+    }
+
+    private static void EncodeAcFromQuantized(BitWriter bw, int[] coeffs, int offset, HuffmanTable acTable, int ss, int se) {
+        var zeroRun = 0;
+        for (var i = ss; i <= se; i++) {
+            var v = coeffs[offset + ZigZag[i]];
             if (v == 0) {
                 zeroRun++;
                 continue;
@@ -394,6 +754,80 @@ internal static class JpegWriter {
         s.WriteByte(0);
     }
 
+    private static readonly byte[] ExifPrefix = { (byte)'E', (byte)'x', (byte)'i', (byte)'f', 0, 0 };
+    private static readonly byte[] XmpPrefix = {
+        (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/',
+        (byte)'n', (byte)'s', (byte)'.', (byte)'a', (byte)'d', (byte)'o', (byte)'b', (byte)'e', (byte)'.',
+        (byte)'c', (byte)'o', (byte)'m', (byte)'/', (byte)'x', (byte)'a', (byte)'p', (byte)'/',
+        (byte)'1', (byte)'.', (byte)'0', (byte)'/', 0
+    };
+    private static readonly byte[] IccPrefix = {
+        (byte)'I', (byte)'C', (byte)'C', (byte)'_', (byte)'P', (byte)'R', (byte)'O', (byte)'F', (byte)'I', (byte)'L', (byte)'E', 0
+    };
+
+    private static void WriteMetadata(Stream s, JpegMetadata metadata) {
+        if (!metadata.HasData) return;
+
+        if (metadata.Exif is { Length: > 0 }) {
+            var payload = EnsurePrefix(metadata.Exif, ExifPrefix);
+            WriteAppSegment(s, 0xFFE1, payload);
+        }
+
+        if (metadata.Xmp is { Length: > 0 }) {
+            var payload = EnsurePrefix(metadata.Xmp, XmpPrefix);
+            WriteAppSegment(s, 0xFFE1, payload);
+        }
+
+        if (metadata.Icc is { Length: > 0 }) {
+            WriteIccSegments(s, metadata.Icc);
+        }
+    }
+
+    private static byte[] EnsurePrefix(byte[] data, byte[] prefix) {
+        if (StartsWith(data, prefix)) return data;
+        var combined = new byte[prefix.Length + data.Length];
+        Buffer.BlockCopy(prefix, 0, combined, 0, prefix.Length);
+        Buffer.BlockCopy(data, 0, combined, prefix.Length, data.Length);
+        return combined;
+    }
+
+    private static bool StartsWith(byte[] data, byte[] prefix) {
+        if (data.Length < prefix.Length) return false;
+        for (var i = 0; i < prefix.Length; i++) {
+            if (data[i] != prefix[i]) return false;
+        }
+        return true;
+    }
+
+    private static void WriteAppSegment(Stream s, int marker, byte[] payload) {
+        if (payload.Length > 0xFFFD) {
+            throw new ArgumentOutOfRangeException(nameof(payload), "APP segment payload too large.");
+        }
+        WriteMarker(s, marker);
+        WriteUInt16(s, (ushort)(payload.Length + 2));
+        s.Write(payload, 0, payload.Length);
+    }
+
+    private static void WriteIccSegments(Stream s, byte[] icc) {
+        const int maxPayload = 0xFFFD;
+        var headerSize = IccPrefix.Length + 2;
+        var maxData = maxPayload - headerSize;
+        var totalSegments = (icc.Length + maxData - 1) / maxData;
+        if (totalSegments <= 0) return;
+        var offset = 0;
+        for (var segment = 1; segment <= totalSegments; segment++) {
+            var remaining = icc.Length - offset;
+            var size = remaining > maxData ? maxData : remaining;
+            var payload = new byte[headerSize + size];
+            Buffer.BlockCopy(IccPrefix, 0, payload, 0, IccPrefix.Length);
+            payload[IccPrefix.Length] = (byte)segment;
+            payload[IccPrefix.Length + 1] = (byte)totalSegments;
+            Buffer.BlockCopy(icc, offset, payload, headerSize, size);
+            WriteAppSegment(s, 0xFFE2, payload);
+            offset += size;
+        }
+    }
+
     private static void WriteDqt(Stream s, int tableId, int[] table) {
         WriteMarker(s, 0xFFDB);
         WriteUInt16(s, 67);
@@ -403,34 +837,20 @@ internal static class JpegWriter {
         }
     }
 
-    private static void WriteSof0(Stream s, int width, int height) {
-        WriteMarker(s, 0xFFC0);
-        WriteUInt16(s, 17);
+    private static void WriteSof(Stream s, bool progressive, int width, int height, ComponentSpec[] components) {
+        WriteMarker(s, progressive ? 0xFFC2 : 0xFFC0);
+        var length = 8 + components.Length * 3;
+        WriteUInt16(s, (ushort)length);
         s.WriteByte(8);
         WriteUInt16(s, (ushort)height);
         WriteUInt16(s, (ushort)width);
-        s.WriteByte(3);
-        s.WriteByte(1);
-        s.WriteByte(0x11);
-        s.WriteByte(0);
-        s.WriteByte(2);
-        s.WriteByte(0x11);
-        s.WriteByte(1);
-        s.WriteByte(3);
-        s.WriteByte(0x11);
-        s.WriteByte(1);
-    }
-
-    private static void WriteSof0Gray(Stream s, int width, int height) {
-        WriteMarker(s, 0xFFC0);
-        WriteUInt16(s, 11);
-        s.WriteByte(8);
-        WriteUInt16(s, (ushort)height);
-        WriteUInt16(s, (ushort)width);
-        s.WriteByte(1);
-        s.WriteByte(1);
-        s.WriteByte(0x11);
-        s.WriteByte(0);
+        s.WriteByte((byte)components.Length);
+        for (var i = 0; i < components.Length; i++) {
+            var comp = components[i];
+            s.WriteByte(comp.Id);
+            s.WriteByte((byte)((comp.H << 4) | comp.V));
+            s.WriteByte(comp.QuantId);
+        }
     }
 
     private static void WriteDht(Stream s, int tableClass, int tableId, byte[] bits, byte[] values) {
@@ -441,30 +861,19 @@ internal static class JpegWriter {
         s.Write(values, 0, values.Length);
     }
 
-    private static void WriteSos(Stream s) {
+    private static void WriteSos(Stream s, ComponentSpec[] components, int[] componentIndices, byte ss, byte se, byte ah, byte al) {
         WriteMarker(s, 0xFFDA);
-        WriteUInt16(s, 12);
-        s.WriteByte(3);
-        s.WriteByte(1);
-        s.WriteByte(0x00);
-        s.WriteByte(2);
-        s.WriteByte(0x11);
-        s.WriteByte(3);
-        s.WriteByte(0x11);
-        s.WriteByte(0);
-        s.WriteByte(63);
-        s.WriteByte(0);
-    }
-
-    private static void WriteSosGray(Stream s) {
-        WriteMarker(s, 0xFFDA);
-        WriteUInt16(s, 8);
-        s.WriteByte(1);
-        s.WriteByte(1);
-        s.WriteByte(0x00);
-        s.WriteByte(0);
-        s.WriteByte(63);
-        s.WriteByte(0);
+        var count = componentIndices.Length;
+        WriteUInt16(s, (ushort)(6 + count * 2));
+        s.WriteByte((byte)count);
+        for (var i = 0; i < count; i++) {
+            var comp = components[componentIndices[i]];
+            s.WriteByte(comp.Id);
+            s.WriteByte((byte)((comp.DcTable << 4) | comp.AcTable));
+        }
+        s.WriteByte(ss);
+        s.WriteByte(se);
+        s.WriteByte((byte)((ah << 4) | al));
     }
 
     private static bool IsGrayscale(byte[] rgba, int width, int height, int stride, int rowOffset, int rowStride) {
@@ -486,6 +895,305 @@ internal static class JpegWriter {
             }
         }
         return true;
+    }
+
+    private static void EncodeBaseline(
+        Stream stream,
+        ComponentSpec[] components,
+        ComponentCoefficients[] coeffs,
+        HuffmanTableSet tables) {
+        var mcuCols = coeffs[0].BlocksPerRow / components[0].H;
+        var mcuRows = coeffs[0].BlocksPerCol / components[0].V;
+
+        var allComponents = new int[components.Length];
+        for (var i = 0; i < allComponents.Length; i++) allComponents[i] = i;
+        WriteSos(stream, components, allComponents, 0, 63, 0, 0);
+
+        var bw = new BitWriter(stream);
+        var prevDc = new int[components.Length];
+
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuCols; mx++) {
+                for (var ci = 0; ci < components.Length; ci++) {
+                    var comp = components[ci];
+                    var compCoeffs = coeffs[ci];
+                    for (var vy = 0; vy < comp.V; vy++) {
+                        for (var vx = 0; vx < comp.H; vx++) {
+                            var blockX = mx * comp.H + vx;
+                            var blockY = my * comp.V + vy;
+                            var offset = (blockY * compCoeffs.BlocksPerRow + blockX) * 64;
+                            var dcTable = ci == 0 ? tables.DcLuma.Table : tables.DcChroma.Table;
+                            var acTable = ci == 0 ? tables.AcLuma.Table : tables.AcChroma.Table;
+                            EncodeBlockFromQuantized(bw, compCoeffs.Data, offset, dcTable, acTable, ref prevDc[ci]);
+                        }
+                    }
+                }
+            }
+        }
+        bw.Flush();
+    }
+
+    private static void EncodeProgressive(
+        Stream stream,
+        ComponentSpec[] components,
+        ComponentCoefficients[] coeffs,
+        HuffmanTableSet tables) {
+        var mcuCols = coeffs[0].BlocksPerRow / components[0].H;
+        var mcuRows = coeffs[0].BlocksPerCol / components[0].V;
+
+        var allComponents = new int[components.Length];
+        for (var i = 0; i < allComponents.Length; i++) allComponents[i] = i;
+
+        // DC scan
+        WriteSos(stream, components, allComponents, 0, 0, 0, 0);
+        var bw = new BitWriter(stream);
+        var prevDc = new int[components.Length];
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuCols; mx++) {
+                for (var ci = 0; ci < components.Length; ci++) {
+                    var comp = components[ci];
+                    var compCoeffs = coeffs[ci];
+                    for (var vy = 0; vy < comp.V; vy++) {
+                        for (var vx = 0; vx < comp.H; vx++) {
+                            var blockX = mx * comp.H + vx;
+                            var blockY = my * comp.V + vy;
+                            var offset = (blockY * compCoeffs.BlocksPerRow + blockX) * 64;
+                            var dcTable = ci == 0 ? tables.DcLuma.Table : tables.DcChroma.Table;
+                            EncodeDcFromQuantized(bw, compCoeffs.Data, offset, dcTable, ref prevDc[ci]);
+                        }
+                    }
+                }
+            }
+        }
+        bw.Flush();
+
+        // AC scan
+        WriteSos(stream, components, allComponents, 1, 63, 0, 0);
+        bw = new BitWriter(stream);
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuCols; mx++) {
+                for (var ci = 0; ci < components.Length; ci++) {
+                    var comp = components[ci];
+                    var compCoeffs = coeffs[ci];
+                    for (var vy = 0; vy < comp.V; vy++) {
+                        for (var vx = 0; vx < comp.H; vx++) {
+                            var blockX = mx * comp.H + vx;
+                            var blockY = my * comp.V + vy;
+                            var offset = (blockY * compCoeffs.BlocksPerRow + blockX) * 64;
+                            var acTable = ci == 0 ? tables.AcLuma.Table : tables.AcChroma.Table;
+                            EncodeAcFromQuantized(bw, compCoeffs.Data, offset, acTable, 1, 63);
+                        }
+                    }
+                }
+            }
+        }
+        bw.Flush();
+    }
+
+    private static void AccumulateFrequencies(
+        ComponentCoefficients[] coeffs,
+        ComponentSpec[] components,
+        int[] dcLuma,
+        int[] acLuma,
+        int[] dcChroma,
+        int[] acChroma) {
+        var mcuCols = coeffs[0].BlocksPerRow / components[0].H;
+        var mcuRows = coeffs[0].BlocksPerCol / components[0].V;
+        var prevDc = new int[components.Length];
+
+        for (var my = 0; my < mcuRows; my++) {
+            for (var mx = 0; mx < mcuCols; mx++) {
+                for (var ci = 0; ci < components.Length; ci++) {
+                    var comp = components[ci];
+                    var compCoeffs = coeffs[ci];
+                    for (var vy = 0; vy < comp.V; vy++) {
+                        for (var vx = 0; vx < comp.H; vx++) {
+                            var blockX = mx * comp.H + vx;
+                            var blockY = my * comp.V + vy;
+                            var offset = (blockY * compCoeffs.BlocksPerRow + blockX) * 64;
+                            var dc = compCoeffs.Data[offset];
+                            var diff = dc - prevDc[ci];
+                            prevDc[ci] = dc;
+                            var dcCat = BitCount(diff);
+                            if (ci == 0) dcLuma[dcCat]++; else dcChroma[dcCat]++;
+
+                            AccumulateAcFrequencies(compCoeffs.Data, offset, ci == 0 ? acLuma : acChroma);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void AccumulateAcFrequencies(int[] coeffs, int offset, int[] freq) {
+        var zeroRun = 0;
+        for (var i = 1; i < 64; i++) {
+            var v = coeffs[offset + ZigZag[i]];
+            if (v == 0) {
+                zeroRun++;
+                continue;
+            }
+
+            while (zeroRun >= 16) {
+                freq[0xF0]++;
+                zeroRun -= 16;
+            }
+
+            var cat = BitCount(v);
+            var symbol = (zeroRun << 4) | cat;
+            freq[symbol]++;
+            zeroRun = 0;
+        }
+
+        if (zeroRun > 0) {
+            freq[0x00]++;
+        }
+    }
+
+    private static HuffmanSpec BuildOptimizedHuffman(int[] frequencies) {
+        var symbols = new int[256];
+        var counts = 0;
+        for (var i = 0; i < frequencies.Length; i++) {
+            if (frequencies[i] > 0) {
+                symbols[counts++] = i;
+            }
+        }
+        if (counts == 0) {
+            symbols[counts++] = 0;
+            frequencies[0] = 1;
+        }
+
+        var lengths = BuildCodeLengths(frequencies);
+        var bits = new int[33];
+        for (var i = 0; i < lengths.Length; i++) {
+            var len = lengths[i];
+            if (len > 0) bits[len]++;
+        }
+
+        LimitCodeLengths(bits, 16);
+
+        var total = 0;
+        for (var i = 1; i <= 16; i++) total += bits[i];
+        if (total < counts) {
+            bits[16] += counts - total;
+        } else if (total > counts) {
+            var extra = total - counts;
+            for (var i = 16; i >= 1 && extra > 0; i--) {
+                var take = Math.Min(extra, bits[i]);
+                bits[i] -= take;
+                extra -= take;
+            }
+        }
+
+        var ordered = new int[counts];
+        Array.Copy(symbols, ordered, counts);
+        Array.Sort(ordered, (a, b) => {
+            var fa = frequencies[a];
+            var fb = frequencies[b];
+            var diff = fb.CompareTo(fa);
+            return diff != 0 ? diff : a.CompareTo(b);
+        });
+
+        var values = new byte[counts];
+        var sizes = new byte[256];
+        var index = 0;
+        var valueIndex = 0;
+        for (var len = 1; len <= 16; len++) {
+            var count = bits[len];
+            for (var i = 0; i < count && index < ordered.Length; i++) {
+                var symbol = ordered[index++];
+                sizes[symbol] = (byte)len;
+                values[valueIndex++] = (byte)symbol;
+            }
+        }
+
+        var bitsOut = new byte[16];
+        for (var i = 1; i <= 16; i++) bitsOut[i - 1] = (byte)bits[i];
+
+        var table = BuildHuffmanTable(bitsOut, values);
+        return new HuffmanSpec(bitsOut, values, table);
+    }
+
+    private static int[] BuildCodeLengths(int[] frequencies) {
+        var maxNodes = frequencies.Length * 2;
+        var freq = new int[maxNodes];
+        var parent = new int[maxNodes];
+        var symbol = new int[maxNodes];
+        var nodeCount = 0;
+        var symbolNodes = new int[frequencies.Length];
+        for (var i = 0; i < symbolNodes.Length; i++) {
+            symbolNodes[i] = -1;
+        }
+
+        for (var i = 0; i < frequencies.Length; i++) {
+            if (frequencies[i] <= 0) continue;
+            freq[nodeCount] = frequencies[i];
+            parent[nodeCount] = -1;
+            symbol[nodeCount] = i;
+            symbolNodes[i] = nodeCount;
+            nodeCount++;
+        }
+
+        var lengthsOut = new int[frequencies.Length];
+        if (nodeCount == 1) {
+            lengthsOut[symbol[0]] = 1;
+            return lengthsOut;
+        }
+
+        var nodesTotal = nodeCount;
+        while (true) {
+            var least1 = -1;
+            var least2 = -1;
+            for (var i = 0; i < nodesTotal; i++) {
+                if (parent[i] != -1) continue;
+                if (least1 < 0 || freq[i] < freq[least1]) {
+                    least2 = least1;
+                    least1 = i;
+                } else if (least2 < 0 || freq[i] < freq[least2]) {
+                    least2 = i;
+                }
+            }
+
+            if (least2 < 0) break;
+
+            freq[nodesTotal] = freq[least1] + freq[least2];
+            parent[least1] = nodesTotal;
+            parent[least2] = nodesTotal;
+            parent[nodesTotal] = -1;
+            symbol[nodesTotal] = -1;
+            nodesTotal++;
+        }
+
+        for (var i = 0; i < frequencies.Length; i++) {
+            var node = symbolNodes[i];
+            if (node < 0) continue;
+            var depth = 0;
+            while (parent[node] != -1) {
+                depth++;
+                node = parent[node];
+            }
+            lengthsOut[i] = depth == 0 ? 1 : depth;
+        }
+
+        return lengthsOut;
+    }
+
+    private static void LimitCodeLengths(int[] bits, int maxLen) {
+        for (var i = bits.Length - 1; i > maxLen; i--) {
+            while (bits[i] > 0) {
+                var j = i - 1;
+                while (j > 0 && bits[j] == 0) j--;
+                if (j == 0) break;
+                if (bits[i] < 2) {
+                    bits[i] = 0;
+                    break;
+                }
+                bits[i] -= 2;
+                bits[i - 1] += 1;
+                bits[j] -= 1;
+                bits[j + 1] += 2;
+            }
+        }
     }
 
     private static HuffmanTable BuildHuffmanTable(byte[] bits, byte[] values) {

--- a/CodeGlyphX/Rendering/Jpeg/MatrixJpegRenderer.cs
+++ b/CodeGlyphX/Rendering/Jpeg/MatrixJpegRenderer.cs
@@ -6,7 +6,7 @@ using CodeGlyphX.Rendering.Png;
 namespace CodeGlyphX.Rendering.Jpeg;
 
 /// <summary>
-/// Renders generic 2D matrices to a JPEG image (baseline, 4:4:4).
+/// Renders generic 2D matrices to a JPEG image.
 /// </summary>
 public static class MatrixJpegRenderer {
     /// <summary>
@@ -15,6 +15,14 @@ public static class MatrixJpegRenderer {
     public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts, int quality = 85) {
         var scanlines = MatrixPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
         return JpegWriter.WriteRgbaScanlines(width, height, scanlines, stride, quality);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a JPEG byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts, JpegEncodeOptions options) {
+        var scanlines = MatrixPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
+        return JpegWriter.WriteRgbaScanlines(width, height, scanlines, stride, options);
     }
 
     /// <summary>
@@ -27,6 +35,18 @@ public static class MatrixJpegRenderer {
     public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream, int quality = 85) {
         var scanlines = MatrixPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
         JpegWriter.WriteRgbaScanlines(stream, width, height, scanlines, stride, quality);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a JPEG stream.
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="stream">Target stream.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream, JpegEncodeOptions options) {
+        var scanlines = MatrixPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
+        JpegWriter.WriteRgbaScanlines(stream, width, height, scanlines, stride, options);
     }
 
     /// <summary>
@@ -43,6 +63,19 @@ public static class MatrixJpegRenderer {
     }
 
     /// <summary>
+    /// Renders the matrix to a JPEG file.
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path, JpegEncodeOptions options) {
+        var jpeg = Render(modules, opts, options);
+        return RenderIO.WriteBinary(path, jpeg);
+    }
+
+    /// <summary>
     /// Renders the matrix to a JPEG file under the specified directory.
     /// </summary>
     /// <param name="modules">Matrix modules.</param>
@@ -53,6 +86,20 @@ public static class MatrixJpegRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName, int quality = 85) {
         var jpeg = Render(modules, opts, quality);
+        return RenderIO.WriteBinary(directory, fileName, jpeg);
+    }
+
+    /// <summary>
+    /// Renders the matrix to a JPEG file under the specified directory.
+    /// </summary>
+    /// <param name="modules">Matrix modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="directory">Output directory.</param>
+    /// <param name="fileName">Output file name.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName, JpegEncodeOptions options) {
+        var jpeg = Render(modules, opts, options);
         return RenderIO.WriteBinary(directory, fileName, jpeg);
     }
 

--- a/CodeGlyphX/Rendering/Jpeg/QrJpegRenderer.cs
+++ b/CodeGlyphX/Rendering/Jpeg/QrJpegRenderer.cs
@@ -6,7 +6,7 @@ using CodeGlyphX.Rendering.Png;
 namespace CodeGlyphX.Rendering.Jpeg;
 
 /// <summary>
-/// Renders QR modules to a JPEG image (baseline, 4:4:4).
+/// Renders QR modules to a JPEG image.
 /// </summary>
 public static class QrJpegRenderer {
     /// <summary>
@@ -15,6 +15,14 @@ public static class QrJpegRenderer {
     public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts, int quality = 85) {
         var scanlines = QrPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
         return JpegWriter.WriteRgbaScanlines(width, height, scanlines, stride, quality);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a JPEG byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts, JpegEncodeOptions options) {
+        var scanlines = QrPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
+        return JpegWriter.WriteRgbaScanlines(width, height, scanlines, stride, options);
     }
 
     /// <summary>
@@ -27,6 +35,18 @@ public static class QrJpegRenderer {
     public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, int quality = 85) {
         var scanlines = QrPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
         JpegWriter.WriteRgbaScanlines(stream, width, height, scanlines, stride, quality);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a JPEG stream.
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="stream">Target stream.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream, JpegEncodeOptions options) {
+        var scanlines = QrPngRenderer.RenderScanlines(modules, opts, out var width, out var height, out var stride);
+        JpegWriter.WriteRgbaScanlines(stream, width, height, scanlines, stride, options);
     }
 
     /// <summary>
@@ -43,6 +63,19 @@ public static class QrJpegRenderer {
     }
 
     /// <summary>
+    /// Renders the QR module matrix to a JPEG file.
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="path">Output file path.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path, JpegEncodeOptions options) {
+        var jpeg = Render(modules, opts, options);
+        return RenderIO.WriteBinary(path, jpeg);
+    }
+
+    /// <summary>
     /// Renders the QR module matrix to a JPEG file under the specified directory.
     /// </summary>
     /// <param name="modules">QR modules.</param>
@@ -53,6 +86,20 @@ public static class QrJpegRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName, int quality = 85) {
         var jpeg = Render(modules, opts, quality);
+        return RenderIO.WriteBinary(directory, fileName, jpeg);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a JPEG file under the specified directory.
+    /// </summary>
+    /// <param name="modules">QR modules.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="directory">Output directory.</param>
+    /// <param name="fileName">Output file name.</param>
+    /// <param name="options">JPEG encoding options.</param>
+    /// <returns>The output file path.</returns>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName, JpegEncodeOptions options) {
+        var jpeg = Render(modules, opts, options);
         return RenderIO.WriteBinary(directory, fileName, jpeg);
     }
 

--- a/README.md
+++ b/README.md
@@ -646,7 +646,18 @@ if (AztecCode.TryDecodeImage(File.ReadAllBytes("aztec.png"), out var text))
 using CodeGlyphX;
 
 var opts = ImageDecodeOptions.Screen(maxMilliseconds: 300, maxDimension: 1200);
+opts.WithJpegOptions(highQualityChroma: true, allowTruncated: true);
 Barcode.TryDecodePng(File.ReadAllBytes("barcode.png"), BarcodeType.Code128, opts, out var barcode);
+```
+
+```csharp
+using CodeGlyphX;
+
+var decode = new CodeGlyphDecodeOptions()
+    .WithJpegOptions(highQualityChroma: true)
+    .WithImageBudget(maxMilliseconds: 250, maxDimension: 1000);
+
+CodeGlyph.TryDecodeImage(File.ReadAllBytes("code.jpg"), out var symbol, decode);
 ```
 
 ## WPF controls

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ using CodeGlyphX;
 
 var opts = ImageDecodeOptions.Screen(maxMilliseconds: 300, maxDimension: 1200);
 opts.WithJpegOptions(highQualityChroma: true, allowTruncated: true);
-Barcode.TryDecodePng(File.ReadAllBytes("barcode.png"), BarcodeType.Code128, opts, out var barcode);
+Barcode.TryDecodeImage(File.ReadAllBytes("barcode.jpg"), BarcodeType.Code128, opts, out var barcode);
 ```
 
 ```csharp


### PR DESCRIPTION
## Summary
- Add managed JPEG encode/decode options (subsampling, progressive, optimized Huffman, metadata) and decode controls (HQ chroma, truncated handling).
- Wire JPEG options through render/decode APIs and builders, plus composite decode overloads.
- Add docs/examples and refresh API XML for website.
- Restore Benchmarks build (missing using + local var shadow).

## Testing
- `dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release --filter FullyQualifiedName~Jpeg`
- `dotnet build CodeGlyphX/CodeGlyphX.csproj -c Release -f net10.0`
- `dotnet test CodeGlyphX.sln -c Release` (Passed, 4 skipped)