### PR TITLE
feat: expand no-deps format support

### DIFF
--- a/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
@@ -2,6 +2,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX.Benchmarks;
 

--- a/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodePackRunner.cs
@@ -261,7 +261,7 @@ internal static class QrDecodePackRunner {
         for (var run = 1; run < targetRuns; run++) {
             var res = DecodeOnce(engine, data, scenario.Options, scenario.ExpectedTexts);
             times.Add(res.ElapsedMilliseconds);
-            if (res.Info is { } info) infos.Add(info);
+            if (res.Info is { } infoEntry) infos.Add(infoEntry);
             if (res.Decoded) decodeSuccess++;
             if (res.ExpectedMatched) expectedMatch++;
             decodedCountSum += res.DecodedCount;

--- a/CodeGlyphX.Tests/TiffPlanarDecodeTests.cs
+++ b/CodeGlyphX.Tests/TiffPlanarDecodeTests.cs
@@ -76,17 +76,26 @@ public sealed class TiffPlanarDecodeTests {
 
         WriteU16(data, headerSize, entryCount);
         var entryBase = headerSize + 2;
-        var i = 0;
-        WriteEntry(data, entryBase + i++ * 12, tag: 256, type: 4, count: 1, value: 1); // width
-        WriteEntry(data, entryBase + i++ * 12, tag: 257, type: 4, count: 1, value: 1); // height
-        WriteEntry(data, entryBase + i++ * 12, tag: 258, type: 3, count: 3, value: bitsOffset); // bits per sample
-        WriteEntry(data, entryBase + i++ * 12, tag: 259, type: 3, count: 1, value: 1); // compression none
-        WriteEntry(data, entryBase + i++ * 12, tag: 262, type: 3, count: 1, value: 2); // photometric RGB
-        WriteEntry(data, entryBase + i++ * 12, tag: 273, type: 4, count: 3, value: stripOffsetsOffset); // strip offsets
-        WriteEntry(data, entryBase + i++ * 12, tag: 277, type: 3, count: 1, value: 3); // samples per pixel
-        WriteEntry(data, entryBase + i++ * 12, tag: 278, type: 4, count: 1, value: 1); // rows per strip
-        WriteEntry(data, entryBase + i++ * 12, tag: 279, type: 4, count: 3, value: stripByteCountsOffset); // strip byte counts
-        WriteEntry(data, entryBase + i++ * 12, tag: 284, type: 3, count: 1, value: 2); // planar configuration separate
+        var entryOffset = entryBase;
+        WriteEntry(data, entryOffset, tag: 256, type: 4, count: 1, value: 1); // width
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 257, type: 4, count: 1, value: 1); // height
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 258, type: 3, count: 3, value: bitsOffset); // bits per sample
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 259, type: 3, count: 1, value: 1); // compression none
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 262, type: 3, count: 1, value: 2); // photometric RGB
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 273, type: 4, count: 3, value: stripOffsetsOffset); // strip offsets
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 277, type: 3, count: 1, value: 3); // samples per pixel
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 278, type: 4, count: 1, value: 1); // rows per strip
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 279, type: 4, count: 3, value: stripByteCountsOffset); // strip byte counts
+        entryOffset += 12;
+        WriteEntry(data, entryOffset, tag: 284, type: 3, count: 1, value: 2); // planar configuration separate
 
         WriteU32(data, entryBase + entryCount * 12, 0); // next IFD
 

--- a/CodeGlyphX/AztecCode.Render.cs
+++ b/CodeGlyphX/AztecCode.Render.cs
@@ -57,13 +57,7 @@ public static partial class AztecCode {
                 return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
             case OutputFormat.Webp: {
                 var quality = renderOptions?.WebpQuality ?? 100;
-                var extrasFrames = extras?.WebpFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var webp = durations is not null
-                        ? MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.WebpAnimationOptions ?? default, quality)
-                        : MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.WebpAnimationOptions ?? default, quality);
+                if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {
                     return RenderedOutput.FromBinary(format, webp);
                 }
                 return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
@@ -71,13 +65,7 @@ public static partial class AztecCode {
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
             case OutputFormat.Gif: {
-                var extrasFrames = extras?.GifFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var gif = durations is not null
-                        ? MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.GifAnimationOptions ?? default)
-                        : MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.GifAnimationOptions ?? default);
+                if (RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)) {
                     return RenderedOutput.FromBinary(format, gif);
                 }
                 return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));

--- a/CodeGlyphX/Barcode.Render.cs
+++ b/CodeGlyphX/Barcode.Render.cs
@@ -59,13 +59,7 @@ public static partial class Barcode {
                 return RenderedOutput.FromBinary(format, BarcodeJpegRenderer.Render(barcode, opts, options?.JpegQuality ?? 90));
             case OutputFormat.Webp: {
                 var quality = options?.WebpQuality ?? 100;
-                var extrasFrames = extras?.BarcodeWebpFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var webp = durations is not null
-                        ? BarcodeWebpRenderer.RenderAnimation(extrasFrames, opts, durations, extras?.WebpAnimationOptions ?? default, quality)
-                        : BarcodeWebpRenderer.RenderAnimation(extrasFrames, opts, duration, extras?.WebpAnimationOptions ?? default, quality);
+                if (RenderAnimationHelpers.TryRenderBarcodeWebp(extras, opts, quality, out var webp)) {
                     return RenderedOutput.FromBinary(format, webp);
                 }
                 return RenderedOutput.FromBinary(format, BarcodeWebpRenderer.Render(barcode, opts, quality));
@@ -73,13 +67,7 @@ public static partial class Barcode {
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, BarcodeBmpRenderer.Render(barcode, opts));
             case OutputFormat.Gif: {
-                var extrasFrames = extras?.BarcodeGifFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var gif = durations is not null
-                        ? BarcodeGifRenderer.RenderAnimation(extrasFrames, opts, durations, extras?.GifAnimationOptions ?? default)
-                        : BarcodeGifRenderer.RenderAnimation(extrasFrames, opts, duration, extras?.GifAnimationOptions ?? default);
+                if (RenderAnimationHelpers.TryRenderBarcodeGif(extras, opts, out var gif)) {
                     return RenderedOutput.FromBinary(format, gif);
                 }
                 return RenderedOutput.FromBinary(format, BarcodeGifRenderer.Render(barcode, opts));

--- a/CodeGlyphX/CodeGlyph.IO.cs
+++ b/CodeGlyphX/CodeGlyph.IO.cs
@@ -431,7 +431,7 @@ public static partial class CodeGlyph {
     /// </summary>
     public static bool TryDecodeImage(byte[] image, out CodeGlyphDecoded decoded, CodeGlyphDecodeOptions? options) {
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
         return TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -441,7 +441,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeImage(byte[] image, out CodeGlyphDecoded decoded, out CodeGlyphDecodeDiagnostics diagnostics, CodeGlyphDecodeOptions? options) {
         diagnostics = new CodeGlyphDecodeDiagnostics();
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) {
             decoded = null!;
             SetFailure(diagnostics, DecodeFailureReason.UnsupportedFormat, "Unsupported image format.");
             return false;
@@ -484,7 +484,7 @@ public static partial class CodeGlyph {
             if (token.IsCancellationRequested) {
                 return new DecodeResult<CodeGlyphDecoded>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) {
                 var imageFailure = DecodeResultHelpers.FailureForImageRead(image, formatKnown, token);
                 return new DecodeResult<CodeGlyphDecoded>(imageFailure, info, stopwatch.Elapsed);
             }
@@ -515,7 +515,7 @@ public static partial class CodeGlyph {
     /// </summary>
     public static bool TryDecodeAllImage(byte[] image, out CodeGlyphDecoded[] decoded, CodeGlyphDecodeOptions? options) {
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
         return TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -525,7 +525,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeImage(Stream stream, out CodeGlyphDecoded decoded, CodeGlyphDecodeOptions? options) {
         if (stream is null) throw new ArgumentNullException(nameof(stream));
         var data = RenderIO.ReadBinary(stream);
-        if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { decoded = null!; return false; }
+        if (!ImageReader.TryDecodeRgba32(data, options?.Image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
         return TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -535,7 +535,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeAllImage(Stream stream, out CodeGlyphDecoded[] decoded, CodeGlyphDecodeOptions? options) {
         if (stream is null) throw new ArgumentNullException(nameof(stream));
         var data = RenderIO.ReadBinary(stream);
-        if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
+        if (!ImageReader.TryDecodeRgba32(data, options?.Image, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
         return TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 

--- a/CodeGlyphX/DataMatrixCode.Render.cs
+++ b/CodeGlyphX/DataMatrixCode.Render.cs
@@ -75,13 +75,7 @@ public static partial class DataMatrixCode {
                 return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85));
             case OutputFormat.Webp: {
                 var quality = options?.WebpQuality ?? 100;
-                var extrasFrames = extras?.WebpFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var webp = durations is not null
-                        ? MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.WebpAnimationOptions ?? default, quality)
-                        : MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.WebpAnimationOptions ?? default, quality);
+                if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {
                     return RenderedOutput.FromBinary(format, webp);
                 }
                 return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
@@ -89,13 +83,7 @@ public static partial class DataMatrixCode {
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
             case OutputFormat.Gif: {
-                var extrasFrames = extras?.GifFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var gif = durations is not null
-                        ? MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.GifAnimationOptions ?? default)
-                        : MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.GifAnimationOptions ?? default);
+                if (RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)) {
                     return RenderedOutput.FromBinary(format, gif);
                 }
                 return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));

--- a/CodeGlyphX/Pdf417Code.Render.cs
+++ b/CodeGlyphX/Pdf417Code.Render.cs
@@ -83,13 +83,7 @@ public static partial class Pdf417Code {
                 return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
             case OutputFormat.Webp: {
                 var quality = renderOptions?.WebpQuality ?? 100;
-                var extrasFrames = extras?.WebpFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var webp = durations is not null
-                        ? MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.WebpAnimationOptions ?? default, quality)
-                        : MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.WebpAnimationOptions ?? default, quality);
+                if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {
                     return RenderedOutput.FromBinary(format, webp);
                 }
                 return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
@@ -97,13 +91,7 @@ public static partial class Pdf417Code {
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
             case OutputFormat.Gif: {
-                var extrasFrames = extras?.GifFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var gif = durations is not null
-                        ? MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.GifAnimationOptions ?? default)
-                        : MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.GifAnimationOptions ?? default);
+                if (RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)) {
                     return RenderedOutput.FromBinary(format, gif);
                 }
                 return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));

--- a/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
+++ b/CodeGlyphX/Qr/QrPixelDecoder.Part1.cs
@@ -680,9 +680,9 @@ internal static partial class QrPixelDecoder {
                     : Math.Max(8, Math.Min(width, height) / 40);
                 var minTile = options?.AggressiveSampling == true ? 24 : 48;
 
-                QrPixelDecodeOptions ResolveTileOptions(int gridBudget) {
-                    var tileOptions = options!;
-                    if (options is null || tileBudgetMs <= 0) return tileOptions;
+                QrPixelDecodeOptions? ResolveTileOptions(int gridBudget) {
+                    if (options is null || tileBudgetMs <= 0) return options;
+                    var tileOptions = options;
                     var divisor = Math.Max(1, gridBudget * gridBudget);
                     var perTileBudget = Math.Max(200, tileBudgetMs / divisor);
                     if (perTileBudget > 0 && options.BudgetMilliseconds != perTileBudget) {

--- a/CodeGlyphX/QrEasy.Render.Generic.cs
+++ b/CodeGlyphX/QrEasy.Render.Generic.cs
@@ -73,13 +73,7 @@ public static partial class QrEasy {
             case OutputFormat.Webp: {
                 var render = BuildPngOptions(opts, qr);
                 var quality = opts.WebpQuality;
-                var extrasFrames = extras?.WebpFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var webp = durations is not null
-                        ? QrWebpRenderer.RenderAnimation(extrasFrames, render, durations, extras?.WebpAnimationOptions ?? default, quality)
-                        : QrWebpRenderer.RenderAnimation(extrasFrames, render, duration, extras?.WebpAnimationOptions ?? default, quality);
+                if (RenderAnimationHelpers.TryRenderQrWebp(extras, render, quality, out var webp)) {
                     return RenderedOutput.FromBinary(format, webp);
                 }
                 return RenderedOutput.FromBinary(format, QrWebpRenderer.Render(qr.Modules, render, quality));
@@ -95,13 +89,7 @@ public static partial class QrEasy {
             }
             case OutputFormat.Gif: {
                 var render = BuildPngOptions(opts, qr);
-                var extrasFrames = extras?.GifFrames;
-                if (extrasFrames is not null && extrasFrames.Length > 0) {
-                    var duration = extras?.AnimationDurationMs ?? 100;
-                    var durations = extras?.AnimationDurationsMs;
-                    var gif = durations is not null
-                        ? QrGifRenderer.RenderAnimation(extrasFrames, render, durations, extras?.GifAnimationOptions ?? default)
-                        : QrGifRenderer.RenderAnimation(extrasFrames, render, duration, extras?.GifAnimationOptions ?? default);
+                if (RenderAnimationHelpers.TryRenderQrGif(extras, render, out var gif)) {
                     return RenderedOutput.FromBinary(format, gif);
                 }
                 return RenderedOutput.FromBinary(format, QrGifRenderer.Render(qr.Modules, render));

--- a/CodeGlyphX/Rendering/Gif/GifWriter.cs
+++ b/CodeGlyphX/Rendering/Gif/GifWriter.cs
@@ -161,13 +161,10 @@ public static class GifWriter {
 
         for (var i = 0; i < optimizedFrames.Length; i++) {
             var frame = optimizedFrames[i];
-            PaletteInfo paletteInfo;
             var frameHasTransparency = FrameHasTransparency(frame);
-            if (useGlobal) {
-                paletteInfo = new PaletteInfo(globalPalette, globalMap, gctSize, gctBits, anyTransparency, globalTransparentIndex, globalQuantized, globalRLevels, globalGLevels, globalBLevels);
-            } else {
-                paletteInfo = BuildFramePalette(frame);
-            }
+            var paletteInfo = useGlobal
+                ? new PaletteInfo(globalPalette, globalMap, gctSize, gctBits, anyTransparency, globalTransparentIndex, globalQuantized, globalRLevels, globalGLevels, globalBLevels)
+                : BuildFramePalette(frame);
 
             var hasTransparency = useGlobal ? frameHasTransparency : paletteInfo.HasTransparency;
             var transparentIndex = paletteInfo.TransparentIndex;
@@ -305,7 +302,9 @@ public static class GifWriter {
             if (allowCrop && TryComputeDiffBounds(canvas, canvasWidth, canvasHeight, frame, disposal == GifDisposalMethod.RestoreBackground, bgR, bgG, bgB, bgA, out var minX, out var minY, out var maxX, out var maxY)) {
                 output = CropFrame(frame, minX, minY, maxX, maxY);
             } else if (allowCrop) {
-                output = new GifAnimationFrame(new byte[] { 0, 0, 0, 0 }, 1, 1, 4, frame.DurationMs, 0, 0, frame.DisposalMethod);
+                output = disposal == GifDisposalMethod.RestoreBackground
+                    ? frame
+                    : new GifAnimationFrame(new byte[] { 0, 0, 0, 0 }, 1, 1, 4, frame.DurationMs, 0, 0, frame.DisposalMethod);
             } else {
                 output = frame;
             }

--- a/CodeGlyphX/Rendering/Psd/PsdReader.cs
+++ b/CodeGlyphX/Rendering/Psd/PsdReader.cs
@@ -41,7 +41,7 @@ public static class PsdReader {
         var version = ReadU16BE(data, 4);
         if (version != 1 && version != 2) throw new FormatException("Unsupported PSD version.");
 
-        var channels = ReadU16BE(data, 12);
+        var channels = (int)ReadU16BE(data, 12);
         height = (int)ReadU32BE(data, 14);
         width = (int)ReadU32BE(data, 18);
         var depth = ReadU16BE(data, 22);

--- a/CodeGlyphX/Rendering/RenderAnimationHelpers.cs
+++ b/CodeGlyphX/Rendering/RenderAnimationHelpers.cs
@@ -1,0 +1,116 @@
+using System;
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
+
+namespace CodeGlyphX.Rendering;
+
+internal static class RenderAnimationHelpers {
+    internal static bool TryRenderMatrixWebp(RenderExtras? extras, MatrixPngRenderOptions pngOptions, int quality, out byte[] webp) {
+        var frames = extras?.WebpFrames;
+        if (frames is null || frames.Length == 0) {
+            webp = Array.Empty<byte>();
+            return false;
+        }
+
+        var durations = extras?.AnimationDurationsMs;
+        var animationOptions = extras?.WebpAnimationOptions ?? default;
+        if (durations is not null && durations.Length > 0) {
+            webp = MatrixWebpRenderer.RenderAnimation(frames, pngOptions, durations, animationOptions, quality);
+        } else {
+            var duration = extras?.AnimationDurationMs ?? 100;
+            webp = MatrixWebpRenderer.RenderAnimation(frames, pngOptions, duration, animationOptions, quality);
+        }
+        return true;
+    }
+
+    internal static bool TryRenderMatrixGif(RenderExtras? extras, MatrixPngRenderOptions pngOptions, out byte[] gif) {
+        var frames = extras?.GifFrames;
+        if (frames is null || frames.Length == 0) {
+            gif = Array.Empty<byte>();
+            return false;
+        }
+
+        var durations = extras?.AnimationDurationsMs;
+        var animationOptions = extras?.GifAnimationOptions ?? default;
+        if (durations is not null && durations.Length > 0) {
+            gif = MatrixGifRenderer.RenderAnimation(frames, pngOptions, durations, animationOptions);
+        } else {
+            var duration = extras?.AnimationDurationMs ?? 100;
+            gif = MatrixGifRenderer.RenderAnimation(frames, pngOptions, duration, animationOptions);
+        }
+        return true;
+    }
+
+    internal static bool TryRenderBarcodeWebp(RenderExtras? extras, BarcodePngRenderOptions pngOptions, int quality, out byte[] webp) {
+        var frames = extras?.BarcodeWebpFrames;
+        if (frames is null || frames.Length == 0) {
+            webp = Array.Empty<byte>();
+            return false;
+        }
+
+        var durations = extras?.AnimationDurationsMs;
+        var animationOptions = extras?.WebpAnimationOptions ?? default;
+        if (durations is not null && durations.Length > 0) {
+            webp = BarcodeWebpRenderer.RenderAnimation(frames, pngOptions, durations, animationOptions, quality);
+        } else {
+            var duration = extras?.AnimationDurationMs ?? 100;
+            webp = BarcodeWebpRenderer.RenderAnimation(frames, pngOptions, duration, animationOptions, quality);
+        }
+        return true;
+    }
+
+    internal static bool TryRenderBarcodeGif(RenderExtras? extras, BarcodePngRenderOptions pngOptions, out byte[] gif) {
+        var frames = extras?.BarcodeGifFrames;
+        if (frames is null || frames.Length == 0) {
+            gif = Array.Empty<byte>();
+            return false;
+        }
+
+        var durations = extras?.AnimationDurationsMs;
+        var animationOptions = extras?.GifAnimationOptions ?? default;
+        if (durations is not null && durations.Length > 0) {
+            gif = BarcodeGifRenderer.RenderAnimation(frames, pngOptions, durations, animationOptions);
+        } else {
+            var duration = extras?.AnimationDurationMs ?? 100;
+            gif = BarcodeGifRenderer.RenderAnimation(frames, pngOptions, duration, animationOptions);
+        }
+        return true;
+    }
+
+    internal static bool TryRenderQrWebp(RenderExtras? extras, QrPngRenderOptions pngOptions, int quality, out byte[] webp) {
+        var frames = extras?.WebpFrames;
+        if (frames is null || frames.Length == 0) {
+            webp = Array.Empty<byte>();
+            return false;
+        }
+
+        var durations = extras?.AnimationDurationsMs;
+        var animationOptions = extras?.WebpAnimationOptions ?? default;
+        if (durations is not null && durations.Length > 0) {
+            webp = QrWebpRenderer.RenderAnimation(frames, pngOptions, durations, animationOptions, quality);
+        } else {
+            var duration = extras?.AnimationDurationMs ?? 100;
+            webp = QrWebpRenderer.RenderAnimation(frames, pngOptions, duration, animationOptions, quality);
+        }
+        return true;
+    }
+
+    internal static bool TryRenderQrGif(RenderExtras? extras, QrPngRenderOptions pngOptions, out byte[] gif) {
+        var frames = extras?.GifFrames;
+        if (frames is null || frames.Length == 0) {
+            gif = Array.Empty<byte>();
+            return false;
+        }
+
+        var durations = extras?.AnimationDurationsMs;
+        var animationOptions = extras?.GifAnimationOptions ?? default;
+        if (durations is not null && durations.Length > 0) {
+            gif = QrGifRenderer.RenderAnimation(frames, pngOptions, durations, animationOptions);
+        } else {
+            var duration = extras?.AnimationDurationMs ?? 100;
+            gif = QrGifRenderer.RenderAnimation(frames, pngOptions, duration, animationOptions);
+        }
+        return true;
+    }
+}

--- a/CodeGlyphX/Rendering/Tiff/TiffCompression.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffCompression.cs
@@ -9,9 +9,6 @@ public enum TiffCompression {
     /// </summary>
     None = 1,
     /// <summary>
-    /// Deflate compression (zlib).
-    /// </summary>
-    /// <summary>
     /// LZW compression.
     /// </summary>
     Lzw = 5,

--- a/CodeGlyphX/Rendering/Webp/WebpReader.cs
+++ b/CodeGlyphX/Rendering/Webp/WebpReader.cs
@@ -67,10 +67,8 @@ public static class WebpReader {
             if (fourCc == FourCcVp8X && TryReadVp8XSize(chunk, out width, out height)) return true;
             if (fourCc == FourCcVp8L && TryReadVp8LSize(chunk, out width, out height)) return true;
             if (fourCc == FourCcVp8 && TryReadVp8Size(chunk, out width, out height)) return true;
-            if (fourCc == FourCcAnmf && anmfWidth == 0 && anmfHeight == 0) {
-                if (TryReadAnmfSize(chunk, out anmfWidth, out anmfHeight)) {
-                    // Keep scanning for VP8X/VP8/VP8L, but remember the first ANMF size.
-                }
+            if (fourCc == FourCcAnmf && anmfWidth == 0 && anmfHeight == 0 && TryReadAnmfSize(chunk, out anmfWidth, out anmfHeight)) {
+                // Keep scanning for VP8X/VP8/VP8L, but remember the first ANMF size.
             }
 
             var padded = chunkLength + (chunkLength & 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -674,12 +674,12 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.58.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
## Summary
- Add no-deps format support for GIF/TIFF/PSD/PDF/WebP with new renderers/readers/writers.
- Extend ImageReader multi-frame and output format info.
- Add tests and docs updates.

## Testing
- Not run in this worktree (commit came from local master history).