### PR TITLE
fix: follow-up tweaks for no-deps formats

### DIFF
--- a/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeBenchmarks.cs
@@ -2,7 +2,6 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using CodeGlyphX.Rendering;
-using CodeGlyphX.Rendering.Png;
 
 namespace CodeGlyphX.Benchmarks;
 
@@ -60,10 +59,10 @@ public class QrDecodeBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        LoadRgba("Assets/DecodingSamples/qr-clean-small.png", out _cleanRgba, out _cleanWidth, out _cleanHeight);
-        LoadRgba("Assets/DecodingSamples/qr-noisy-ui.png", out _noisyRgba, out _noisyWidth, out _noisyHeight);
-        LoadRgba("Assets/DecodingSamples/qr-screenshot-1.png", out _screenshotRgba, out _screenshotWidth, out _screenshotHeight);
-        LoadRgba("Assets/DecodingSamples/qr-dot-aa.png", out _antialiasRgba, out _antialiasWidth, out _antialiasHeight);
+        LoadSample("Assets/DecodingSamples/qr-clean-small.png", out _cleanRgba, out _cleanWidth, out _cleanHeight);
+        LoadSample("Assets/DecodingSamples/qr-noisy-ui.png", out _noisyRgba, out _noisyWidth, out _noisyHeight);
+        LoadSample("Assets/DecodingSamples/qr-screenshot-1.png", out _screenshotRgba, out _screenshotWidth, out _screenshotHeight);
+        LoadSample("Assets/DecodingSamples/qr-dot-aa.png", out _antialiasRgba, out _antialiasWidth, out _antialiasHeight);
 #if !BENCH_QUICK
         BuildLogoSample(out _logoRgba, out _logoWidth, out _logoHeight);
 #endif
@@ -134,13 +133,12 @@ public class QrDecodeBenchmarks
         return QrDecoder.TryDecode(_noQuietRgba, _noQuietWidth, _noQuietHeight, _noQuietWidth * 4, PixelFormat.Rgba32, out _, _robust);
     }
 
-    private static void LoadRgba(string relativePath, out byte[] rgba, out int width, out int height)
+    private static void LoadSample(string relativePath, out byte[] rgba, out int width, out int height)
     {
-        var bytes = RepoFiles.ReadRepoFile(relativePath);
-        if (!ImageReader.TryDecodeRgba32(bytes, out rgba, out width, out height))
-        {
-            throw new InvalidOperationException($"Failed to decode image '{relativePath}'.");
-        }
+        var data = QrDecodeSampleFactory.LoadSample(relativePath);
+        rgba = data.Rgba;
+        width = data.Width;
+        height = data.Height;
     }
 
 #if !BENCH_QUICK
@@ -154,49 +152,32 @@ public class QrDecodeBenchmarks
             out _);
         var options = QrPresets.Logo(logo);
         var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
-        DecodePng(png, out rgba, out width, out height);
+        QrDecodeSampleFactory.DecodePng(png, out rgba, out width, out height);
     }
 #endif
 
     private static void BuildFancySample(out byte[] rgba, out int width, out int height)
     {
-        var options = new QrEasyOptions { Style = QrRenderStyle.Fancy };
-        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
-        DecodePng(png, out rgba, out width, out height);
+        var data = QrDecodeSampleFactory.BuildFancyGenerated(SampleText);
+        rgba = data.Rgba;
+        width = data.Width;
+        height = data.Height;
     }
 
     private static void BuildResampledSample(out byte[] rgba, out int width, out int height)
     {
-        var options = new QrEasyOptions { ModuleSize = 8 };
-        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
-        DecodePng(png, out var baseRgba, out var baseWidth, out var baseHeight);
-
-        var downW = Math.Max(1, (int)Math.Round(baseWidth * 0.62));
-        var downH = Math.Max(1, (int)Math.Round(baseHeight * 0.62));
-        var down = QrDecodeImageOps.ResampleBilinear(baseRgba, baseWidth, baseHeight, downW, downH);
-
-        var upW = Math.Max(1, (int)Math.Round(baseWidth * 1.12));
-        var upH = Math.Max(1, (int)Math.Round(baseHeight * 1.12));
-        var up = QrDecodeImageOps.ResampleBilinear(down, downW, downH, upW, upH);
-
-        rgba = up;
-        width = upW;
-        height = upH;
+        var data = QrDecodeSampleFactory.BuildResampledGenerated(SampleText);
+        rgba = data.Rgba;
+        width = data.Width;
+        height = data.Height;
     }
 
     private static void BuildNoQuietSample(out byte[] rgba, out int width, out int height)
     {
-        var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
-        var png = QrCode.Render(SampleText, OutputFormat.Png, options).Data;
-        DecodePng(png, out rgba, out width, out height);
-    }
-
-    private static void DecodePng(byte[] png, out byte[] rgba, out int width, out int height)
-    {
-        if (!ImageReader.TryDecodeRgba32(png, out rgba, out width, out height))
-        {
-            throw new InvalidOperationException("Failed to decode generated QR PNG sample.");
-        }
+        var data = QrDecodeSampleFactory.BuildNoQuietGenerated(SampleText);
+        rgba = data.Rgba;
+        width = data.Width;
+        height = data.Height;
     }
 
 }

--- a/CodeGlyphX.Benchmarks/QrDecodeSampleFactory.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeSampleFactory.cs
@@ -1,0 +1,64 @@
+using System;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX.Benchmarks;
+
+internal static class QrDecodeSampleFactory {
+    internal const string DefaultPayload = "https://github.com/EvotecIT/CodeGlyphX";
+
+    public static QrDecodeScenarioData LoadSample(string relativePath) {
+        var bytes = RepoFiles.ReadRepoFile(relativePath);
+        if (!ImageReader.TryDecodeRgba32(bytes, out var rgba, out var width, out var height)) {
+            throw new InvalidOperationException($"Failed to decode sample '{relativePath}'.");
+        }
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    public static QrDecodeScenarioData BuildResampledGenerated(string payload = DefaultPayload) {
+        var options = new QrEasyOptions { ModuleSize = 8 };
+        var png = QrCode.Render(payload, OutputFormat.Png, options).Data;
+        DecodePng(png, out var baseRgba, out var baseWidth, out var baseHeight);
+
+        var downW = Math.Max(1, (int)Math.Round(baseWidth * 0.62, MidpointRounding.AwayFromZero));
+        var downH = Math.Max(1, (int)Math.Round(baseHeight * 0.62, MidpointRounding.AwayFromZero));
+        var down = QrDecodeImageOps.ResampleBilinear(baseRgba, baseWidth, baseHeight, downW, downH);
+
+        var upW = Math.Max(1, (int)Math.Round(baseWidth * 1.12, MidpointRounding.AwayFromZero));
+        var upH = Math.Max(1, (int)Math.Round(baseHeight * 1.12, MidpointRounding.AwayFromZero));
+        var up = QrDecodeImageOps.ResampleBilinear(down, downW, downH, upW, upH);
+
+        return new QrDecodeScenarioData(up, upW, upH);
+    }
+
+    public static QrDecodeScenarioData BuildNoQuietGenerated(string payload = DefaultPayload) {
+        var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
+        var png = QrCode.Render(payload, OutputFormat.Png, options).Data;
+        DecodePng(png, out var rgba, out var width, out var height);
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    public static QrDecodeScenarioData BuildFancyGenerated(string payload = DefaultPayload) {
+        var options = new QrEasyOptions { Style = QrRenderStyle.Fancy };
+        var png = QrCode.Render(payload, OutputFormat.Png, options).Data;
+        DecodePng(png, out var rgba, out var width, out var height);
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    public static QrDecodeScenarioData BuildLongPayloadGenerated(string payload, int targetSizePx = 1400) {
+        var options = new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.M,
+            TargetSizePx = targetSizePx,
+            TargetSizeIncludesQuietZone = true,
+            QuietZone = 4
+        };
+        var png = QrCode.Render(payload, OutputFormat.Png, options).Data;
+        DecodePng(png, out var rgba, out var width, out var height);
+        return new QrDecodeScenarioData(rgba, width, height);
+    }
+
+    public static void DecodePng(byte[] png, out byte[] rgba, out int width, out int height) {
+        if (!ImageReader.TryDecodeRgba32(png, out rgba, out width, out height)) {
+            throw new InvalidOperationException("Failed to decode generated QR PNG sample.");
+        }
+    }
+}

--- a/CodeGlyphX.Benchmarks/QrDecodeScenarioPacks.cs
+++ b/CodeGlyphX.Benchmarks/QrDecodeScenarioPacks.cs
@@ -95,7 +95,7 @@ internal static class QrDecodeScenarioPacks {
         return scenarios;
     }
 
-    private const string GeneratedPayload = "https://github.com/EvotecIT/CodeGlyphX";
+    private const string GeneratedPayload = QrDecodeSampleFactory.DefaultPayload;
     private const string ExpectedJess3 = "http://jess3.com";
     private const string ExpectedCleanLarge = "This is a quick test! 123#?";
     private const string ExpectedCleanSmall = "otpauth://totp/Evotec+Services+sp.+z+o.o.%3aprzemyslaw.klys%40evotec.pl?secret=jnll6mrqknd57pmn&issuer=Microsoft";
@@ -107,7 +107,7 @@ internal static class QrDecodeScenarioPacks {
         return new QrDecodeScenario(
             name,
             pack,
-            () => LoadSample(relativePath),
+            () => QrDecodeSampleFactory.LoadSample(relativePath),
             options,
             new[] { expectedText });
     }
@@ -128,14 +128,6 @@ internal static class QrDecodeScenarioPacks {
             build,
             options,
             expectedTexts);
-    }
-
-    private static QrDecodeScenarioData LoadSample(string relativePath) {
-        var bytes = RepoFiles.ReadRepoFile(relativePath);
-        if (!ImageReader.TryDecodeRgba32(bytes, out var rgba, out var width, out var height)) {
-            throw new InvalidOperationException($"Failed to decode sample '{relativePath}'.");
-        }
-        return new QrDecodeScenarioData(rgba, width, height);
     }
 
     private static QrPixelDecodeOptions IdealOptions(QrPackMode mode) {
@@ -207,46 +199,15 @@ internal static class QrDecodeScenarioPacks {
     }
 
     private static QrDecodeScenarioData BuildResampledGenerated() {
-        var options = new QrEasyOptions { ModuleSize = 8 };
-        var png = QrCode.Render(GeneratedPayload, OutputFormat.Png, options).Data;
-        if (!ImageReader.TryDecodeRgba32(png, out var baseRgba, out var baseWidth, out var baseHeight)) {
-            throw new InvalidOperationException("Failed to decode generated resample PNG.");
-        }
-
-        var downW = Math.Max(1, (int)Math.Round(baseWidth * 0.62, MidpointRounding.AwayFromZero));
-        var downH = Math.Max(1, (int)Math.Round(baseHeight * 0.62, MidpointRounding.AwayFromZero));
-        var down = QrDecodeImageOps.ResampleBilinear(baseRgba, baseWidth, baseHeight, downW, downH);
-
-        var upW = Math.Max(1, (int)Math.Round(baseWidth * 1.12, MidpointRounding.AwayFromZero));
-        var upH = Math.Max(1, (int)Math.Round(baseHeight * 1.12, MidpointRounding.AwayFromZero));
-        var up = QrDecodeImageOps.ResampleBilinear(down, downW, downH, upW, upH);
-
-        return new QrDecodeScenarioData(up, upW, upH);
+        return QrDecodeSampleFactory.BuildResampledGenerated(GeneratedPayload);
     }
 
     private static QrDecodeScenarioData BuildNoQuietGenerated() {
-        var options = new QrEasyOptions { QuietZone = 0, ErrorCorrectionLevel = QrErrorCorrectionLevel.H };
-        var png = QrCode.Render(GeneratedPayload, OutputFormat.Png, options).Data;
-        if (!ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height)) {
-            throw new InvalidOperationException("Failed to decode generated no-quiet PNG.");
-        }
-
-        return new QrDecodeScenarioData(rgba, width, height);
+        return QrDecodeSampleFactory.BuildNoQuietGenerated(GeneratedPayload);
     }
 
     private static QrDecodeScenarioData BuildLongPayloadGenerated() {
-        var options = new QrEasyOptions {
-            ErrorCorrectionLevel = QrErrorCorrectionLevel.M,
-            TargetSizePx = 1400,
-            TargetSizeIncludesQuietZone = true,
-            QuietZone = 4
-        };
-        var png = QrCode.Render(LongPayload, OutputFormat.Png, options).Data;
-        if (!ImageReader.TryDecodeRgba32(png, out var rgba, out var width, out var height)) {
-            throw new InvalidOperationException("Failed to decode generated long-payload PNG.");
-        }
-
-        return new QrDecodeScenarioData(rgba, width, height);
+        return QrDecodeSampleFactory.BuildLongPayloadGenerated(LongPayload);
     }
 
     private static QrDecodeScenarioData BuildMultiQrScreenshotLike() {

--- a/CodeGlyphX.Tests/BarcodeAnimationRenderExtrasTests.cs
+++ b/CodeGlyphX.Tests/BarcodeAnimationRenderExtrasTests.cs
@@ -1,0 +1,73 @@
+using CodeGlyphX;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class BarcodeAnimationRenderExtrasTests {
+    [Fact]
+    public void Render_Barcode_Gif_Animation_Uses_RenderExtras_Frames() {
+        var frame1 = new Barcode1D(new[] {
+            new BarSegment(true, 2),
+            new BarSegment(false, 1),
+            new BarSegment(true, 1)
+        });
+        var frame2 = new Barcode1D(new[] {
+            new BarSegment(true, 1),
+            new BarSegment(false, 1),
+            new BarSegment(true, 2)
+        });
+
+        var options = new BarcodeOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            HeightModules = 4
+        };
+
+        var extras = new RenderExtras {
+            BarcodeGifFrames = new[] { frame1, frame2 },
+            AnimationDurationsMs = new[] { 40, 60 }
+        };
+
+        var output = Barcode.Render(frame1, OutputFormat.Gif, options, extras);
+        var frames = GifReader.DecodeAnimationFrames(output.Data, out _, out _, out _);
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(40, frames[0].DurationMs);
+        Assert.Equal(60, frames[1].DurationMs);
+    }
+
+    [Fact]
+    public void Render_Barcode_Webp_Animation_Uses_RenderExtras_Frames() {
+        var frame1 = new Barcode1D(new[] {
+            new BarSegment(true, 2),
+            new BarSegment(false, 1),
+            new BarSegment(true, 1)
+        });
+        var frame2 = new Barcode1D(new[] {
+            new BarSegment(true, 1),
+            new BarSegment(false, 1),
+            new BarSegment(true, 2)
+        });
+
+        var options = new BarcodeOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            HeightModules = 4
+        };
+
+        var extras = new RenderExtras {
+            BarcodeWebpFrames = new[] { frame1, frame2 },
+            AnimationDurationsMs = new[] { 35, 55 }
+        };
+
+        var output = Barcode.Render(frame1, OutputFormat.Webp, options, extras);
+        var frames = WebpReader.DecodeAnimationFrames(output.Data, out _, out _, out _);
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(35, frames[0].DurationMs);
+        Assert.Equal(55, frames[1].DurationMs);
+    }
+}

--- a/CodeGlyphX.Tests/GifAnimationDecodeTests.cs
+++ b/CodeGlyphX.Tests/GifAnimationDecodeTests.cs
@@ -1,0 +1,69 @@
+using CodeGlyphX.Rendering.Gif;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifAnimationDecodeTests {
+    [Fact]
+    public void Decode_Gif_Animation_Frames() {
+        var gif = new byte[] {
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61, // GIF89a
+            0x01, 0x00, 0x01, 0x00, // 1x1
+            0x80, 0x00, 0x00, // GCT, background, aspect
+            0xFF, 0x00, 0x00, // red
+            0x00, 0x00, 0xFF, // blue
+            0x21, 0xF9, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, // GCE frame 1
+            0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, // image descriptor
+            0x02, 0x02, 0x44, 0x01, 0x00, // image data (red)
+            0x21, 0xF9, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, // GCE frame 2
+            0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, // image descriptor
+            0x02, 0x02, 0x4C, 0x01, 0x00, // image data (blue)
+            0x3B // trailer
+        };
+
+        Assert.True(GifReader.TryDecodeAnimationFrames(gif, out var frames, out var width, out var height, out var options));
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(10, frames[0].DurationMs);
+        Assert.Equal(10, frames[1].DurationMs);
+
+        Assert.Equal(255, frames[0].Rgba[0]);
+        Assert.Equal(0, frames[0].Rgba[1]);
+        Assert.Equal(0, frames[0].Rgba[2]);
+        Assert.Equal(255, frames[0].Rgba[3]);
+
+        Assert.Equal(0, frames[1].Rgba[0]);
+        Assert.Equal(0, frames[1].Rgba[1]);
+        Assert.Equal(255, frames[1].Rgba[2]);
+        Assert.Equal(255, frames[1].Rgba[3]);
+
+        Assert.Equal(0, options.LoopCount);
+    }
+
+    [Fact]
+    public void Decode_Gif_Animation_Canvas_Frames() {
+        var gif = new byte[] {
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61,
+            0x01, 0x00, 0x01, 0x00,
+            0x80, 0x00, 0x00,
+            0xFF, 0x00, 0x00,
+            0x00, 0x00, 0xFF,
+            0x21, 0xF9, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+            0x02, 0x02, 0x44, 0x01, 0x00,
+            0x21, 0xF9, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+            0x02, 0x02, 0x4C, 0x01, 0x00,
+            0x3B
+        };
+
+        Assert.True(GifReader.TryDecodeAnimationCanvasFrames(gif, out var frames, out var width, out var height, out _));
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(255, frames[0].Rgba[0]);
+        Assert.Equal(0, frames[1].Rgba[0]);
+        Assert.Equal(255, frames[1].Rgba[2]);
+    }
+}

--- a/CodeGlyphX.Tests/GifAnimationDisposalOptimizationTests.cs
+++ b/CodeGlyphX.Tests/GifAnimationDisposalOptimizationTests.cs
@@ -1,0 +1,24 @@
+using CodeGlyphX.Rendering.Gif;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifAnimationDisposalOptimizationTests {
+    [Fact]
+    public void Encode_Gif_Animation_RestoreBackground_Crops_With_Transparent_Hole() {
+        var red = new byte[] { 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255 };
+        var frame1 = new GifAnimationFrame(red, 2, 2, 8, durationMs: 20, disposeToBackground: true);
+
+        var frame2Pixels = new byte[] {
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0
+        };
+        var frame2 = new GifAnimationFrame(frame2Pixels, 2, 2, 8, durationMs: 20, disposeToBackground: true);
+
+        var gif = GifWriter.WriteAnimation(2, 2, new[] { frame1, frame2 }, new GifAnimationOptions(loopCount: 0, backgroundRgba: 0));
+        Assert.True(GifReader.TryDecodeAnimationFrames(gif, out var frames, out _, out _, out _));
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(2, frames[1].Width);
+        Assert.Equal(2, frames[1].Height);
+    }
+}

--- a/CodeGlyphX.Tests/GifAnimationEncodeTests.cs
+++ b/CodeGlyphX.Tests/GifAnimationEncodeTests.cs
@@ -1,0 +1,25 @@
+using CodeGlyphX.Rendering.Gif;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifAnimationEncodeTests {
+    [Fact]
+    public void Encode_Gif_Animation_RoundTrip() {
+        var frame1 = new GifAnimationFrame(new byte[] { 255, 0, 0, 255 }, 1, 1, 4, durationMs: 20);
+        var frame2 = new GifAnimationFrame(new byte[] { 0, 0, 255, 255 }, 1, 1, 4, durationMs: 30);
+        var options = new GifAnimationOptions(loopCount: 2, backgroundRgba: 0);
+
+        var gif = GifWriter.WriteAnimation(1, 1, new[] { frame1, frame2 }, options);
+        Assert.True(GifReader.TryDecodeAnimationFrames(gif, out var frames, out var width, out var height, out var decodedOptions));
+
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(2, decodedOptions.LoopCount);
+
+        Assert.Equal(255, frames[0].Rgba[0]);
+        Assert.Equal(0, frames[0].Rgba[2]);
+        Assert.Equal(255, frames[1].Rgba[2]);
+    }
+}

--- a/CodeGlyphX.Tests/GifAnimationOptimizationTests.cs
+++ b/CodeGlyphX.Tests/GifAnimationOptimizationTests.cs
@@ -1,0 +1,31 @@
+using CodeGlyphX.Rendering.Gif;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifAnimationOptimizationTests {
+    [Fact]
+    public void Encode_Gif_Animation_Crops_Diff_Frames() {
+        var canvas = new byte[] {
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0
+        };
+        var frame1 = new GifAnimationFrame(canvas, 2, 2, 8, durationMs: 20);
+
+        var frame2Pixels = new byte[] {
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            255, 0, 0, 255
+        };
+        var frame2 = new GifAnimationFrame(frame2Pixels, 2, 2, 8, durationMs: 20);
+
+        var gif = GifWriter.WriteAnimation(2, 2, new[] { frame1, frame2 });
+        Assert.True(GifReader.TryDecodeAnimationFrames(gif, out var frames, out _, out _, out _));
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(1, frames[1].Width);
+        Assert.Equal(1, frames[1].Height);
+    }
+}

--- a/CodeGlyphX.Tests/GifAnimationRenderTests.cs
+++ b/CodeGlyphX.Tests/GifAnimationRenderTests.cs
@@ -1,0 +1,50 @@
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Png;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifAnimationRenderTests {
+    [Fact]
+    public void Render_Gif_Animation_From_Matrix_Frames() {
+        var frame1 = new BitMatrix(2, 2);
+        frame1[0, 0] = true;
+        frame1[1, 1] = true;
+
+        var frame2 = new BitMatrix(2, 2);
+        frame2[0, 1] = true;
+        frame2[1, 0] = true;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0
+        };
+
+        var gif = MatrixGifRenderer.RenderAnimation(new[] { frame1, frame2 }, opts, durationMs: 50);
+        var frames = GifReader.DecodeAnimationFrames(gif, out var width, out var height, out _);
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(2, width);
+        Assert.Equal(2, height);
+    }
+
+    [Fact]
+    public void Render_Gif_Animation_With_Durations() {
+        var frame1 = new BitMatrix(1, 1);
+        frame1[0, 0] = true;
+        var frame2 = new BitMatrix(1, 1);
+        frame2[0, 0] = false;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0
+        };
+
+        var gif = MatrixGifRenderer.RenderAnimation(new[] { frame1, frame2 }, opts, new[] { 30, 60 });
+        var frames = GifReader.DecodeAnimationFrames(gif, out _, out _, out _);
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(30, frames[0].DurationMs);
+        Assert.Equal(60, frames[1].DurationMs);
+    }
+}

--- a/CodeGlyphX.Tests/GifAnimationRestorePreviousOptimizationTests.cs
+++ b/CodeGlyphX.Tests/GifAnimationRestorePreviousOptimizationTests.cs
@@ -1,0 +1,27 @@
+using CodeGlyphX.Rendering.Gif;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifAnimationRestorePreviousOptimizationTests {
+    [Fact]
+    public void Encode_Gif_Animation_RestorePrevious_Crops_Diff() {
+        var frame1Pixels = new byte[] {
+            255, 0, 0, 255, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0
+        };
+        var frame1 = new GifAnimationFrame(frame1Pixels, 2, 2, 8, durationMs: 20);
+
+        var frame2Pixels = new byte[] {
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 255, 0, 255
+        };
+        var frame2 = new GifAnimationFrame(frame2Pixels, 2, 2, 8, durationMs: 20, disposal: GifDisposal.RestorePrevious);
+
+        var gif = GifWriter.WriteAnimation(2, 2, new[] { frame1, frame2 });
+        Assert.True(GifReader.TryDecodeAnimationFrames(gif, out var frames, out _, out _, out _));
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(1, frames[1].Width);
+        Assert.Equal(1, frames[1].Height);
+    }
+}

--- a/CodeGlyphX.Tests/GifQuantizationEncodeTests.cs
+++ b/CodeGlyphX.Tests/GifQuantizationEncodeTests.cs
@@ -1,0 +1,29 @@
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Gif;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class GifQuantizationEncodeTests {
+    [Fact]
+    public void Encode_Gif_Quantizes_When_Colors_Exceed_256() {
+        const int width = 17;
+        const int height = 17;
+        var rgba = new byte[width * height * 4];
+        var idx = 0;
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                rgba[idx++] = (byte)(x * 15);
+                rgba[idx++] = (byte)(y * 15);
+                rgba[idx++] = (byte)((x + y) * 7);
+                rgba[idx++] = 255;
+            }
+        }
+
+        var gif = GifWriter.WriteRgba32(width, height, rgba, width * 4);
+        Assert.True(ImageReader.TryDecodeRgba32(gif, out var decoded, out var w, out var h));
+        Assert.Equal(width, w);
+        Assert.Equal(height, h);
+        Assert.Equal(width * height * 4, decoded.Length);
+    }
+}

--- a/CodeGlyphX.Tests/ImageFormatDecodeTests.cs
+++ b/CodeGlyphX.Tests/ImageFormatDecodeTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Ico;
 using CodeGlyphX.Rendering.Pam;
@@ -9,6 +10,7 @@ using CodeGlyphX.Rendering.Pgm;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Ppm;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
 using Xunit;
@@ -26,6 +28,9 @@ public sealed class ImageFormatDecodeTests {
 
     [Fact]
     public void Decode_Bmp() => AssertRoundTrip(QrBmpRenderer.Render(Encode(), DefaultOptions()));
+
+    [Fact]
+    public void Decode_Gif_Render() => AssertRoundTrip(QrGifRenderer.Render(Encode(), DefaultOptions()));
 
     [Fact]
     public void Decode_Ppm() => AssertRoundTrip(QrPpmRenderer.Render(Encode(), DefaultOptions()));
@@ -47,6 +52,9 @@ public sealed class ImageFormatDecodeTests {
 
     [Fact]
     public void Decode_Tga() => AssertRoundTrip(QrTgaRenderer.Render(Encode(), DefaultOptions()));
+
+    [Fact]
+    public void Decode_Tiff_Render() => AssertRoundTrip(QrTiffRenderer.Render(Encode(), DefaultOptions()));
 
     [Fact]
     public void Decode_Ico() => AssertRoundTrip(QrIcoRenderer.Render(Encode(), DefaultOptions()));

--- a/CodeGlyphX.Tests/ImageReaderMultiFrameTests.cs
+++ b/CodeGlyphX.Tests/ImageReaderMultiFrameTests.cs
@@ -1,0 +1,40 @@
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class ImageReaderMultiFrameTests {
+    [Fact]
+    public void Decode_Gif_Animation_Frames_Via_ImageReader() {
+        var gif = new byte[] {
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61,
+            0x01, 0x00, 0x01, 0x00,
+            0x80, 0x00, 0x00,
+            0xFF, 0x00, 0x00,
+            0x00, 0x00, 0xFF,
+            0x21, 0xF9, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+            0x02, 0x02, 0x44, 0x01, 0x00,
+            0x21, 0xF9, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x2C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+            0x02, 0x02, 0x4C, 0x01, 0x00,
+            0x3B
+        };
+
+        Assert.True(ImageReader.TryDecodeGifAnimationFrames(gif, out var frames, out var width, out var height, out _));
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(2, frames.Length);
+    }
+
+    [Fact]
+    public void Decode_Tiff_Pages_Via_ImageReader() {
+        var page1 = new TiffRgba32Page(new byte[] { 255, 0, 0, 255 }, 1, 1, 4);
+        var page2 = new TiffRgba32Page(new byte[] { 0, 255, 0, 255 }, 1, 1, 4);
+        var tiff = TiffWriter.WriteRgba32Pages(page1, page2);
+
+        Assert.True(ImageReader.TryDecodeTiffPagesRgba32(tiff, out var pages));
+        Assert.Equal(2, pages.Length);
+    }
+}

--- a/CodeGlyphX.Tests/PdfDecodeTests.cs
+++ b/CodeGlyphX.Tests/PdfDecodeTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using CodeGlyphX.Rendering;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class PdfDecodeTests {
+    [Fact]
+    public void Decode_Pdf_Flate_Image() {
+        var rgb = new byte[] { 255, 0, 0 };
+        var pdf = BuildPdfWithFlateImage(1, 1, rgb);
+
+        var rgba = ImageReader.DecodeRgba32(pdf, out var width, out var height);
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(4, rgba.Length);
+        Assert.Equal(255, rgba[0]);
+        Assert.Equal(0, rgba[1]);
+        Assert.Equal(0, rgba[2]);
+        Assert.Equal(255, rgba[3]);
+    }
+
+    private static byte[] BuildPdfWithFlateImage(int width, int height, byte[] rgb) {
+        byte[] compressed;
+        using (var ms = new MemoryStream()) {
+            using (var deflate = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true)) {
+                deflate.Write(rgb, 0, rgb.Length);
+            }
+            compressed = ms.ToArray();
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("%PDF-1.4\n");
+        sb.Append("1 0 obj\n");
+        sb.Append("<< /Type /XObject /Subtype /Image ");
+        sb.Append("/Width ").Append(width).Append(' ');
+        sb.Append("/Height ").Append(height).Append(' ');
+        sb.Append("/ColorSpace /DeviceRGB ");
+        sb.Append("/BitsPerComponent 8 ");
+        sb.Append("/Filter /FlateDecode ");
+        sb.Append("/Length ").Append(compressed.Length).Append(" >>\n");
+        sb.Append("stream\n");
+
+        var header = Encoding.ASCII.GetBytes(sb.ToString());
+        var footer = Encoding.ASCII.GetBytes("\nendstream\nendobj\n%%EOF\n");
+
+        var output = new byte[header.Length + compressed.Length + footer.Length];
+        Buffer.BlockCopy(header, 0, output, 0, header.Length);
+        Buffer.BlockCopy(compressed, 0, output, header.Length, compressed.Length);
+        Buffer.BlockCopy(footer, 0, output, header.Length + compressed.Length, footer.Length);
+        return output;
+    }
+}

--- a/CodeGlyphX.Tests/PsdDecodeTests.cs
+++ b/CodeGlyphX.Tests/PsdDecodeTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Psd;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class PsdDecodeTests {
+    [Fact]
+    public void Decode_Psd_Rgb_Raw() {
+        var psd = BuildRgbPsdRaw(width: 2, height: 1, r: new byte[] { 255, 0 }, g: new byte[] { 0, 255 }, b: new byte[] { 0, 0 });
+        Assert.True(ImageReader.TryDetectFormat(psd, out var format));
+        Assert.Equal(ImageFormat.Psd, format);
+        Assert.True(PsdReader.TryReadDimensions(psd, out var width, out var height));
+        Assert.Equal(2, width);
+        Assert.Equal(1, height);
+
+        var rgba = ImageReader.DecodeRgba32(psd, out width, out height);
+        Assert.Equal(2, width);
+        Assert.Equal(1, height);
+        Assert.Equal(8, rgba.Length);
+        Assert.Equal(255, rgba[0]);
+        Assert.Equal(0, rgba[1]);
+        Assert.Equal(0, rgba[2]);
+        Assert.Equal(255, rgba[3]);
+        Assert.Equal(0, rgba[4]);
+        Assert.Equal(255, rgba[5]);
+        Assert.Equal(0, rgba[6]);
+        Assert.Equal(255, rgba[7]);
+    }
+
+    [Fact]
+    public void Decode_Psd_Grayscale_Rle() {
+        var psd = BuildGrayscalePsdRle(width: 1, height: 1, value: 128);
+        var rgba = ImageReader.DecodeRgba32(psd, out var width, out var height);
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(4, rgba.Length);
+        Assert.Equal(128, rgba[0]);
+        Assert.Equal(128, rgba[1]);
+        Assert.Equal(128, rgba[2]);
+        Assert.Equal(255, rgba[3]);
+    }
+
+    private static byte[] BuildRgbPsdRaw(int width, int height, byte[] r, byte[] g, byte[] b) {
+        var bytes = new List<byte>();
+        WriteU32BE(bytes, 0x38425053u); // 8BPS
+        WriteU16BE(bytes, 1);
+        bytes.AddRange(new byte[6]);
+        WriteU16BE(bytes, 3); // channels
+        WriteU32BE(bytes, (uint)height);
+        WriteU32BE(bytes, (uint)width);
+        WriteU16BE(bytes, 8);
+        WriteU16BE(bytes, 3); // RGB
+        WriteU32BE(bytes, 0);
+        WriteU32BE(bytes, 0);
+        WriteU32BE(bytes, 0);
+        WriteU16BE(bytes, 0); // raw
+        bytes.AddRange(r);
+        bytes.AddRange(g);
+        bytes.AddRange(b);
+        return bytes.ToArray();
+    }
+
+    private static byte[] BuildGrayscalePsdRle(int width, int height, byte value) {
+        var bytes = new List<byte>();
+        WriteU32BE(bytes, 0x38425053u); // 8BPS
+        WriteU16BE(bytes, 1);
+        bytes.AddRange(new byte[6]);
+        WriteU16BE(bytes, 1); // channels
+        WriteU32BE(bytes, (uint)height);
+        WriteU32BE(bytes, (uint)width);
+        WriteU16BE(bytes, 8);
+        WriteU16BE(bytes, 1); // grayscale
+        WriteU32BE(bytes, 0);
+        WriteU32BE(bytes, 0);
+        WriteU32BE(bytes, 0);
+        WriteU16BE(bytes, 1); // RLE
+
+        // RLE row lengths (channels * height)
+        WriteU16BE(bytes, 2); // one row, 2 bytes encoded
+        bytes.Add(0); // literal count = 1
+        bytes.Add(value);
+        return bytes.ToArray();
+    }
+
+    private static void WriteU16BE(List<byte> bytes, ushort value) {
+        bytes.Add((byte)(value >> 8));
+        bytes.Add((byte)value);
+    }
+
+    private static void WriteU32BE(List<byte> bytes, uint value) {
+        bytes.Add((byte)(value >> 24));
+        bytes.Add((byte)(value >> 16));
+        bytes.Add((byte)(value >> 8));
+        bytes.Add((byte)value);
+    }
+}

--- a/CodeGlyphX.Tests/RenderExtrasAnimationTests.cs
+++ b/CodeGlyphX.Tests/RenderExtrasAnimationTests.cs
@@ -1,0 +1,44 @@
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class RenderExtrasAnimationTests {
+    [Fact]
+    public void Render_Uses_GifFrames_From_Extras() {
+        var frame1 = new BitMatrix(1, 1);
+        frame1[0, 0] = true;
+        var frame2 = new BitMatrix(1, 1);
+        frame2[0, 0] = false;
+
+        var extras = new RenderExtras {
+            GifFrames = new[] { frame1, frame2 },
+            AnimationDurationMs = 30
+        };
+
+        var output = QrCode.Render("test", OutputFormat.Gif, extras: extras);
+        var frames = GifReader.DecodeAnimationFrames(output.Data, out _, out _, out _);
+
+        Assert.Equal(2, frames.Length);
+    }
+
+    [Fact]
+    public void Render_Uses_WebpFrames_From_Extras() {
+        var frame1 = new BitMatrix(1, 1);
+        frame1[0, 0] = true;
+        var frame2 = new BitMatrix(1, 1);
+        frame2[0, 0] = false;
+
+        var extras = new RenderExtras {
+            WebpFrames = new[] { frame1, frame2 },
+            AnimationDurationMs = 40
+        };
+
+        var output = QrCode.Render("test", OutputFormat.Webp, extras: extras);
+        var frames = WebpReader.DecodeAnimationFrames(output.Data, out _, out _, out _);
+
+        Assert.Equal(2, frames.Length);
+    }
+}

--- a/CodeGlyphX.Tests/RendererFormatTests.cs
+++ b/CodeGlyphX.Tests/RendererFormatTests.cs
@@ -35,6 +35,14 @@ public sealed class RendererFormatTests {
         var bmp = QrCode.Render(payload, OutputFormat.Bmp).Data;
         Assert.True(IsBmp(bmp));
 
+        var gif = QrCode.Render(payload, OutputFormat.Gif).Data;
+        Assert.True(ImageReader.TryDetectFormat(gif, out var gifFormat));
+        Assert.Equal(ImageFormat.Gif, gifFormat);
+
+        var tiff = QrCode.Render(payload, OutputFormat.Tiff).Data;
+        Assert.True(ImageReader.TryDetectFormat(tiff, out var tiffFormat));
+        Assert.Equal(ImageFormat.Tiff, tiffFormat);
+
         var ppm = QrCode.Render(payload, OutputFormat.Ppm).Data;
         Assert.True(IsPpm(ppm));
 

--- a/CodeGlyphX.Tests/TiffBilevelDecodeTests.cs
+++ b/CodeGlyphX.Tests/TiffBilevelDecodeTests.cs
@@ -1,0 +1,99 @@
+using System;
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffBilevelDecodeTests {
+    [Fact]
+    public void Decode_Bilevel_Tiff_BlackIsZero() {
+        var tiff = BuildBilevelTiff(width: 8, height: 2, photometric: 1, packedRows: new byte[] { 0xAA, 0x55 });
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(8, width);
+        Assert.Equal(2, height);
+
+        Assert.Equal(255, rgba[0]);
+        Assert.Equal(0, rgba[4]);
+        Assert.Equal(255, rgba[8]);
+        Assert.Equal(0, rgba[12]);
+
+        var row1 = 1 * width * 4;
+        Assert.Equal(0, rgba[row1 + 0]);
+        Assert.Equal(255, rgba[row1 + 4]);
+        Assert.Equal(0, rgba[row1 + 8]);
+        Assert.Equal(255, rgba[row1 + 12]);
+    }
+
+    [Fact]
+    public void Decode_Bilevel_Tiff_WhiteIsZero() {
+        var tiff = BuildBilevelTiff(width: 8, height: 1, photometric: 0, packedRows: new byte[] { 0x80 });
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(8, width);
+        Assert.Equal(1, height);
+
+        Assert.Equal(0, rgba[0]);
+        Assert.Equal(255, rgba[4]);
+    }
+
+    private static byte[] BuildBilevelTiff(int width, int height, ushort photometric, byte[] packedRows) {
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+
+        var bytesPerRow = (width + 7) / 8;
+        if (packedRows.Length != bytesPerRow * height) {
+            throw new ArgumentException("Packed row data does not match dimensions.", nameof(packedRows));
+        }
+
+        const int entryCount = 9;
+        const int headerSize = 8;
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var imageOffset = headerSize + ifdSize;
+        var data = new byte[imageOffset + packedRows.Length];
+
+        data[0] = (byte)'I';
+        data[1] = (byte)'I';
+        data[2] = 42;
+        data[3] = 0;
+        WriteUInt32LE(data, 4, headerSize);
+
+        WriteUInt16LE(data, headerSize, entryCount);
+        var entryOffset = headerSize + 2;
+
+        WriteEntry(data, ref entryOffset, 256, 3, 1, (uint)width); // ImageWidth
+        WriteEntry(data, ref entryOffset, 257, 3, 1, (uint)height); // ImageLength
+        WriteEntry(data, ref entryOffset, 258, 3, 1, 1); // BitsPerSample
+        WriteEntry(data, ref entryOffset, 259, 3, 1, 1); // Compression
+        WriteEntry(data, ref entryOffset, 262, 3, 1, photometric); // PhotometricInterpretation
+        WriteEntry(data, ref entryOffset, 273, 4, 1, (uint)imageOffset); // StripOffsets
+        WriteEntry(data, ref entryOffset, 277, 3, 1, 1); // SamplesPerPixel
+        WriteEntry(data, ref entryOffset, 278, 3, 1, (uint)height); // RowsPerStrip
+        WriteEntry(data, ref entryOffset, 279, 4, 1, (uint)packedRows.Length); // StripByteCounts
+
+        WriteUInt32LE(data, headerSize + 2 + entryCount * 12, 0);
+
+        Buffer.BlockCopy(packedRows, 0, data, imageOffset, packedRows.Length);
+        return data;
+    }
+
+    private static void WriteEntry(byte[] data, ref int offset, ushort tag, ushort type, uint count, uint value) {
+        WriteUInt16LE(data, offset, tag);
+        WriteUInt16LE(data, offset + 2, type);
+        WriteUInt32LE(data, offset + 4, count);
+        WriteUInt32LE(data, offset + 8, value);
+        offset += 12;
+    }
+
+    private static void WriteUInt16LE(byte[] data, int offset, ushort value) {
+        data[offset] = (byte)value;
+        data[offset + 1] = (byte)(value >> 8);
+    }
+
+    private static void WriteUInt32LE(byte[] data, int offset, uint value) {
+        data[offset] = (byte)value;
+        data[offset + 1] = (byte)(value >> 8);
+        data[offset + 2] = (byte)(value >> 16);
+        data[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/CodeGlyphX.Tests/TiffBilevelEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffBilevelEncodeTests.cs
@@ -1,0 +1,61 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffBilevelEncodeTests {
+    [Theory]
+    [InlineData(TiffCompression.None)]
+    [InlineData(TiffCompression.PackBits)]
+    [InlineData(TiffCompression.Deflate)]
+    public void Encode_Bilevel_Tiff_RoundTrip(TiffCompression compression) {
+        const int width = 10;
+        const int height = 1;
+        var row = new byte[] { 0xAA, 0x80 }; // 10101010 10xxxxxx
+
+        var tiff = TiffWriter.WriteBilevel(width, height, row, stride: 2, rowsPerStrip: 1, compression: compression);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var decodedWidth, out var decodedHeight);
+
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+
+        Assert.Equal(255, rgba[0]);
+        Assert.Equal(0, rgba[4]);
+        Assert.Equal(255, rgba[8]);
+        Assert.Equal(0, rgba[12]);
+        Assert.Equal(255, rgba[16]);
+        Assert.Equal(0, rgba[20]);
+        Assert.Equal(255, rgba[24]);
+        Assert.Equal(0, rgba[28]);
+        Assert.Equal(255, rgba[32]);
+        Assert.Equal(0, rgba[36]);
+    }
+
+    [Fact]
+    public void Encode_Bilevel_Tiff_WhiteIsZero() {
+        var row = new byte[] { 0x80 }; // first bit = 1
+        var tiff = TiffWriter.WriteBilevel(8, 1, row, stride: 1, rowsPerStrip: 1, compression: TiffCompression.None, photometric: 0);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var decodedWidth, out var decodedHeight);
+
+        Assert.Equal(8, decodedWidth);
+        Assert.Equal(1, decodedHeight);
+        Assert.Equal(0, rgba[0]);
+        Assert.Equal(255, rgba[4]);
+    }
+
+    [Fact]
+    public void Encode_Bilevel_From_Rgba_Defaults() {
+        var rgba = new byte[] {
+            0, 0, 0, 255,
+            255, 255, 255, 255
+        };
+
+        var tiff = TiffWriter.WriteBilevelFromRgba(2, 1, rgba, stride: 8);
+        var decoded = TiffReader.DecodeRgba32(tiff, out var decodedWidth, out var decodedHeight);
+
+        Assert.Equal(2, decodedWidth);
+        Assert.Equal(1, decodedHeight);
+        Assert.Equal(0, decoded[0]);
+        Assert.Equal(255, decoded[4]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffBilevelRendererTests.cs
+++ b/CodeGlyphX.Tests/TiffBilevelRendererTests.cs
@@ -1,0 +1,110 @@
+using CodeGlyphX;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffBilevelRendererTests {
+    [Fact]
+    public void Render_Bilevel_Matrix_Tiff() {
+        var modules = new BitMatrix(1, 1);
+        modules[0, 0] = true;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0
+        };
+
+        var tiff = MatrixTiffRenderer.RenderBilevel(modules, opts);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(0, rgba[0]);
+    }
+
+    [Fact]
+    public void Render_Bilevel_Barcode_Tiff() {
+        var barcode = new Barcode1D(new[] {
+            new BarSegment(true, 1),
+            new BarSegment(false, 1)
+        });
+
+        var opts = new BarcodePngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            HeightModules = 1
+        };
+
+        var tiff = BarcodeTiffRenderer.RenderBilevel(barcode, opts);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(2, width);
+        Assert.Equal(1, height);
+        Assert.Equal(0, rgba[0]);
+        Assert.Equal(255, rgba[4]);
+    }
+
+    [Fact]
+    public void Render_Bilevel_Tiled_Matrix_Tiff() {
+        var modules = new BitMatrix(1, 1);
+        modules[0, 0] = true;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0
+        };
+
+        var tiff = MatrixTiffRenderer.RenderBilevelTiled(modules, opts, tileWidth: 2, tileHeight: 2);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(0, rgba[0]);
+    }
+
+    [Fact]
+    public void Render_Bilevel_From_Modules_Respects_Color_Luminance() {
+        var modules = new BitMatrix(1, 1);
+        modules[0, 0] = true;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            Foreground = Rgba32.White,
+            Background = Rgba32.Black
+        };
+
+        var tiff = MatrixTiffRenderer.RenderBilevelFromModules(modules, opts);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(255, rgba[0]);
+    }
+
+    [Fact]
+    public void Render_Barcode_Bilevel_From_Bars_Respects_Color_Luminance() {
+        var barcode = new Barcode1D(new[] {
+            new BarSegment(true, 1),
+            new BarSegment(false, 1)
+        });
+
+        var opts = new BarcodePngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            HeightModules = 1,
+            Foreground = Rgba32.White,
+            Background = Rgba32.Black
+        };
+
+        var tiff = BarcodeTiffRenderer.RenderBilevelFromBars(barcode, opts);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(2, width);
+        Assert.Equal(1, height);
+        Assert.Equal(255, rgba[0]);
+        Assert.Equal(0, rgba[4]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffBilevelTileEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffBilevelTileEncodeTests.cs
@@ -1,0 +1,34 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffBilevelTileEncodeTests {
+    [Theory]
+    [InlineData(TiffCompression.None)]
+    [InlineData(TiffCompression.PackBits)]
+    [InlineData(TiffCompression.Deflate)]
+    public void Encode_Bilevel_Tiff_Tiled_RoundTrip(TiffCompression compression) {
+        const int width = 10;
+        const int height = 2;
+        var packed = new byte[] {
+            0xAA, 0x80, // row 0: 10101010 10......
+            0x55, 0x00  // row 1: 01010101 00......
+        };
+
+        var tiff = TiffWriter.WriteBilevelTiled(width, height, packed, stride: 2, tileWidth: 8, tileHeight: 1, compression: compression);
+        var rgba = TiffReader.DecodeRgba32(tiff, out var decodedWidth, out var decodedHeight);
+
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+
+        Assert.Equal(255, rgba[0]); // x=0, y=0 -> white
+        Assert.Equal(0, rgba[4]);   // x=1, y=0 -> black
+        Assert.Equal(255, rgba[32]); // x=8, y=0 -> white
+        Assert.Equal(0, rgba[36]);   // x=9, y=0 -> black
+
+        var row1 = width * 4;
+        Assert.Equal(0, rgba[row1 + 0]); // x=0, y=1 -> black
+        Assert.Equal(255, rgba[row1 + 4]); // x=1, y=1 -> white
+    }
+}

--- a/CodeGlyphX.Tests/TiffDeflateEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffDeflateEncodeTests.cs
@@ -1,0 +1,31 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffDeflateEncodeTests {
+    [Fact]
+    public void Encode_Tiff_Deflate_RoundTrip() {
+        const int width = 4;
+        const int height = 3;
+        var rgba = new byte[width * height * 4];
+        for (var i = 0; i < rgba.Length; i += 4) {
+            rgba[i + 0] = 10;
+            rgba[i + 1] = 40;
+            rgba[i + 2] = 90;
+            rgba[i + 3] = 255;
+        }
+
+        using var ms = new System.IO.MemoryStream();
+        TiffWriter.WriteRgba32(ms, width, height, rgba, width * 4, rowsPerStrip: 1, compression: TiffCompression.Deflate);
+        var data = ms.ToArray();
+
+        Assert.True(TiffReader.TryDecodeRgba32(data, out var decoded, out var decodedWidth, out var decodedHeight));
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+        Assert.Equal(rgba.Length, decoded.Length);
+        Assert.Equal(10, decoded[0]);
+        Assert.Equal(40, decoded[1]);
+        Assert.Equal(90, decoded[2]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffLzwEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffLzwEncodeTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffLzwEncodeTests {
+    [Fact]
+    public void Encode_Tiff_Lzw_RoundTrip() {
+        const int width = 3;
+        const int height = 2;
+        var rgba = new byte[] {
+            0, 0, 0, 255,
+            255, 255, 255, 255,
+            255, 0, 0, 255,
+            0, 255, 0, 255,
+            0, 0, 255, 255,
+            128, 128, 128, 255
+        };
+
+        using var ms = new MemoryStream();
+        TiffWriter.WriteRgba32(ms, width, height, rgba, stride: width * 4, rowsPerStrip: 1, compression: TiffCompression.Lzw, usePredictor: true);
+        var encoded = ms.ToArray();
+        var decoded = TiffReader.DecodeRgba32(encoded, out var decodedWidth, out var decodedHeight);
+
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+        Assert.Equal(rgba, decoded);
+    }
+
+    [Fact]
+    public void Encode_Tiff_Lzw_Tiled_RoundTrip() {
+        const int width = 4;
+        const int height = 3;
+        var rgba = new byte[width * height * 4];
+        for (var i = 0; i < rgba.Length; i += 4) {
+            rgba[i + 0] = (byte)(i * 3);
+            rgba[i + 1] = (byte)(i * 5);
+            rgba[i + 2] = (byte)(i * 7);
+            rgba[i + 3] = 255;
+        }
+
+        using var ms = new MemoryStream();
+        TiffWriter.WriteRgba32Tiled(ms, width, height, rgba, stride: width * 4, tileWidth: 2, tileHeight: 2, compression: TiffCompression.Lzw, usePredictor: false);
+        var encoded = ms.ToArray();
+        var decoded = TiffReader.DecodeRgba32(encoded, out var decodedWidth, out var decodedHeight);
+
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+        Assert.Equal(rgba, decoded);
+    }
+}

--- a/CodeGlyphX.Tests/TiffMultiPageEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffMultiPageEncodeTests.cs
@@ -1,0 +1,99 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffMultiPageEncodeTests {
+    [Fact]
+    public void Encode_Tiff_MultiPage_RoundTrip() {
+        var page1 = new TiffRgba32Page(new byte[] { 255, 0, 0, 255 }, 1, 1, 4);
+        var page2 = new TiffRgba32Page(new byte[] { 0, 255, 0, 255 }, 1, 1, 4);
+
+        var tiff = TiffWriter.WriteRgba32Pages(page1, page2);
+        var pages = TiffReader.DecodePagesRgba32(tiff);
+
+        Assert.Equal(2, pages.Length);
+        Assert.Equal(255, pages[0].Rgba[0]);
+        Assert.Equal(0, pages[0].Rgba[1]);
+        Assert.Equal(0, pages[0].Rgba[2]);
+        Assert.Equal(255, pages[0].Rgba[3]);
+
+        Assert.Equal(0, pages[1].Rgba[0]);
+        Assert.Equal(255, pages[1].Rgba[1]);
+        Assert.Equal(0, pages[1].Rgba[2]);
+        Assert.Equal(255, pages[1].Rgba[3]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_MultiPage_DeflatePredictor_RoundTrip() {
+        var page1 = new TiffRgba32Page(new byte[] {
+            10, 20, 30, 255,
+            40, 50, 60, 255
+        }, 2, 1, 8);
+        var page2 = new TiffRgba32Page(new byte[] {
+            70, 80, 90, 255,
+            100, 110, 120, 255
+        }, 2, 1, 8);
+
+        var tiff = TiffWriter.WriteRgba32Pages(TiffCompression.Deflate, usePredictor: true, page1, page2);
+        var pages = TiffReader.DecodePagesRgba32(tiff);
+
+        Assert.Equal(2, pages.Length);
+        Assert.Equal(10, pages[0].Rgba[0]);
+        Assert.Equal(20, pages[0].Rgba[1]);
+        Assert.Equal(30, pages[0].Rgba[2]);
+        Assert.Equal(255, pages[0].Rgba[3]);
+
+        Assert.Equal(70, pages[1].Rgba[0]);
+        Assert.Equal(80, pages[1].Rgba[1]);
+        Assert.Equal(90, pages[1].Rgba[2]);
+        Assert.Equal(255, pages[1].Rgba[3]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_MultiPage_Strips_RoundTrip() {
+        var page1 = new TiffRgba32Page(new byte[] {
+            255, 0, 0, 255,
+            0, 255, 0, 255
+        }, 1, 2, 4);
+        var page2 = new TiffRgba32Page(new byte[] {
+            0, 0, 255, 255,
+            255, 255, 0, 255
+        }, 1, 2, 4);
+
+        var tiff = TiffWriter.WriteRgba32Pages(rowsPerStrip: 1, compression: TiffCompression.None, usePredictor: false, page1, page2);
+        var pages = TiffReader.DecodePagesRgba32(tiff);
+
+        Assert.Equal(2, pages.Length);
+        Assert.Equal(255, pages[0].Rgba[0]);
+        Assert.Equal(0, pages[0].Rgba[1]);
+        Assert.Equal(0, pages[0].Rgba[2]);
+
+        Assert.Equal(0, pages[1].Rgba[0]);
+        Assert.Equal(0, pages[1].Rgba[1]);
+        Assert.Equal(255, pages[1].Rgba[2]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_MultiPage_PackBits_Strips_RoundTrip() {
+        var page1 = new TiffRgba32Page(new byte[] {
+            10, 10, 10, 255, 10, 10, 10, 255,
+            20, 20, 20, 255, 20, 20, 20, 255
+        }, 2, 2, 8);
+        var page2 = new TiffRgba32Page(new byte[] {
+            30, 30, 30, 255, 30, 30, 30, 255,
+            40, 40, 40, 255, 40, 40, 40, 255
+        }, 2, 2, 8);
+
+        var tiff = TiffWriter.WriteRgba32Pages(rowsPerStrip: 1, compression: TiffCompression.PackBits, usePredictor: false, page1, page2);
+        var pages = TiffReader.DecodePagesRgba32(tiff);
+
+        Assert.Equal(2, pages.Length);
+        Assert.Equal(10, pages[0].Rgba[0]);
+        Assert.Equal(10, pages[0].Rgba[1]);
+        Assert.Equal(10, pages[0].Rgba[2]);
+        Assert.Equal(30, pages[1].Rgba[0]);
+        Assert.Equal(30, pages[1].Rgba[1]);
+        Assert.Equal(30, pages[1].Rgba[2]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffMultiPageTileEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffMultiPageTileEncodeTests.cs
@@ -1,0 +1,48 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffMultiPageTileEncodeTests {
+    [Fact]
+    public void Encode_Tiff_Tiled_MultiPage_RoundTrip() {
+        var page1 = new TiffRgba32Page(new byte[] {
+            255, 0, 0, 255,  0, 255, 0, 255
+        }, 2, 1, 8);
+        var page2 = new TiffRgba32Page(new byte[] {
+            0, 0, 255, 255,  255, 255, 0, 255
+        }, 2, 1, 8);
+
+        var tiff = TiffWriter.WriteRgba32PagesTiled(tileWidth: 2, tileHeight: 1, page1, page2);
+        var pages = TiffReader.DecodePagesRgba32(tiff);
+
+        Assert.Equal(2, pages.Length);
+        Assert.Equal(255, pages[0].Rgba[0]);
+        Assert.Equal(0, pages[0].Rgba[1]);
+        Assert.Equal(0, pages[0].Rgba[2]);
+        Assert.Equal(0, pages[1].Rgba[0]);
+        Assert.Equal(0, pages[1].Rgba[1]);
+        Assert.Equal(255, pages[1].Rgba[2]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_Tiled_MultiPage_Deflate_RoundTrip() {
+        var page1 = new TiffRgba32Page(new byte[] {
+            10, 20, 30, 255,  40, 50, 60, 255
+        }, 2, 1, 8);
+        var page2 = new TiffRgba32Page(new byte[] {
+            70, 80, 90, 255,  100, 110, 120, 255
+        }, 2, 1, 8);
+
+        var tiff = TiffWriter.WriteRgba32PagesTiled(tileWidth: 2, tileHeight: 1, compression: TiffCompression.Deflate, usePredictor: true, page1, page2);
+        var pages = TiffReader.DecodePagesRgba32(tiff);
+
+        Assert.Equal(2, pages.Length);
+        Assert.Equal(10, pages[0].Rgba[0]);
+        Assert.Equal(20, pages[0].Rgba[1]);
+        Assert.Equal(30, pages[0].Rgba[2]);
+        Assert.Equal(70, pages[1].Rgba[0]);
+        Assert.Equal(80, pages[1].Rgba[1]);
+        Assert.Equal(90, pages[1].Rgba[2]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffPackBitsEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffPackBitsEncodeTests.cs
@@ -1,0 +1,31 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffPackBitsEncodeTests {
+    [Fact]
+    public void Encode_Tiff_PackBits_RoundTrip() {
+        const int width = 4;
+        const int height = 2;
+        var rgba = new byte[width * height * 4];
+        for (var i = 0; i < rgba.Length; i += 4) {
+            rgba[i + 0] = 50;
+            rgba[i + 1] = 100;
+            rgba[i + 2] = 150;
+            rgba[i + 3] = 255;
+        }
+
+        using var ms = new System.IO.MemoryStream();
+        TiffWriter.WriteRgba32(ms, width, height, rgba, width * 4, rowsPerStrip: 1, compression: TiffCompression.PackBits);
+        var data = ms.ToArray();
+
+        Assert.True(TiffReader.TryDecodeRgba32(data, out var decoded, out var decodedWidth, out var decodedHeight));
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+        Assert.Equal(rgba.Length, decoded.Length);
+        Assert.Equal(50, decoded[0]);
+        Assert.Equal(100, decoded[1]);
+        Assert.Equal(150, decoded[2]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffPlanarDecodeTests.cs
+++ b/CodeGlyphX.Tests/TiffPlanarDecodeTests.cs
@@ -1,0 +1,135 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffPlanarDecodeTests {
+    [Fact]
+    public void Decode_Tiff_Planar_Rgb() {
+        var tiff = BuildPlanarRgbTiff();
+
+        var rgba = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(0x11, rgba[0]);
+        Assert.Equal(0x22, rgba[1]);
+        Assert.Equal(0x33, rgba[2]);
+        Assert.Equal(255, rgba[3]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_Planar_RoundTrip() {
+        var rgba = new byte[] { 10, 20, 30, 255 };
+        var tiff = TiffWriter.WriteRgba32Planar(width: 1, height: 1, rgba, stride: 4);
+
+        var decoded = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(1, width);
+        Assert.Equal(1, height);
+        Assert.Equal(10, decoded[0]);
+        Assert.Equal(20, decoded[1]);
+        Assert.Equal(30, decoded[2]);
+        Assert.Equal(255, decoded[3]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_Planar_Deflate_RoundTrip() {
+        var rgba = new byte[] { 1, 2, 3, 255, 4, 5, 6, 255 };
+        using var ms = new System.IO.MemoryStream();
+        TiffWriter.WriteRgba32Planar(
+            ms,
+            width: 2,
+            height: 1,
+            rgba,
+            stride: 8,
+            rowsPerStrip: 1,
+            compression: TiffCompression.Deflate,
+            usePredictor: true);
+        var tiff = ms.ToArray();
+
+        var decoded = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(2, width);
+        Assert.Equal(1, height);
+        Assert.Equal(1, decoded[0]);
+        Assert.Equal(2, decoded[1]);
+        Assert.Equal(3, decoded[2]);
+        Assert.Equal(4, decoded[4]);
+        Assert.Equal(5, decoded[5]);
+        Assert.Equal(6, decoded[6]);
+    }
+
+    private static byte[] BuildPlanarRgbTiff() {
+        const int entryCount = 10;
+        const int ifdSize = 2 + entryCount * 12 + 4;
+        const int headerSize = 8;
+        var bitsOffset = headerSize + ifdSize;
+        var stripOffsetsOffset = bitsOffset + 6;
+        var stripByteCountsOffset = stripOffsetsOffset + 12;
+        var dataOffset = stripByteCountsOffset + 12;
+
+        var data = new byte[dataOffset + 3];
+        WriteAscii(data, 0, "II");
+        WriteU16(data, 2, 42);
+        WriteU32(data, 4, headerSize);
+
+        WriteU16(data, headerSize, entryCount);
+        var entryBase = headerSize + 2;
+        var i = 0;
+        WriteEntry(data, entryBase + i++ * 12, tag: 256, type: 4, count: 1, value: 1); // width
+        WriteEntry(data, entryBase + i++ * 12, tag: 257, type: 4, count: 1, value: 1); // height
+        WriteEntry(data, entryBase + i++ * 12, tag: 258, type: 3, count: 3, value: bitsOffset); // bits per sample
+        WriteEntry(data, entryBase + i++ * 12, tag: 259, type: 3, count: 1, value: 1); // compression none
+        WriteEntry(data, entryBase + i++ * 12, tag: 262, type: 3, count: 1, value: 2); // photometric RGB
+        WriteEntry(data, entryBase + i++ * 12, tag: 273, type: 4, count: 3, value: stripOffsetsOffset); // strip offsets
+        WriteEntry(data, entryBase + i++ * 12, tag: 277, type: 3, count: 1, value: 3); // samples per pixel
+        WriteEntry(data, entryBase + i++ * 12, tag: 278, type: 4, count: 1, value: 1); // rows per strip
+        WriteEntry(data, entryBase + i++ * 12, tag: 279, type: 4, count: 3, value: stripByteCountsOffset); // strip byte counts
+        WriteEntry(data, entryBase + i++ * 12, tag: 284, type: 3, count: 1, value: 2); // planar configuration separate
+
+        WriteU32(data, entryBase + entryCount * 12, 0); // next IFD
+
+        WriteU16(data, bitsOffset + 0, 8);
+        WriteU16(data, bitsOffset + 2, 8);
+        WriteU16(data, bitsOffset + 4, 8);
+
+        WriteU32(data, stripOffsetsOffset + 0, dataOffset);
+        WriteU32(data, stripOffsetsOffset + 4, dataOffset + 1);
+        WriteU32(data, stripOffsetsOffset + 8, dataOffset + 2);
+
+        WriteU32(data, stripByteCountsOffset + 0, 1);
+        WriteU32(data, stripByteCountsOffset + 4, 1);
+        WriteU32(data, stripByteCountsOffset + 8, 1);
+
+        data[dataOffset + 0] = 0x11; // R
+        data[dataOffset + 1] = 0x22; // G
+        data[dataOffset + 2] = 0x33; // B
+
+        return data;
+    }
+
+    private static void WriteEntry(byte[] buffer, int offset, ushort tag, ushort type, uint count, int value) {
+        WriteU16(buffer, offset, tag);
+        WriteU16(buffer, offset + 2, type);
+        WriteU32(buffer, offset + 4, count);
+        WriteU32(buffer, offset + 8, value);
+    }
+
+    private static void WriteAscii(byte[] buffer, int offset, string value) {
+        buffer[offset] = (byte)value[0];
+        buffer[offset + 1] = (byte)value[1];
+    }
+
+    private static void WriteU16(byte[] buffer, int offset, int value) {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+    }
+
+    private static void WriteU32(byte[] buffer, int offset, int value) {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+        buffer[offset + 2] = (byte)((value >> 16) & 0xFF);
+        buffer[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+}

--- a/CodeGlyphX.Tests/TiffPredictorEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffPredictorEncodeTests.cs
@@ -1,0 +1,34 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffPredictorEncodeTests {
+    [Fact]
+    public void Encode_Tiff_Predictor_Deflate_RoundTrip() {
+        const int width = 5;
+        const int height = 2;
+        var rgba = new byte[width * height * 4];
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                var idx = (y * width + x) * 4;
+                rgba[idx + 0] = (byte)(x * 30);
+                rgba[idx + 1] = (byte)(y * 40);
+                rgba[idx + 2] = (byte)(x * 20);
+                rgba[idx + 3] = 255;
+            }
+        }
+
+        using var ms = new System.IO.MemoryStream();
+        TiffWriter.WriteRgba32(ms, width, height, rgba, width * 4, rowsPerStrip: 1, compression: TiffCompression.Deflate, usePredictor: true);
+        var data = ms.ToArray();
+
+        Assert.True(TiffReader.TryDecodeRgba32(data, out var decoded, out var decodedWidth, out var decodedHeight));
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+        Assert.Equal(rgba.Length, decoded.Length);
+        Assert.Equal(rgba[0], decoded[0]);
+        Assert.Equal(rgba[1], decoded[1]);
+        Assert.Equal(rgba[2], decoded[2]);
+    }
+}

--- a/CodeGlyphX.Tests/TiffStripEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffStripEncodeTests.cs
@@ -1,0 +1,50 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffStripEncodeTests {
+    [Fact]
+    public void Encode_Tiff_Uses_Multiple_Strips() {
+        const int width = 3;
+        const int height = 3;
+        var rgba = new byte[width * height * 4];
+        for (var i = 0; i < rgba.Length; i += 4) {
+            rgba[i + 0] = 10;
+            rgba[i + 1] = 20;
+            rgba[i + 2] = 30;
+            rgba[i + 3] = 255;
+        }
+
+        using var ms = new System.IO.MemoryStream();
+        TiffWriter.WriteRgba32(ms, width, height, rgba, width * 4, rowsPerStrip: 1);
+        var data = ms.ToArray();
+
+        var ifdOffset = ReadU32(data, 4);
+        var entryCount = ReadU16(data, (int)ifdOffset);
+        var entriesOffset = (int)ifdOffset + 2;
+        var stripCount = 0u;
+        for (var i = 0; i < entryCount; i++) {
+            var entryOffset = entriesOffset + i * 12;
+            var tag = ReadU16(data, entryOffset);
+            if (tag == 273) {
+                stripCount = ReadU32(data, entryOffset + 4);
+                break;
+            }
+        }
+
+        Assert.Equal((uint)height, stripCount);
+        Assert.True(TiffReader.TryDecodeRgba32(data, out var decoded, out var decodedWidth, out var decodedHeight));
+        Assert.Equal(width, decodedWidth);
+        Assert.Equal(height, decodedHeight);
+        Assert.Equal(rgba.Length, decoded.Length);
+    }
+
+    private static ushort ReadU16(byte[] data, int offset) {
+        return (ushort)(data[offset] | (data[offset + 1] << 8));
+    }
+
+    private static uint ReadU32(byte[] data, int offset) {
+        return (uint)(data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24));
+    }
+}

--- a/CodeGlyphX.Tests/TiffTileEncodeTests.cs
+++ b/CodeGlyphX.Tests/TiffTileEncodeTests.cs
@@ -1,0 +1,52 @@
+using CodeGlyphX.Rendering.Tiff;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class TiffTileEncodeTests {
+    [Fact]
+    public void Encode_Tiff_Tiled_Uncompressed_RoundTrip() {
+        var rgba = new byte[] {
+            255, 0, 0, 255,   0, 255, 0, 255,   0, 0, 255, 255,
+            10, 20, 30, 255,  40, 50, 60, 255,  70, 80, 90, 255
+        };
+        var tiff = TiffWriter.WriteRgba32Tiled(width: 3, height: 2, rgba, stride: 12, tileWidth: 2, tileHeight: 2);
+        var decoded = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(3, width);
+        Assert.Equal(2, height);
+        Assert.Equal(255, decoded[0]);
+        Assert.Equal(0, decoded[1]);
+        Assert.Equal(0, decoded[2]);
+        Assert.Equal(10, decoded[12]);
+        Assert.Equal(20, decoded[13]);
+        Assert.Equal(30, decoded[14]);
+    }
+
+    [Fact]
+    public void Encode_Tiff_Tiled_DeflatePredictor_RoundTrip() {
+        var rgba = new byte[] {
+            255, 255, 255, 255,  0, 0, 0, 255,
+            0, 0, 0, 255,        255, 255, 255, 255
+        };
+        var tiff = TiffWriter.WriteRgba32Tiled(
+            width: 2,
+            height: 2,
+            rgba,
+            stride: 8,
+            tileWidth: 2,
+            tileHeight: 2,
+            compression: TiffCompression.Deflate,
+            usePredictor: true);
+        var decoded = TiffReader.DecodeRgba32(tiff, out var width, out var height);
+
+        Assert.Equal(2, width);
+        Assert.Equal(2, height);
+        Assert.Equal(255, decoded[0]);
+        Assert.Equal(255, decoded[1]);
+        Assert.Equal(255, decoded[2]);
+        Assert.Equal(0, decoded[4]);
+        Assert.Equal(0, decoded[5]);
+        Assert.Equal(0, decoded[6]);
+    }
+}

--- a/CodeGlyphX.Tests/WebpAnimationAlphaDecodeTests.cs
+++ b/CodeGlyphX.Tests/WebpAnimationAlphaDecodeTests.cs
@@ -1,0 +1,23 @@
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class WebpAnimationAlphaDecodeTests {
+    [Fact]
+    public void Decode_Webp_Animation_Preserves_Alpha() {
+        var rgba = new byte[] {
+            10, 20, 30, 0,     40, 50, 60, 255,
+            70, 80, 90, 255,   100, 110, 120, 255
+        };
+        var frame = new WebpAnimationFrame(rgba, width: 2, height: 2, stride: 8, durationMs: 100);
+        var webp = WebpWriter.WriteAnimationRgba32Lossy(2, 2, new[] { frame }, options: default, quality: 60);
+
+        var frames = WebpReader.DecodeAnimationFrames(webp, out var width, out var height, out _);
+
+        Assert.Equal(2, width);
+        Assert.Equal(2, height);
+        Assert.Single(frames);
+        Assert.Equal(0, frames[0].Rgba[3]);
+    }
+}

--- a/CodeGlyphX.Tests/WebpAnimationRenderTests.cs
+++ b/CodeGlyphX.Tests/WebpAnimationRenderTests.cs
@@ -1,0 +1,50 @@
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class WebpAnimationRenderTests {
+    [Fact]
+    public void Render_Webp_Animation_From_Matrix_Frames() {
+        var frame1 = new BitMatrix(2, 2);
+        frame1[0, 0] = true;
+        frame1[1, 1] = true;
+
+        var frame2 = new BitMatrix(2, 2);
+        frame2[0, 1] = true;
+        frame2[1, 0] = true;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0
+        };
+
+        var webp = MatrixWebpRenderer.RenderAnimation(new[] { frame1, frame2 }, opts, durationMs: 50, quality: 80);
+        var frames = WebpReader.DecodeAnimationFrames(webp, out var width, out var height, out _);
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(2, width);
+        Assert.Equal(2, height);
+    }
+
+    [Fact]
+    public void Render_Webp_Animation_With_Durations() {
+        var frame1 = new BitMatrix(1, 1);
+        frame1[0, 0] = true;
+        var frame2 = new BitMatrix(1, 1);
+        frame2[0, 0] = false;
+
+        var opts = new MatrixPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0
+        };
+
+        var webp = MatrixWebpRenderer.RenderAnimation(new[] { frame1, frame2 }, opts, new[] { 40, 80 }, quality: 100);
+        var frames = WebpReader.DecodeAnimationFrames(webp, out _, out _, out _);
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal(40, frames[0].DurationMs);
+        Assert.Equal(80, frames[1].DurationMs);
+    }
+}

--- a/CodeGlyphX.Tests/WebpDimensionsFallbackTests.cs
+++ b/CodeGlyphX.Tests/WebpDimensionsFallbackTests.cs
@@ -1,0 +1,51 @@
+using CodeGlyphX.Rendering.Webp;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class WebpDimensionsFallbackTests {
+    [Fact]
+    public void TryReadDimensions_Uses_Anmf_When_No_Vp8x() {
+        var data = BuildAnmfOnlyContainer(width: 10, height: 12);
+
+        Assert.True(WebpReader.TryReadDimensions(data, out var width, out var height));
+        Assert.Equal(10, width);
+        Assert.Equal(12, height);
+    }
+
+    private static byte[] BuildAnmfOnlyContainer(int width, int height) {
+        var payload = new byte[16];
+        WriteU24LE(payload, 6, width - 1);
+        WriteU24LE(payload, 9, height - 1);
+
+        var totalSize = 12 + 8 + payload.Length;
+        var data = new byte[totalSize];
+        WriteFourCc(data, 0, "RIFF");
+        WriteU32LE(data, 4, totalSize - 8);
+        WriteFourCc(data, 8, "WEBP");
+        WriteFourCc(data, 12, "ANMF");
+        WriteU32LE(data, 16, payload.Length);
+        Buffer.BlockCopy(payload, 0, data, 20, payload.Length);
+        return data;
+    }
+
+    private static void WriteFourCc(byte[] buffer, int offset, string fourCc) {
+        buffer[offset] = (byte)fourCc[0];
+        buffer[offset + 1] = (byte)fourCc[1];
+        buffer[offset + 2] = (byte)fourCc[2];
+        buffer[offset + 3] = (byte)fourCc[3];
+    }
+
+    private static void WriteU24LE(byte[] buffer, int offset, int value) {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+        buffer[offset + 2] = (byte)((value >> 16) & 0xFF);
+    }
+
+    private static void WriteU32LE(byte[] buffer, int offset, int value) {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+        buffer[offset + 2] = (byte)((value >> 16) & 0xFF);
+        buffer[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+}

--- a/CodeGlyphX.Website/Pages/Docs.razor
+++ b/CodeGlyphX.Website/Pages/Docs.razor
@@ -587,7 +587,7 @@ QR.Save(QrPayloads.OneTimePassword(
                         <td style="padding: 0.75rem;"><code>.webp</code></td>
                         <td style="padding: 0.75rem;">Yes</td>
                         <td style="padding: 0.75rem;">Yes</td>
-                        <td style="padding: 0.75rem;">Managed VP8/VP8L; ImageReader returns first frame for animations</td>
+                        <td style="padding: 0.75rem;">Managed VP8/VP8L; ImageReader returns first animation frame (use WebpReader/ImageReader multi-frame helpers); animation via WebpWriter or Webp renderers RenderAnimation</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">BMP</td>
@@ -599,16 +599,23 @@ QR.Save(QrPayloads.OneTimePassword(
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">GIF</td>
                         <td style="padding: 0.75rem;"><code>.gif</code></td>
-                        <td style="padding: 0.75rem;">No</td>
                         <td style="padding: 0.75rem;">Yes</td>
-                        <td style="padding: 0.75rem;">First frame only, transparency via GCE</td>
+                        <td style="padding: 0.75rem;">Yes</td>
+                        <td style="padding: 0.75rem;">Single-frame encode (indexed, 256 colors max; quantizes + dithers if needed); animation via GifReader/GifWriter.WriteAnimation or GIF renderers RenderAnimation (diff-cropped)</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">TIFF</td>
                         <td style="padding: 0.75rem;"><code>.tif</code>, <code>.tiff</code></td>
+                        <td style="padding: 0.75rem;">Yes</td>
+                        <td style="padding: 0.75rem;">Yes</td>
+                        <td style="padding: 0.75rem;">Baseline RGBA encode (multi-page via TiffWriter.WriteRgba32Pages; tiled multi-page via WriteRgba32PagesTiled; planar via WriteRgba32Planar; bilevel 1-bit via WriteBilevel/WriteBilevelFromRgba or RenderBilevel; direct matrix bilevel via RenderBilevelFromModules; direct barcode bilevel via RenderBilevelFromBars; tiled bilevel via WriteBilevelTiled/WriteBilevelTiledFromRgba or RenderBilevelTiled; tiled direct matrix bilevel via RenderBilevelTiledFromModules; tiled direct barcode bilevel via RenderBilevelTiledFromBars; strips via rowsPerStrip; tiles via WriteRgba32Tiled; PackBits/Deflate/LZW via TiffCompression; optional predictor via usePredictor); decode strips/tiles, planar config 1/2, PackBits/LZW/Deflate, 1/8/16-bit</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem;">PSD</td>
+                        <td style="padding: 0.75rem;"><code>.psd</code></td>
                         <td style="padding: 0.75rem;">No</td>
                         <td style="padding: 0.75rem;">Yes</td>
-                        <td style="padding: 0.75rem;">Baseline strips, PackBits/LZW/Deflate, 8/16-bit</td>
+                        <td style="padding: 0.75rem;">Flattened 8-bit grayscale/RGB; raw or RLE image data</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">PPM/PGM/PAM/PBM</td>
@@ -649,8 +656,8 @@ QR.Save(QrPayloads.OneTimePassword(
                         <td style="padding: 0.75rem;">PDF / EPS</td>
                         <td style="padding: 0.75rem;"><code>.pdf</code>, <code>.eps</code>, <code>.ps</code></td>
                         <td style="padding: 0.75rem;">Yes</td>
-                        <td style="padding: 0.75rem;">No</td>
-                        <td style="padding: 0.75rem;">Vector by default, raster via RenderMode</td>
+                        <td style="padding: 0.75rem;">Limited</td>
+                        <td style="padding: 0.75rem;">Vector by default, raster via RenderMode (PDF decode: image-only JPEG/Flate)</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">
                         <td style="padding: 0.75rem;">HTML</td>
@@ -999,10 +1006,10 @@ var decodeResult = QrImageDecoder.DecodeImage(stream);</pre>
 
             <h2>Known Gaps (Decoding)</h2>
             <ul style="color: var(--text-muted); margin-left: 1.5rem;">
-                <li>AVIF, HEIC, JPEG2000, PSD</li>
-                <li>Animated GIF (first frame only)</li>
-                <li>Multi-page / tiled TIFF and mixed sample sizes</li>
-                <li>PDF/PS decode (rasterize first)</li>
+                <li>AVIF, HEIC, JPEG2000</li>
+                <li>ImageReader.DecodeRgba32 returns the first GIF/WebP frame; use ImageReader.DecodeGifAnimationFrames / DecodeWebpAnimationFrames (or GifReader/WebpReader) for animation frames</li>
+                <li>ImageReader.DecodeRgba32 returns the first TIFF page; use ImageReader.TryDecodeTiffPagesRgba32 (or TiffReader.DecodePagesRgba32) for multi-page</li>
+                <li>PDF decode supports image-only PDFs with embedded JPEG/Flate; PS decode still needs rasterization</li>
             </ul>
 
             <h2>Format Corpus (Optional)</h2>

--- a/CodeGlyphX/AztecCode.Render.cs
+++ b/CodeGlyphX/AztecCode.Render.cs
@@ -4,6 +4,7 @@ using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Ico;
 using CodeGlyphX.Rendering.Jpeg;
@@ -16,6 +17,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
@@ -53,10 +55,35 @@ public static partial class AztecCode {
             }
             case OutputFormat.Jpeg:
                 return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
-            case OutputFormat.Webp:
-                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, renderOptions?.WebpQuality ?? 100));
+            case OutputFormat.Webp: {
+                var quality = renderOptions?.WebpQuality ?? 100;
+                var extrasFrames = extras?.WebpFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var webp = durations is not null
+                        ? MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.WebpAnimationOptions ?? default, quality)
+                        : MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.WebpAnimationOptions ?? default, quality);
+                    return RenderedOutput.FromBinary(format, webp);
+                }
+                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
+            }
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
+            case OutputFormat.Gif: {
+                var extrasFrames = extras?.GifFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var gif = durations is not null
+                        ? MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.GifAnimationOptions ?? default)
+                        : MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.GifAnimationOptions ?? default);
+                    return RenderedOutput.FromBinary(format, gif);
+                }
+                return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));
+            }
+            case OutputFormat.Tiff:
+                return RenderedOutput.FromBinary(format, MatrixTiffRenderer.Render(modules, pngOptions));
             case OutputFormat.Ppm:
                 return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
             case OutputFormat.Pbm:

--- a/CodeGlyphX/Barcode.Render.cs
+++ b/CodeGlyphX/Barcode.Render.cs
@@ -3,6 +3,7 @@ using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Ico;
 using CodeGlyphX.Rendering.Jpeg;
@@ -15,6 +16,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
@@ -55,10 +57,35 @@ public static partial class Barcode {
             }
             case OutputFormat.Jpeg:
                 return RenderedOutput.FromBinary(format, BarcodeJpegRenderer.Render(barcode, opts, options?.JpegQuality ?? 90));
-            case OutputFormat.Webp:
-                return RenderedOutput.FromBinary(format, BarcodeWebpRenderer.Render(barcode, opts, options?.WebpQuality ?? 100));
+            case OutputFormat.Webp: {
+                var quality = options?.WebpQuality ?? 100;
+                var extrasFrames = extras?.BarcodeWebpFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var webp = durations is not null
+                        ? BarcodeWebpRenderer.RenderAnimation(extrasFrames, opts, durations, extras?.WebpAnimationOptions ?? default, quality)
+                        : BarcodeWebpRenderer.RenderAnimation(extrasFrames, opts, duration, extras?.WebpAnimationOptions ?? default, quality);
+                    return RenderedOutput.FromBinary(format, webp);
+                }
+                return RenderedOutput.FromBinary(format, BarcodeWebpRenderer.Render(barcode, opts, quality));
+            }
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, BarcodeBmpRenderer.Render(barcode, opts));
+            case OutputFormat.Gif: {
+                var extrasFrames = extras?.BarcodeGifFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var gif = durations is not null
+                        ? BarcodeGifRenderer.RenderAnimation(extrasFrames, opts, durations, extras?.GifAnimationOptions ?? default)
+                        : BarcodeGifRenderer.RenderAnimation(extrasFrames, opts, duration, extras?.GifAnimationOptions ?? default);
+                    return RenderedOutput.FromBinary(format, gif);
+                }
+                return RenderedOutput.FromBinary(format, BarcodeGifRenderer.Render(barcode, opts));
+            }
+            case OutputFormat.Tiff:
+                return RenderedOutput.FromBinary(format, BarcodeTiffRenderer.Render(barcode, opts));
             case OutputFormat.Ppm:
                 return RenderedOutput.FromBinary(format, BarcodePpmRenderer.Render(barcode, opts));
             case OutputFormat.Pbm:

--- a/CodeGlyphX/CodeGlyph.IO.cs
+++ b/CodeGlyphX/CodeGlyph.IO.cs
@@ -431,7 +431,7 @@ public static partial class CodeGlyph {
     /// </summary>
     public static bool TryDecodeImage(byte[] image, out CodeGlyphDecoded decoded, CodeGlyphDecodeOptions? options) {
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
         return TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -441,7 +441,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeImage(byte[] image, out CodeGlyphDecoded decoded, out CodeGlyphDecodeDiagnostics diagnostics, CodeGlyphDecodeOptions? options) {
         diagnostics = new CodeGlyphDecodeDiagnostics();
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) {
             decoded = null!;
             SetFailure(diagnostics, DecodeFailureReason.UnsupportedFormat, "Unsupported image format.");
             return false;
@@ -484,7 +484,7 @@ public static partial class CodeGlyph {
             if (token.IsCancellationRequested) {
                 return new DecodeResult<CodeGlyphDecoded>(DecodeFailureReason.Cancelled, info, stopwatch.Elapsed);
             }
-            if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) {
+            if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) {
                 var imageFailure = DecodeResultHelpers.FailureForImageRead(image, formatKnown, token);
                 return new DecodeResult<CodeGlyphDecoded>(imageFailure, info, stopwatch.Elapsed);
             }
@@ -515,7 +515,7 @@ public static partial class CodeGlyph {
     /// </summary>
     public static bool TryDecodeAllImage(byte[] image, out CodeGlyphDecoded[] decoded, CodeGlyphDecodeOptions? options) {
         if (image is null) throw new ArgumentNullException(nameof(image));
-        if (!ImageReader.TryDecodeRgba32(image, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
+        if (!ImageReader.TryDecodeRgba32(image, options?.Image, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
         return TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -525,7 +525,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeImage(Stream stream, out CodeGlyphDecoded decoded, CodeGlyphDecodeOptions? options) {
         if (stream is null) throw new ArgumentNullException(nameof(stream));
         var data = RenderIO.ReadBinary(stream);
-        if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { decoded = null!; return false; }
+        if (!ImageReader.TryDecodeRgba32(data, options?.Image, out var rgba, out var width, out var height)) { decoded = null!; return false; }
         return TryDecode(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 
@@ -535,7 +535,7 @@ public static partial class CodeGlyph {
     public static bool TryDecodeAllImage(Stream stream, out CodeGlyphDecoded[] decoded, CodeGlyphDecodeOptions? options) {
         if (stream is null) throw new ArgumentNullException(nameof(stream));
         var data = RenderIO.ReadBinary(stream);
-        if (!ImageReader.TryDecodeRgba32(data, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
+        if (!ImageReader.TryDecodeRgba32(data, options?.Image, out var rgba, out var width, out var height)) { decoded = Array.Empty<CodeGlyphDecoded>(); return false; }
         return TryDecodeAll(rgba, width, height, width * 4, PixelFormat.Rgba32, out decoded, options);
     }
 

--- a/CodeGlyphX/DataMatrixCode.Render.cs
+++ b/CodeGlyphX/DataMatrixCode.Render.cs
@@ -4,6 +4,7 @@ using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Ico;
 using CodeGlyphX.Rendering.Jpeg;
@@ -16,6 +17,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
@@ -71,10 +73,35 @@ public static partial class DataMatrixCode {
             }
             case OutputFormat.Jpeg:
                 return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85));
-            case OutputFormat.Webp:
-                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, options?.WebpQuality ?? 100));
+            case OutputFormat.Webp: {
+                var quality = options?.WebpQuality ?? 100;
+                var extrasFrames = extras?.WebpFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var webp = durations is not null
+                        ? MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.WebpAnimationOptions ?? default, quality)
+                        : MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.WebpAnimationOptions ?? default, quality);
+                    return RenderedOutput.FromBinary(format, webp);
+                }
+                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
+            }
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
+            case OutputFormat.Gif: {
+                var extrasFrames = extras?.GifFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var gif = durations is not null
+                        ? MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.GifAnimationOptions ?? default)
+                        : MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.GifAnimationOptions ?? default);
+                    return RenderedOutput.FromBinary(format, gif);
+                }
+                return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));
+            }
+            case OutputFormat.Tiff:
+                return RenderedOutput.FromBinary(format, MatrixTiffRenderer.Render(modules, pngOptions));
             case OutputFormat.Ppm:
                 return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
             case OutputFormat.Pbm:

--- a/CodeGlyphX/Pdf417Code.Render.cs
+++ b/CodeGlyphX/Pdf417Code.Render.cs
@@ -4,6 +4,7 @@ using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Ico;
 using CodeGlyphX.Rendering.Jpeg;
@@ -16,6 +17,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
@@ -79,10 +81,35 @@ public static partial class Pdf417Code {
             }
             case OutputFormat.Jpeg:
                 return RenderedOutput.FromBinary(format, MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85));
-            case OutputFormat.Webp:
-                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, renderOptions?.WebpQuality ?? 100));
+            case OutputFormat.Webp: {
+                var quality = renderOptions?.WebpQuality ?? 100;
+                var extrasFrames = extras?.WebpFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var webp = durations is not null
+                        ? MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.WebpAnimationOptions ?? default, quality)
+                        : MatrixWebpRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.WebpAnimationOptions ?? default, quality);
+                    return RenderedOutput.FromBinary(format, webp);
+                }
+                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
+            }
             case OutputFormat.Bmp:
                 return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
+            case OutputFormat.Gif: {
+                var extrasFrames = extras?.GifFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var gif = durations is not null
+                        ? MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, durations, extras?.GifAnimationOptions ?? default)
+                        : MatrixGifRenderer.RenderAnimation(extrasFrames, pngOptions, duration, extras?.GifAnimationOptions ?? default);
+                    return RenderedOutput.FromBinary(format, gif);
+                }
+                return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));
+            }
+            case OutputFormat.Tiff:
+                return RenderedOutput.FromBinary(format, MatrixTiffRenderer.Render(modules, pngOptions));
             case OutputFormat.Ppm:
                 return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
             case OutputFormat.Pbm:

--- a/CodeGlyphX/Qr/QrPixelDecoder.Part2.cs
+++ b/CodeGlyphX/Qr/QrPixelDecoder.Part2.cs
@@ -9,6 +9,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using System.Threading;
 using CodeGlyphX;
+using CodeGlyphX.Internal;
 
 namespace CodeGlyphX.Qr;
 

--- a/CodeGlyphX/QrEasy.Render.Generic.cs
+++ b/CodeGlyphX/QrEasy.Render.Generic.cs
@@ -4,6 +4,7 @@ using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Ascii;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Html;
 using CodeGlyphX.Rendering.Ico;
 using CodeGlyphX.Rendering.Jpeg;
@@ -16,6 +17,7 @@ using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using CodeGlyphX.Rendering.Svgz;
 using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Webp;
 using CodeGlyphX.Rendering.Xbm;
 using CodeGlyphX.Rendering.Xpm;
@@ -71,11 +73,37 @@ public static partial class QrEasy {
             case OutputFormat.Webp: {
                 var render = BuildPngOptions(opts, qr);
                 var quality = opts.WebpQuality;
+                var extrasFrames = extras?.WebpFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var webp = durations is not null
+                        ? QrWebpRenderer.RenderAnimation(extrasFrames, render, durations, extras?.WebpAnimationOptions ?? default, quality)
+                        : QrWebpRenderer.RenderAnimation(extrasFrames, render, duration, extras?.WebpAnimationOptions ?? default, quality);
+                    return RenderedOutput.FromBinary(format, webp);
+                }
                 return RenderedOutput.FromBinary(format, QrWebpRenderer.Render(qr.Modules, render, quality));
             }
             case OutputFormat.Bmp: {
                 var render = BuildPngOptions(opts, qr);
                 return RenderedOutput.FromBinary(format, QrBmpRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Gif: {
+                var render = BuildPngOptions(opts, qr);
+                var extrasFrames = extras?.GifFrames;
+                if (extrasFrames is not null && extrasFrames.Length > 0) {
+                    var duration = extras?.AnimationDurationMs ?? 100;
+                    var durations = extras?.AnimationDurationsMs;
+                    var gif = durations is not null
+                        ? QrGifRenderer.RenderAnimation(extrasFrames, render, durations, extras?.GifAnimationOptions ?? default)
+                        : QrGifRenderer.RenderAnimation(extrasFrames, render, duration, extras?.GifAnimationOptions ?? default);
+                    return RenderedOutput.FromBinary(format, gif);
+                }
+                return RenderedOutput.FromBinary(format, QrGifRenderer.Render(qr.Modules, render));
+            }
+            case OutputFormat.Tiff: {
+                var render = BuildPngOptions(opts, qr);
+                return RenderedOutput.FromBinary(format, QrTiffRenderer.Render(qr.Modules, render));
             }
             case OutputFormat.Ppm: {
                 var render = BuildPngOptions(opts, qr);

--- a/CodeGlyphX/Rendering/Gif/BarcodeGifRenderer.cs
+++ b/CodeGlyphX/Rendering/Gif/BarcodeGifRenderer.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Gif;
+
+/// <summary>
+/// Renders 1D barcodes to a GIF image (indexed color).
+/// </summary>
+public static class BarcodeGifRenderer {
+    /// <summary>
+    /// Renders the barcode to a GIF byte array.
+    /// </summary>
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        return GifWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a GIF stream.
+    /// </summary>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        GifWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a GIF file.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
+        var gif = Render(barcode, opts);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a GIF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
+        var gif = Render(barcode, opts);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF from multiple barcode frames.
+    /// </summary>
+    public static byte[] RenderAnimation(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, GifAnimationOptions options = default) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (durationMs <= 0) throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+        var gifFrames = new GifAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var pixels = BarcodePngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            gifFrames[i] = new GifAnimationFrame(pixels, widthPx, heightPx, stride, durationMs);
+        }
+
+        return GifWriter.WriteAnimation(canvasWidth, canvasHeight, gifFrames, options);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF from multiple barcode frames with per-frame durations.
+    /// </summary>
+    public static byte[] RenderAnimation(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, GifAnimationOptions options = default) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (durationsMs is null) throw new ArgumentNullException(nameof(durationsMs));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (frames.Length != durationsMs.Length) throw new ArgumentException("Durations must match frame count.", nameof(durationsMs));
+
+        var gifFrames = new GifAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var duration = durationsMs[i];
+            if (duration <= 0) throw new ArgumentOutOfRangeException(nameof(durationsMs));
+            var pixels = BarcodePngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            gifFrames[i] = new GifAnimationFrame(pixels, widthPx, heightPx, stride, duration);
+        }
+
+        return GifWriter.WriteAnimation(canvasWidth, canvasHeight, gifFrames, options);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a stream from multiple barcode frames.
+    /// </summary>
+    public static void RenderAnimationToStream(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, Stream stream, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        stream.Write(gif, 0, gif.Length);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a stream from multiple barcode frames with per-frame durations.
+    /// </summary>
+    public static void RenderAnimationToStream(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, Stream stream, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        stream.Write(gif, 0, gif.Length);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file from multiple barcode frames.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, string path, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file from multiple barcode frames with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, string path, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file under the specified directory.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, string directory, string fileName, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file under the specified directory with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, string directory, string fileName, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+}

--- a/CodeGlyphX/Rendering/Gif/GifAnimation.cs
+++ b/CodeGlyphX/Rendering/Gif/GifAnimation.cs
@@ -1,0 +1,115 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Gif;
+
+/// <summary>
+/// Describes a single RGBA32 frame for animated GIF decoding.
+/// </summary>
+public readonly struct GifAnimationFrame {
+    /// <summary>
+    /// Creates a GIF animation frame backed by an RGBA32 buffer.
+    /// </summary>
+    public GifAnimationFrame(
+        byte[] rgba,
+        int width,
+        int height,
+        int stride,
+        int durationMs,
+        int x = 0,
+        int y = 0,
+        GifDisposal disposal = GifDisposal.None) {
+        Rgba = rgba ?? throw new ArgumentNullException(nameof(rgba));
+        Width = width;
+        Height = height;
+        Stride = stride;
+        DurationMs = durationMs;
+        X = x;
+        Y = y;
+        Disposal = disposal;
+    }
+
+    /// <summary>
+    /// RGBA32 pixel buffer.
+    /// </summary>
+    public byte[] Rgba { get; }
+
+    /// <summary>
+    /// Frame width in pixels.
+    /// </summary>
+    public int Width { get; }
+
+    /// <summary>
+    /// Frame height in pixels.
+    /// </summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Frame stride in bytes.
+    /// </summary>
+    public int Stride { get; }
+
+    /// <summary>
+    /// Frame duration in milliseconds.
+    /// </summary>
+    public int DurationMs { get; }
+
+    /// <summary>
+    /// Frame X offset on the canvas.
+    /// </summary>
+    public int X { get; }
+
+    /// <summary>
+    /// Frame Y offset on the canvas.
+    /// </summary>
+    public int Y { get; }
+
+    /// <summary>
+    /// Disposal method for the frame.
+    /// </summary>
+    public GifDisposal Disposal { get; }
+}
+
+/// <summary>
+/// GIF disposal methods.
+/// </summary>
+public enum GifDisposal {
+    /// <summary>
+    /// No disposal specified.
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// Do not dispose (keep frame).
+    /// </summary>
+    DoNotDispose = 1,
+    /// <summary>
+    /// Restore to background.
+    /// </summary>
+    RestoreBackground = 2,
+    /// <summary>
+    /// Restore to previous.
+    /// </summary>
+    RestorePrevious = 3
+}
+
+/// <summary>
+/// Options extracted from an animated GIF.
+/// </summary>
+public readonly struct GifAnimationOptions {
+    /// <summary>
+    /// Creates animation options.
+    /// </summary>
+    public GifAnimationOptions(int loopCount, uint backgroundRgba) {
+        LoopCount = loopCount;
+        BackgroundRgba = backgroundRgba;
+    }
+
+    /// <summary>
+    /// Loop count (0 = infinite).
+    /// </summary>
+    public int LoopCount { get; }
+
+    /// <summary>
+    /// Background color in RGBA byte order.
+    /// </summary>
+    public uint BackgroundRgba { get; }
+}

--- a/CodeGlyphX/Rendering/Gif/GifReader.cs
+++ b/CodeGlyphX/Rendering/Gif/GifReader.cs
@@ -3,7 +3,7 @@ using System;
 namespace CodeGlyphX.Rendering.Gif;
 
 /// <summary>
-/// Decodes GIF images to RGBA buffers (first frame only).
+/// Decodes GIF images to RGBA buffers and animation frames.
 /// </summary>
 public static class GifReader {
     /// <summary>
@@ -145,10 +145,395 @@ public static class GifReader {
         return rgba;
     }
 
+    /// <summary>
+    /// Attempts to decode GIF animation frames (frame rectangles only).
+    /// </summary>
+    public static bool TryDecodeAnimationFrames(
+        ReadOnlySpan<byte> gif,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        try {
+            frames = DecodeAnimationFrames(gif, out canvasWidth, out canvasHeight, out options);
+            return true;
+        } catch (FormatException) {
+            frames = Array.Empty<GifAnimationFrame>();
+            canvasWidth = 0;
+            canvasHeight = 0;
+            options = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Decodes GIF animation frames (frame rectangles only).
+    /// </summary>
+    public static GifAnimationFrame[] DecodeAnimationFrames(
+        ReadOnlySpan<byte> gif,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        return DecodeAnimation(gif, composite: false, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode GIF animation frames composited onto the canvas.
+    /// </summary>
+    public static bool TryDecodeAnimationCanvasFrames(
+        ReadOnlySpan<byte> gif,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        try {
+            frames = DecodeAnimation(gif, composite: true, out canvasWidth, out canvasHeight, out options);
+            return true;
+        } catch (FormatException) {
+            frames = Array.Empty<GifAnimationFrame>();
+            canvasWidth = 0;
+            canvasHeight = 0;
+            options = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Decodes GIF animation frames composited onto the canvas.
+    /// </summary>
+    public static GifAnimationFrame[] DecodeAnimationCanvasFrames(
+        ReadOnlySpan<byte> gif,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        return DecodeAnimation(gif, composite: true, out canvasWidth, out canvasHeight, out options);
+    }
+
     internal static bool IsGif(ReadOnlySpan<byte> data) {
         if (data.Length < 6) return false;
         return data[0] == (byte)'G' && data[1] == (byte)'I' && data[2] == (byte)'F'
                && data[3] == (byte)'8' && (data[4] == (byte)'7' || data[4] == (byte)'9') && data[5] == (byte)'a';
+    }
+
+    private static GifAnimationFrame[] DecodeAnimation(
+        ReadOnlySpan<byte> gif,
+        bool composite,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (gif.Length < 13) throw new FormatException("Invalid GIF header.");
+        if (!IsGif(gif)) throw new FormatException("Invalid GIF signature.");
+
+        canvasWidth = ReadUInt16LE(gif, 6);
+        canvasHeight = ReadUInt16LE(gif, 8);
+        if (canvasWidth <= 0 || canvasHeight <= 0) throw new FormatException("Invalid GIF dimensions.");
+
+        var packed = gif[10];
+        var gctFlag = (packed & 0x80) != 0;
+        var gctSize = 1 << ((packed & 0x07) + 1);
+        var bgIndex = gif[11];
+
+        var offset = 13;
+        ReadOnlySpan<byte> globalTable = ReadOnlySpan<byte>.Empty;
+        if (gctFlag) {
+            var gctBytes = gctSize * 3;
+            if (offset + gctBytes > gif.Length) throw new FormatException("Truncated GIF color table.");
+            globalTable = gif.Slice(offset, gctBytes);
+            offset += gctBytes;
+        }
+
+        var bgR = (byte)0;
+        var bgG = (byte)0;
+        var bgB = (byte)0;
+        var bgA = (byte)0;
+        if (!globalTable.IsEmpty && bgIndex < gctSize) {
+            var p = bgIndex * 3;
+            bgR = globalTable[p + 0];
+            bgG = globalTable[p + 1];
+            bgB = globalTable[p + 2];
+            bgA = 255;
+        }
+        options = new GifAnimationOptions(loopCount: 0, backgroundRgba: (uint)(bgR | (bgG << 8) | (bgB << 16) | (bgA << 24)));
+
+        var frames = new System.Collections.Generic.List<GifAnimationFrame>();
+        byte[]? canvas = composite ? new byte[canvasWidth * canvasHeight * 4] : null;
+        if (canvas is not null) {
+            FillCanvas(canvas, bgR, bgG, bgB, bgA);
+        }
+
+        var delay = 0;
+        var hasTransparency = false;
+        var transparentIndex = -1;
+        var disposal = GifDisposal.None;
+
+        while (offset < gif.Length) {
+            var block = gif[offset++];
+            if (block == 0x3B) break;
+
+            if (block == 0x21) {
+                if (offset >= gif.Length) break;
+                var label = gif[offset++];
+                if (label == 0xF9) {
+                    if (offset + 5 > gif.Length) throw new FormatException("Invalid GIF GCE.");
+                    var blockSize = gif[offset++];
+                    if (blockSize != 4) {
+                        offset += blockSize;
+                    } else {
+                        var packedGce = gif[offset++];
+                        var transparentFlag = (packedGce & 0x01) != 0;
+                        disposal = (GifDisposal)((packedGce >> 2) & 0x07);
+                        delay = ReadUInt16LE(gif, offset) * 10;
+                        offset += 2;
+                        transparentIndex = gif[offset++];
+                        hasTransparency = transparentFlag;
+                    }
+                    if (offset < gif.Length && gif[offset] == 0) offset++;
+                    continue;
+                }
+
+                if (label == 0xFF) {
+                    var appBlock = ReadSubBlocks(gif, ref offset);
+                    if (TryReadLoopCount(appBlock, out var loopCount)) {
+                        options = new GifAnimationOptions(loopCount, options.BackgroundRgba);
+                    }
+                    continue;
+                }
+
+                SkipSubBlocks(gif, ref offset);
+                continue;
+            }
+
+            if (block != 0x2C) throw new FormatException("Unsupported GIF block.");
+
+            if (offset + 9 > gif.Length) throw new FormatException("Invalid GIF image descriptor.");
+            var left = ReadUInt16LE(gif, offset);
+            var top = ReadUInt16LE(gif, offset + 2);
+            var imgW = ReadUInt16LE(gif, offset + 4);
+            var imgH = ReadUInt16LE(gif, offset + 6);
+            var imgPacked = gif[offset + 8];
+            offset += 9;
+
+            var lctFlag = (imgPacked & 0x80) != 0;
+            var interlaced = (imgPacked & 0x40) != 0;
+            var lctSize = 1 << ((imgPacked & 0x07) + 1);
+
+            ReadOnlySpan<byte> colorTable = globalTable;
+            if (lctFlag) {
+                var lctBytes = lctSize * 3;
+                if (offset + lctBytes > gif.Length) throw new FormatException("Truncated GIF local color table.");
+                colorTable = gif.Slice(offset, lctBytes);
+                offset += lctBytes;
+            }
+            if (colorTable.IsEmpty) throw new FormatException("Missing GIF color table.");
+
+            if (offset >= gif.Length) throw new FormatException("Missing GIF image data.");
+            var minCodeSize = gif[offset++];
+            var imageData = ReadSubBlocks(gif, ref offset);
+            var pixels = new byte[imgW * imgH];
+            _ = LzwDecode(imageData, minCodeSize, pixels);
+
+            var durationMs = delay;
+            if (!composite) {
+                var frameRgba = new byte[imgW * imgH * 4];
+                if (!interlaced) {
+                    DecodeFrame(pixels, imgW, imgH, colorTable, hasTransparency, transparentIndex, frameRgba);
+                } else {
+                    var idx = 0;
+                    DecodeInterlaced(pixels, ref idx, imgW, imgH, colorTable, hasTransparency, transparentIndex, frameRgba);
+                }
+                frames.Add(new GifAnimationFrame(frameRgba, imgW, imgH, imgW * 4, durationMs, left, top, disposal));
+            } else {
+                if (canvas is null) throw new FormatException("GIF canvas buffer is missing.");
+                byte[]? restore = null;
+                if (disposal == GifDisposal.RestorePrevious) {
+                    restore = new byte[canvas.Length];
+                    Buffer.BlockCopy(canvas, 0, restore, 0, canvas.Length);
+                }
+
+                if (!interlaced) {
+                    ApplyFrame(pixels, imgW, imgH, left, top, canvasWidth, canvasHeight, colorTable, hasTransparency, transparentIndex, canvas);
+                } else {
+                    var idx = 0;
+                    ApplyInterlaced(pixels, ref idx, imgW, imgH, left, top, canvasWidth, canvasHeight, colorTable, hasTransparency, transparentIndex, canvas);
+                }
+
+                var composited = new byte[canvas.Length];
+                Buffer.BlockCopy(canvas, 0, composited, 0, canvas.Length);
+                frames.Add(new GifAnimationFrame(composited, canvasWidth, canvasHeight, canvasWidth * 4, durationMs, 0, 0, disposal));
+
+                if (disposal == GifDisposal.RestoreBackground) {
+                    ClearRect(canvas, canvasWidth, canvasHeight, left, top, imgW, imgH, bgR, bgG, bgB, bgA);
+                } else if (disposal == GifDisposal.RestorePrevious && restore is not null) {
+                    Buffer.BlockCopy(restore, 0, canvas, 0, canvas.Length);
+                }
+            }
+
+            delay = 0;
+            hasTransparency = false;
+            transparentIndex = -1;
+            disposal = GifDisposal.None;
+        }
+
+        return frames.ToArray();
+    }
+
+    private static void DecodeFrame(
+        byte[] pixels,
+        int imgW,
+        int imgH,
+        ReadOnlySpan<byte> colorTable,
+        bool hasTransparency,
+        int transparentIndex,
+        byte[] rgba) {
+        var idx = 0;
+        for (var y = 0; y < imgH; y++) {
+            var dstRow = y * imgW * 4;
+            for (var x = 0; x < imgW; x++) {
+                if (idx >= pixels.Length) return;
+                var colorIndex = pixels[idx++];
+                WriteColor(colorTable, colorIndex, hasTransparency, transparentIndex, rgba, dstRow + x * 4);
+            }
+        }
+    }
+
+    private static void DecodeInterlaced(
+        byte[] pixels,
+        ref int idx,
+        int imgW,
+        int imgH,
+        ReadOnlySpan<byte> colorTable,
+        bool hasTransparency,
+        int transparentIndex,
+        byte[] rgba) {
+        var starts = new[] { 0, 4, 2, 1 };
+        var steps = new[] { 8, 8, 4, 2 };
+        for (var pass = 0; pass < 4; pass++) {
+            for (var y = starts[pass]; y < imgH; y += steps[pass]) {
+                var dstRow = y * imgW * 4;
+                for (var x = 0; x < imgW; x++) {
+                    if (idx >= pixels.Length) return;
+                    var colorIndex = pixels[idx++];
+                    WriteColor(colorTable, colorIndex, hasTransparency, transparentIndex, rgba, dstRow + x * 4);
+                }
+            }
+        }
+    }
+
+    private static void ApplyFrame(
+        byte[] pixels,
+        int imgW,
+        int imgH,
+        int left,
+        int top,
+        int canvasW,
+        int canvasH,
+        ReadOnlySpan<byte> colorTable,
+        bool hasTransparency,
+        int transparentIndex,
+        byte[] canvas) {
+        var idx = 0;
+        for (var y = 0; y < imgH; y++) {
+            var dstY = top + y;
+            if ((uint)dstY >= (uint)canvasH) {
+                idx += imgW;
+                continue;
+            }
+            var dstRow = dstY * canvasW * 4;
+            var xBase = left * 4;
+            for (var x = 0; x < imgW; x++) {
+                if (idx >= pixels.Length) return;
+                var dstX = left + x;
+                var colorIndex = pixels[idx++];
+                if ((uint)dstX >= (uint)canvasW) continue;
+                WriteColorOver(colorTable, colorIndex, hasTransparency, transparentIndex, canvas, dstRow + xBase + x * 4);
+            }
+        }
+    }
+
+    private static void ApplyInterlaced(
+        byte[] pixels,
+        ref int idx,
+        int imgW,
+        int imgH,
+        int left,
+        int top,
+        int canvasW,
+        int canvasH,
+        ReadOnlySpan<byte> colorTable,
+        bool hasTransparency,
+        int transparentIndex,
+        byte[] canvas) {
+        var starts = new[] { 0, 4, 2, 1 };
+        var steps = new[] { 8, 8, 4, 2 };
+        for (var pass = 0; pass < 4; pass++) {
+            for (var y = starts[pass]; y < imgH; y += steps[pass]) {
+                var dstY = top + y;
+                if ((uint)dstY >= (uint)canvasH) {
+                    idx += imgW;
+                    continue;
+                }
+                var dstRow = dstY * canvasW * 4;
+                var xBase = left * 4;
+                for (var x = 0; x < imgW; x++) {
+                    if (idx >= pixels.Length) return;
+                    var dstX = left + x;
+                    var colorIndex = pixels[idx++];
+                    if ((uint)dstX >= (uint)canvasW) continue;
+                    WriteColorOver(colorTable, colorIndex, hasTransparency, transparentIndex, canvas, dstRow + xBase + x * 4);
+                }
+            }
+        }
+    }
+
+    private static void WriteColorOver(ReadOnlySpan<byte> table, int index, bool hasTransparency, int transparentIndex, byte[] rgba, int dst) {
+        if (hasTransparency && index == transparentIndex) return;
+        var p = index * 3;
+        if (p + 2 >= table.Length) return;
+        rgba[dst + 0] = table[p + 0];
+        rgba[dst + 1] = table[p + 1];
+        rgba[dst + 2] = table[p + 2];
+        rgba[dst + 3] = 255;
+    }
+
+    private static void FillCanvas(byte[] canvas, byte r, byte g, byte b, byte a) {
+        for (var i = 0; i < canvas.Length; i += 4) {
+            canvas[i + 0] = r;
+            canvas[i + 1] = g;
+            canvas[i + 2] = b;
+            canvas[i + 3] = a;
+        }
+    }
+
+    private static void ClearRect(byte[] canvas, int canvasW, int canvasH, int left, int top, int width, int height, byte r, byte g, byte b, byte a) {
+        for (var y = 0; y < height; y++) {
+            var dstY = top + y;
+            if ((uint)dstY >= (uint)canvasH) continue;
+            var dstRow = dstY * canvasW * 4;
+            for (var x = 0; x < width; x++) {
+                var dstX = left + x;
+                if ((uint)dstX >= (uint)canvasW) continue;
+                var dst = dstRow + dstX * 4;
+                canvas[dst + 0] = r;
+                canvas[dst + 1] = g;
+                canvas[dst + 2] = b;
+                canvas[dst + 3] = a;
+            }
+        }
+    }
+
+    private static bool TryReadLoopCount(ReadOnlySpan<byte> data, out int loopCount) {
+        loopCount = 0;
+        if (data.Length < 14) return false;
+        var identifier = System.Text.Encoding.ASCII.GetString(data.Slice(0, 8).ToArray());
+        var auth = System.Text.Encoding.ASCII.GetString(data.Slice(8, 3).ToArray());
+        if (!identifier.Equals("NETSCAPE", StringComparison.OrdinalIgnoreCase) || !auth.Equals("2.0", StringComparison.OrdinalIgnoreCase)) return false;
+        var pos = 11;
+        if (pos >= data.Length) return false;
+        var blockSize = data[pos++];
+        if (blockSize < 3 || pos + blockSize > data.Length) return false;
+        if (data[pos++] != 1) return false;
+        loopCount = data[pos] | (data[pos + 1] << 8);
+        return true;
     }
 
     private static void WriteInterlaced(

--- a/CodeGlyphX/Rendering/Gif/GifWriter.cs
+++ b/CodeGlyphX/Rendering/Gif/GifWriter.cs
@@ -1,0 +1,939 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CodeGlyphX.Rendering.Gif;
+
+/// <summary>
+/// Writes GIF images from RGBA buffers.
+/// </summary>
+public static class GifWriter {
+    /// <summary>
+    /// Writes a GIF byte array from an RGBA buffer (single frame).
+    /// </summary>
+    public static byte[] WriteRgba32(int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        using var ms = new MemoryStream();
+        WriteRgba32(ms, width, height, rgba, stride);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a GIF to a stream from an RGBA buffer (single frame).
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+
+        var indices = new byte[width * height];
+        BuildPalette(rgba, width, height, stride, indices, out var palette, out var hasTransparency, out var transparentIndex);
+
+        var colorTableSize = 1;
+        var colorTableBits = 0;
+        while (colorTableSize < palette.Count) {
+            colorTableSize <<= 1;
+            colorTableBits++;
+        }
+        if (colorTableSize < 2) {
+            colorTableSize = 2;
+            colorTableBits = 1;
+        }
+
+        var gctSizeField = colorTableBits - 1;
+        var colorResolution = colorTableBits - 1;
+        if (colorResolution < 0) colorResolution = 0;
+        if (colorResolution > 7) colorResolution = 7;
+        var packed = (byte)(0x80 | (colorResolution << 4) | gctSizeField);
+
+        stream.Write(GifHeader, 0, GifHeader.Length);
+        WriteUInt16(stream, (ushort)width);
+        WriteUInt16(stream, (ushort)height);
+        stream.WriteByte(packed);
+        stream.WriteByte(0); // background color index
+        stream.WriteByte(0); // pixel aspect ratio
+
+        WriteGlobalColorTable(stream, palette, colorTableSize);
+
+        if (hasTransparency) {
+            stream.WriteByte(0x21);
+            stream.WriteByte(0xF9);
+            stream.WriteByte(0x04);
+            stream.WriteByte(0x01); // transparency flag
+            WriteUInt16(stream, 0); // delay
+            stream.WriteByte((byte)transparentIndex);
+            stream.WriteByte(0);
+        }
+
+        stream.WriteByte(0x2C);
+        WriteUInt16(stream, 0);
+        WriteUInt16(stream, 0);
+        WriteUInt16(stream, (ushort)width);
+        WriteUInt16(stream, (ushort)height);
+        stream.WriteByte(0x00); // no local color table, not interlaced
+
+        var minCodeSize = Math.Max(2, colorTableBits);
+        stream.WriteByte((byte)minCodeSize);
+        var encoded = LzwEncode(indices, minCodeSize);
+        WriteSubBlocks(stream, encoded);
+
+        stream.WriteByte(0x3B);
+    }
+
+    /// <summary>
+    /// Writes a GIF animation byte array from RGBA frame buffers.
+    /// </summary>
+    public static byte[] WriteAnimation(int canvasWidth, int canvasHeight, GifAnimationFrame[] frames, GifAnimationOptions options = default) {
+        using var ms = new MemoryStream();
+        WriteAnimation(ms, canvasWidth, canvasHeight, frames, options);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a GIF animation to a stream from RGBA frame buffers.
+    /// </summary>
+    public static void WriteAnimation(Stream stream, int canvasWidth, int canvasHeight, GifAnimationFrame[] frames, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (canvasWidth <= 0) throw new ArgumentOutOfRangeException(nameof(canvasWidth));
+        if (canvasHeight <= 0) throw new ArgumentOutOfRangeException(nameof(canvasHeight));
+
+        for (var i = 0; i < frames.Length; i++) {
+            ValidateFrame(frames[i], canvasWidth, canvasHeight);
+        }
+
+        var backgroundRgba = options.BackgroundRgba;
+        var bgR = (byte)(backgroundRgba & 0xFF);
+        var bgG = (byte)((backgroundRgba >> 8) & 0xFF);
+        var bgB = (byte)((backgroundRgba >> 16) & 0xFF);
+        var bgA = (byte)((backgroundRgba >> 24) & 0xFF);
+
+        var optimizedFrames = OptimizeFramesForEncoding(frames, canvasWidth, canvasHeight, bgR, bgG, bgB, bgA);
+        var anyTransparency = FramesHaveTransparency(optimizedFrames);
+        var useGlobal = TryBuildGlobalPalette(optimizedFrames, bgR, bgG, bgB, bgA, anyTransparency, out var globalPalette, out var globalMap, out var globalTransparentIndex, out var backgroundIndex);
+
+        if (!useGlobal) {
+            globalPalette = BuildBackgroundPalette(bgR, bgG, bgB);
+            backgroundIndex = 0;
+            globalTransparentIndex = -1;
+            globalMap = null;
+        }
+
+        var gctSize = GetTableSize(globalPalette.Count);
+        var gctBits = GetTableBits(gctSize);
+        var packed = (byte)(0x80 | (ClampColorResolution(gctBits - 1) << 4) | (gctBits - 1));
+
+        stream.Write(GifHeader, 0, GifHeader.Length);
+        WriteUInt16(stream, (ushort)canvasWidth);
+        WriteUInt16(stream, (ushort)canvasHeight);
+        stream.WriteByte(packed);
+        stream.WriteByte((byte)backgroundIndex);
+        stream.WriteByte(0);
+
+        WriteGlobalColorTable(stream, globalPalette, gctSize);
+
+        if (optimizedFrames.Length > 1) {
+            WriteLoopExtension(stream, options.LoopCount);
+        }
+
+        for (var i = 0; i < optimizedFrames.Length; i++) {
+            var frame = optimizedFrames[i];
+            PaletteInfo paletteInfo;
+            var frameHasTransparency = FrameHasTransparency(frame);
+            if (useGlobal) {
+                paletteInfo = new PaletteInfo(globalPalette, globalMap!, gctSize, gctBits, anyTransparency, globalTransparentIndex, false, 0, 0, 0);
+            } else {
+                paletteInfo = BuildFramePalette(frame);
+            }
+
+            var hasTransparency = useGlobal ? frameHasTransparency : paletteInfo.HasTransparency;
+            var transparentIndex = paletteInfo.TransparentIndex;
+            var disposal = ClampDisposal(frame.Disposal);
+            var delay = frame.DurationMs < 0 ? 0 : (frame.DurationMs + 5) / 10;
+            if (delay > ushort.MaxValue) delay = ushort.MaxValue;
+
+            stream.WriteByte(0x21);
+            stream.WriteByte(0xF9);
+            stream.WriteByte(0x04);
+            var packedGce = (byte)(((int)disposal & 0x07) << 2);
+            if (hasTransparency) packedGce |= 0x01;
+            stream.WriteByte(packedGce);
+            WriteUInt16(stream, (ushort)delay);
+            stream.WriteByte((byte)(hasTransparency ? transparentIndex : 0));
+            stream.WriteByte(0);
+
+            stream.WriteByte(0x2C);
+            WriteUInt16(stream, (ushort)frame.X);
+            WriteUInt16(stream, (ushort)frame.Y);
+            WriteUInt16(stream, (ushort)frame.Width);
+            WriteUInt16(stream, (ushort)frame.Height);
+
+            if (!useGlobal) {
+                var lctPacked = (byte)(0x80 | (paletteInfo.TableBits - 1));
+                stream.WriteByte(lctPacked);
+                WriteGlobalColorTable(stream, paletteInfo.Colors, paletteInfo.TableSize);
+            } else {
+                stream.WriteByte(0x00);
+            }
+
+            var minCodeSize = Math.Max(2, paletteInfo.TableBits);
+            stream.WriteByte((byte)minCodeSize);
+
+            var indices = paletteInfo.IsQuantized
+                ? BuildFrameIndicesQuantized(frame, paletteInfo)
+                : BuildFrameIndices(frame, paletteInfo, useGlobal);
+            var encoded = LzwEncode(indices, minCodeSize);
+            WriteSubBlocks(stream, encoded);
+        }
+
+        stream.WriteByte(0x3B);
+    }
+
+    private static void BuildPalette(
+        ReadOnlySpan<byte> rgba,
+        int width,
+        int height,
+        int stride,
+        byte[] indices,
+        out List<int> palette,
+        out bool hasTransparency,
+        out int transparentIndex) {
+        hasTransparency = false;
+        transparentIndex = -1;
+        palette = new List<int>(256);
+        var lookup = new Dictionary<int, int>(256);
+        var nextIndex = 0;
+        var overflow = false;
+
+        for (var y = 0; y < height && !overflow; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var p = row + x * 4;
+                var r = rgba[p + 0];
+                var g = rgba[p + 1];
+                var b = rgba[p + 2];
+                var a = rgba[p + 3];
+                if (a < 128) {
+                    if (!hasTransparency) {
+                        hasTransparency = true;
+                        transparentIndex = 0;
+                        palette.Add(0);
+                        nextIndex = 1;
+                    }
+                    continue;
+                }
+
+                var key = (r << 16) | (g << 8) | b;
+                if (!lookup.TryGetValue(key, out _)) {
+                    if (palette.Count >= 256) {
+                        overflow = true;
+                        break;
+                    }
+                    lookup[key] = nextIndex++;
+                    palette.Add(key);
+                }
+            }
+        }
+
+        if (!overflow) {
+            FillIndicesExact(rgba, width, height, stride, indices, lookup, hasTransparency, transparentIndex);
+            if (palette.Count == 0) {
+                palette.Add(0);
+            }
+            return;
+        }
+
+        hasTransparency = HasTransparency(rgba, width, height, stride);
+        BuildUniformPalette(hasTransparency, out palette, out var rLevels, out var gLevels, out var bLevels, out transparentIndex);
+        FillIndicesQuantizedDithered(rgba, width, height, stride, indices, hasTransparency, rLevels, gLevels, bLevels, transparentIndex);
+    }
+
+    private static void ValidateFrame(GifAnimationFrame frame, int canvasWidth, int canvasHeight) {
+        if (frame.Width <= 0) throw new ArgumentOutOfRangeException(nameof(frame.Width));
+        if (frame.Height <= 0) throw new ArgumentOutOfRangeException(nameof(frame.Height));
+        if (frame.Stride < frame.Width * 4) throw new ArgumentOutOfRangeException(nameof(frame.Stride));
+        if (frame.Rgba.Length < (frame.Height - 1) * frame.Stride + frame.Width * 4) {
+            throw new ArgumentException("RGBA buffer is too small.", nameof(frame.Rgba));
+        }
+        if (frame.X < 0 || frame.Y < 0) throw new ArgumentOutOfRangeException(nameof(frame.X));
+        if (frame.X + frame.Width > canvasWidth || frame.Y + frame.Height > canvasHeight) {
+            throw new ArgumentOutOfRangeException(nameof(frame.Width), "Frame exceeds canvas bounds.");
+        }
+    }
+
+    private static GifAnimationFrame[] OptimizeFramesForEncoding(
+        GifAnimationFrame[] frames,
+        int canvasWidth,
+        int canvasHeight,
+        byte bgR,
+        byte bgG,
+        byte bgB,
+        byte bgA) {
+        var canvas = new byte[canvasWidth * canvasHeight * 4];
+        FillCanvas(canvas, bgR, bgG, bgB, bgA);
+        var optimized = new GifAnimationFrame[frames.Length];
+
+        for (var i = 0; i < frames.Length; i++) {
+            var frame = frames[i];
+            var disposal = ClampDisposal(frame.Disposal);
+            var allowCrop = disposal == GifDisposal.None || disposal == GifDisposal.DoNotDispose || disposal == GifDisposal.RestoreBackground || disposal == GifDisposal.RestorePrevious;
+
+            GifAnimationFrame output;
+            if (allowCrop && TryComputeDiffBounds(canvas, canvasWidth, canvasHeight, frame, disposal == GifDisposal.RestoreBackground, bgR, bgG, bgB, bgA, out var minX, out var minY, out var maxX, out var maxY)) {
+                output = CropFrame(frame, minX, minY, maxX, maxY);
+            } else if (allowCrop) {
+                output = new GifAnimationFrame(new byte[] { 0, 0, 0, 0 }, 1, 1, 4, frame.DurationMs, 0, 0, frame.Disposal);
+            } else {
+                output = frame;
+            }
+
+            if (disposal != GifDisposal.RestorePrevious) {
+                ApplyFrameToCanvas(canvas, canvasWidth, canvasHeight, output);
+                if (disposal == GifDisposal.RestoreBackground) {
+                    ClearRect(canvas, canvasWidth, canvasHeight, output.X, output.Y, output.Width, output.Height, bgR, bgG, bgB, bgA);
+                }
+            }
+
+            optimized[i] = output;
+        }
+
+        return optimized;
+    }
+
+    private static bool TryComputeDiffBounds(
+        byte[] canvas,
+        int canvasWidth,
+        int canvasHeight,
+        GifAnimationFrame frame,
+        bool considerBackgroundRestore,
+        byte bgR,
+        byte bgG,
+        byte bgB,
+        byte bgA,
+        out int minX,
+        out int minY,
+        out int maxX,
+        out int maxY) {
+        minX = frame.Width;
+        minY = frame.Height;
+        maxX = -1;
+        maxY = -1;
+
+        for (var y = 0; y < frame.Height; y++) {
+            var row = y * frame.Stride;
+            var dstY = frame.Y + y;
+            if ((uint)dstY >= (uint)canvasHeight) continue;
+            var canvasRow = dstY * canvasWidth * 4;
+            for (var x = 0; x < frame.Width; x++) {
+                var p = row + x * 4;
+                var a = frame.Rgba[p + 3];
+                if (a < 128) continue;
+                var dstX = frame.X + x;
+                if ((uint)dstX >= (uint)canvasWidth) continue;
+                var dst = canvasRow + dstX * 4;
+                if (frame.Rgba[p + 0] == canvas[dst + 0]
+                    && frame.Rgba[p + 1] == canvas[dst + 1]
+                    && frame.Rgba[p + 2] == canvas[dst + 2]
+                    && a == canvas[dst + 3]) {
+                    continue;
+                }
+                if (x < minX) minX = x;
+                if (y < minY) minY = y;
+                if (x > maxX) maxX = x;
+                if (y > maxY) maxY = y;
+            }
+        }
+
+        if (!considerBackgroundRestore || maxX < minX || maxY < minY) {
+            return maxX >= minX && maxY >= minY;
+        }
+
+        var rectMinX = minX;
+        var rectMinY = minY;
+        var rectMaxX = maxX;
+        var rectMaxY = maxY;
+
+        for (var y = 0; y < frame.Height; y++) {
+            var row = y * frame.Stride;
+            var dstY = frame.Y + y;
+            if ((uint)dstY >= (uint)canvasHeight) continue;
+            var canvasRow = dstY * canvasWidth * 4;
+            for (var x = 0; x < frame.Width; x++) {
+                var p = row + x * 4;
+                var a = frame.Rgba[p + 3];
+                if (a >= 128) continue;
+                var dstX = frame.X + x;
+                if ((uint)dstX >= (uint)canvasWidth) continue;
+                var dst = canvasRow + dstX * 4;
+                if (canvas[dst + 0] == bgR && canvas[dst + 1] == bgG && canvas[dst + 2] == bgB && canvas[dst + 3] == bgA) {
+                    continue;
+                }
+                if (x < rectMinX) rectMinX = x;
+                if (y < rectMinY) rectMinY = y;
+                if (x > rectMaxX) rectMaxX = x;
+                if (y > rectMaxY) rectMaxY = y;
+            }
+        }
+
+        minX = rectMinX;
+        minY = rectMinY;
+        maxX = rectMaxX;
+        maxY = rectMaxY;
+
+        return maxX >= minX && maxY >= minY;
+    }
+
+    private static GifAnimationFrame CropFrame(GifAnimationFrame frame, int minX, int minY, int maxX, int maxY) {
+        var width = maxX - minX + 1;
+        var height = maxY - minY + 1;
+        if (width <= 0 || height <= 0) {
+            return new GifAnimationFrame(new byte[] { 0, 0, 0, 0 }, 1, 1, 4, frame.DurationMs, 0, 0, frame.Disposal);
+        }
+        if (width == frame.Width && height == frame.Height && minX == 0 && minY == 0) return frame;
+
+        var cropped = new byte[width * height * 4];
+        for (var y = 0; y < height; y++) {
+            var srcRow = (minY + y) * frame.Stride;
+            var srcOffset = srcRow + minX * 4;
+            var dstRow = y * width * 4;
+            Buffer.BlockCopy(frame.Rgba, srcOffset, cropped, dstRow, width * 4);
+        }
+        return new GifAnimationFrame(cropped, width, height, width * 4, frame.DurationMs, frame.X + minX, frame.Y + minY, frame.Disposal);
+    }
+
+    private static void ApplyFrameToCanvas(byte[] canvas, int canvasWidth, int canvasHeight, GifAnimationFrame frame) {
+        for (var y = 0; y < frame.Height; y++) {
+            var srcRow = y * frame.Stride;
+            var dstY = frame.Y + y;
+            if ((uint)dstY >= (uint)canvasHeight) continue;
+            var dstRow = dstY * canvasWidth * 4;
+            for (var x = 0; x < frame.Width; x++) {
+                var src = srcRow + x * 4;
+                var a = frame.Rgba[src + 3];
+                if (a < 128) continue;
+                var dstX = frame.X + x;
+                if ((uint)dstX >= (uint)canvasWidth) continue;
+                var dst = dstRow + dstX * 4;
+                canvas[dst + 0] = frame.Rgba[src + 0];
+                canvas[dst + 1] = frame.Rgba[src + 1];
+                canvas[dst + 2] = frame.Rgba[src + 2];
+                canvas[dst + 3] = a;
+            }
+        }
+    }
+
+    private static bool FramesHaveTransparency(GifAnimationFrame[] frames) {
+        for (var i = 0; i < frames.Length; i++) {
+            if (FrameHasTransparency(frames[i])) return true;
+        }
+        return false;
+    }
+
+    private static bool FrameHasTransparency(GifAnimationFrame frame) {
+        for (var y = 0; y < frame.Height; y++) {
+            var row = y * frame.Stride;
+            for (var x = 0; x < frame.Width; x++) {
+                if (frame.Rgba[row + x * 4 + 3] < 128) return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasTransparency(ReadOnlySpan<byte> rgba, int width, int height, int stride) {
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                if (rgba[row + x * 4 + 3] < 128) return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool TryBuildGlobalPalette(
+        GifAnimationFrame[] frames,
+        byte bgR,
+        byte bgG,
+        byte bgB,
+        byte bgA,
+        bool anyTransparency,
+        out List<int> palette,
+        out Dictionary<int, int>? map,
+        out int transparentIndex,
+        out int backgroundIndex) {
+        palette = new List<int>(256);
+        map = new Dictionary<int, int>(256);
+        transparentIndex = -1;
+
+        var nextIndex = 0;
+        if (anyTransparency) {
+            transparentIndex = 0;
+            palette.Add(0);
+            nextIndex = 1;
+        }
+
+        backgroundIndex = 0;
+        if (bgA >= 128) {
+            var bgColor = (bgR << 16) | (bgG << 8) | bgB;
+            if (!map.TryGetValue(bgColor, out var bgIdx)) {
+                if (nextIndex >= 256) return false;
+                bgIdx = nextIndex++;
+                map[bgColor] = bgIdx;
+                palette.Add(bgColor);
+            }
+            backgroundIndex = bgIdx;
+        } else if (anyTransparency) {
+            backgroundIndex = transparentIndex;
+        }
+
+        for (var i = 0; i < frames.Length; i++) {
+            var frame = frames[i];
+            for (var y = 0; y < frame.Height; y++) {
+                var row = y * frame.Stride;
+                for (var x = 0; x < frame.Width; x++) {
+                    var p = row + x * 4;
+                    if (frame.Rgba[p + 3] < 128) continue;
+                    var color = (frame.Rgba[p + 0] << 16) | (frame.Rgba[p + 1] << 8) | frame.Rgba[p + 2];
+                    if (map.ContainsKey(color)) continue;
+                    if (nextIndex >= 256) return false;
+                    map[color] = nextIndex++;
+                    palette.Add(color);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static List<int> BuildBackgroundPalette(byte bgR, byte bgG, byte bgB) {
+        var palette = new List<int>(2) {
+            (bgR << 16) | (bgG << 8) | bgB
+        };
+        if (palette.Count < 2) palette.Add(0);
+        return palette;
+    }
+
+    private static PaletteInfo BuildFramePalette(GifAnimationFrame frame) {
+        var palette = new List<int>(256);
+        var map = new Dictionary<int, int>(256);
+        var hasTransparency = FrameHasTransparency(frame);
+        var transparentIndex = -1;
+        var nextIndex = 0;
+        var overflow = false;
+
+        if (hasTransparency) {
+            transparentIndex = 0;
+            palette.Add(0);
+            nextIndex = 1;
+        }
+
+        for (var y = 0; y < frame.Height && !overflow; y++) {
+            var row = y * frame.Stride;
+            for (var x = 0; x < frame.Width; x++) {
+                var p = row + x * 4;
+                if (frame.Rgba[p + 3] < 128) continue;
+                var color = (frame.Rgba[p + 0] << 16) | (frame.Rgba[p + 1] << 8) | frame.Rgba[p + 2];
+                if (map.ContainsKey(color)) continue;
+                if (nextIndex >= 256) {
+                    overflow = true;
+                    break;
+                }
+                map[color] = nextIndex++;
+                palette.Add(color);
+            }
+        }
+
+        if (!overflow) {
+            var tableSize = GetTableSize(palette.Count);
+            var tableBits = GetTableBits(tableSize);
+            return new PaletteInfo(palette, map, tableSize, tableBits, hasTransparency, transparentIndex, false, 0, 0, 0);
+        }
+
+        BuildUniformPalette(hasTransparency, out palette, out var rLevels, out var gLevels, out var bLevels, out transparentIndex);
+        var uniformSize = GetTableSize(palette.Count);
+        var uniformBits = GetTableBits(uniformSize);
+        return new PaletteInfo(palette, null, uniformSize, uniformBits, hasTransparency, transparentIndex, true, rLevels, gLevels, bLevels);
+    }
+
+    private static byte[] BuildFrameIndices(GifAnimationFrame frame, PaletteInfo palette, bool useGlobal) {
+        var indices = new byte[frame.Width * frame.Height];
+        var dst = 0;
+        for (var y = 0; y < frame.Height; y++) {
+            var row = y * frame.Stride;
+            for (var x = 0; x < frame.Width; x++) {
+                var p = row + x * 4;
+                if (palette.HasTransparency && frame.Rgba[p + 3] < 128) {
+                    indices[dst++] = (byte)palette.TransparentIndex;
+                    continue;
+                }
+                if (palette.IsQuantized) {
+                    throw new InvalidOperationException("Quantized palettes must use the dithered path.");
+                } else {
+                    var color = (frame.Rgba[p + 0] << 16) | (frame.Rgba[p + 1] << 8) | frame.Rgba[p + 2];
+                    if (!palette.ColorMap!.TryGetValue(color, out var index)) {
+                        if (useGlobal) throw new ArgumentException("Frame color not found in global palette.");
+                        throw new ArgumentException("Frame color not found in local palette.");
+                    }
+                    indices[dst++] = (byte)index;
+                }
+            }
+        }
+        return indices;
+    }
+
+    private static void WriteLoopExtension(Stream stream, int loopCount) {
+        if (loopCount < 0) loopCount = 0;
+        stream.WriteByte(0x21);
+        stream.WriteByte(0xFF);
+        stream.WriteByte(0x0B);
+        stream.WriteByte((byte)'N');
+        stream.WriteByte((byte)'E');
+        stream.WriteByte((byte)'T');
+        stream.WriteByte((byte)'S');
+        stream.WriteByte((byte)'C');
+        stream.WriteByte((byte)'A');
+        stream.WriteByte((byte)'P');
+        stream.WriteByte((byte)'E');
+        stream.WriteByte((byte)'2');
+        stream.WriteByte((byte)'.');
+        stream.WriteByte((byte)'0');
+        stream.WriteByte(0x03);
+        stream.WriteByte(0x01);
+        stream.WriteByte((byte)(loopCount & 0xFF));
+        stream.WriteByte((byte)((loopCount >> 8) & 0xFF));
+        stream.WriteByte(0x00);
+    }
+
+    private static GifDisposal ClampDisposal(GifDisposal disposal) {
+        return disposal switch {
+            GifDisposal.DoNotDispose => GifDisposal.DoNotDispose,
+            GifDisposal.RestoreBackground => GifDisposal.RestoreBackground,
+            GifDisposal.RestorePrevious => GifDisposal.RestorePrevious,
+            _ => GifDisposal.None
+        };
+    }
+
+    private static int ClampColorResolution(int value) {
+        if (value < 0) return 0;
+        if (value > 7) return 7;
+        return value;
+    }
+
+    private static int GetTableSize(int colorCount) {
+        var size = 2;
+        while (size < colorCount) size <<= 1;
+        return size;
+    }
+
+    private static int GetTableBits(int tableSize) {
+        var bits = 0;
+        var size = 1;
+        while (size < tableSize) {
+            size <<= 1;
+            bits++;
+        }
+        return bits;
+    }
+
+    private static void FillIndicesExact(
+        ReadOnlySpan<byte> rgba,
+        int width,
+        int height,
+        int stride,
+        byte[] indices,
+        Dictionary<int, int> map,
+        bool hasTransparency,
+        int transparentIndex) {
+        var dst = 0;
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var p = row + x * 4;
+                if (hasTransparency && rgba[p + 3] < 128) {
+                    indices[dst++] = (byte)transparentIndex;
+                    continue;
+                }
+                var color = (rgba[p + 0] << 16) | (rgba[p + 1] << 8) | rgba[p + 2];
+                if (!map.TryGetValue(color, out var index)) {
+                    index = 0;
+                }
+                indices[dst++] = (byte)index;
+            }
+        }
+    }
+
+    private static byte[] BuildFrameIndicesQuantized(GifAnimationFrame frame, PaletteInfo palette) {
+        var indices = new byte[frame.Width * frame.Height];
+        FillIndicesQuantizedDithered(frame.Rgba, frame.Width, frame.Height, frame.Stride, indices, palette.HasTransparency, palette.RLevels, palette.GLevels, palette.BLevels, palette.TransparentIndex);
+        return indices;
+    }
+
+    private static void FillIndicesQuantizedDithered(
+        ReadOnlySpan<byte> rgba,
+        int width,
+        int height,
+        int stride,
+        byte[] indices,
+        bool hasTransparency,
+        int rLevels,
+        int gLevels,
+        int bLevels,
+        int transparentIndex) {
+        var dst = 0;
+        var errR = new int[width + 2];
+        var errG = new int[width + 2];
+        var errB = new int[width + 2];
+        var nextR = new int[width + 2];
+        var nextG = new int[width + 2];
+        var nextB = new int[width + 2];
+        var offset = hasTransparency ? 1 : 0;
+
+        for (var y = 0; y < height; y++) {
+            Array.Clear(nextR, 0, nextR.Length);
+            Array.Clear(nextG, 0, nextG.Length);
+            Array.Clear(nextB, 0, nextB.Length);
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var p = row + x * 4;
+                if (hasTransparency && rgba[p + 3] < 128) {
+                    indices[dst++] = (byte)transparentIndex;
+                    continue;
+                }
+
+                var idx = x + 1;
+                var r = ClampToByte(rgba[p + 0] + ((errR[idx] + 8) >> 4));
+                var g = ClampToByte(rgba[p + 1] + ((errG[idx] + 8) >> 4));
+                var b = ClampToByte(rgba[p + 2] + ((errB[idx] + 8) >> 4));
+
+                var rIndex = (r * rLevels) >> 8;
+                var gIndex = (g * gLevels) >> 8;
+                var bIndex = (b * bLevels) >> 8;
+
+                var rQ = rLevels == 1 ? 0 : (rIndex * 255 / (rLevels - 1));
+                var gQ = gLevels == 1 ? 0 : (gIndex * 255 / (gLevels - 1));
+                var bQ = bLevels == 1 ? 0 : (bIndex * 255 / (bLevels - 1));
+
+                var index = (rIndex * gLevels + gIndex) * bLevels + bIndex;
+                indices[dst++] = (byte)(index + offset);
+
+                var errValR = r - rQ;
+                var errValG = g - gQ;
+                var errValB = b - bQ;
+
+                errR[idx + 1] += errValR * 7;
+                errG[idx + 1] += errValG * 7;
+                errB[idx + 1] += errValB * 7;
+
+                nextR[idx - 1] += errValR * 3;
+                nextG[idx - 1] += errValG * 3;
+                nextB[idx - 1] += errValB * 3;
+
+                nextR[idx] += errValR * 5;
+                nextG[idx] += errValG * 5;
+                nextB[idx] += errValB * 5;
+
+                nextR[idx + 1] += errValR;
+                nextG[idx + 1] += errValG;
+                nextB[idx + 1] += errValB;
+            }
+
+            var swapR = errR;
+            errR = nextR;
+            nextR = swapR;
+
+            var swapG = errG;
+            errG = nextG;
+            nextG = swapG;
+
+            var swapB = errB;
+            errB = nextB;
+            nextB = swapB;
+        }
+    }
+
+    private static void BuildUniformPalette(
+        bool hasTransparency,
+        out List<int> palette,
+        out int rLevels,
+        out int gLevels,
+        out int bLevels,
+        out int transparentIndex) {
+        if (hasTransparency) {
+            rLevels = 7;
+            gLevels = 7;
+            bLevels = 5;
+            transparentIndex = 0;
+            palette = new List<int>(1 + rLevels * gLevels * bLevels) { 0 };
+        } else {
+            rLevels = 8;
+            gLevels = 8;
+            bLevels = 4;
+            transparentIndex = -1;
+            palette = new List<int>(rLevels * gLevels * bLevels);
+        }
+
+        for (var r = 0; r < rLevels; r++) {
+            var rVal = rLevels == 1 ? 0 : (r * 255 / (rLevels - 1));
+            for (var g = 0; g < gLevels; g++) {
+                var gVal = gLevels == 1 ? 0 : (g * 255 / (gLevels - 1));
+                for (var b = 0; b < bLevels; b++) {
+                    var bVal = bLevels == 1 ? 0 : (b * 255 / (bLevels - 1));
+                    palette.Add((rVal << 16) | (gVal << 8) | bVal);
+                }
+            }
+        }
+    }
+
+    private static int ClampToByte(int value) {
+        if (value < 0) return 0;
+        if (value > 255) return 255;
+        return value;
+    }
+
+    private readonly struct PaletteInfo {
+        public PaletteInfo(
+            List<int> colors,
+            Dictionary<int, int>? colorMap,
+            int tableSize,
+            int tableBits,
+            bool hasTransparency,
+            int transparentIndex,
+            bool isQuantized,
+            int rLevels,
+            int gLevels,
+            int bLevels) {
+            Colors = colors;
+            ColorMap = colorMap;
+            TableSize = tableSize;
+            TableBits = tableBits;
+            HasTransparency = hasTransparency;
+            TransparentIndex = transparentIndex;
+            IsQuantized = isQuantized;
+            RLevels = rLevels;
+            GLevels = gLevels;
+            BLevels = bLevels;
+        }
+
+        public List<int> Colors { get; }
+        public Dictionary<int, int>? ColorMap { get; }
+        public int TableSize { get; }
+        public int TableBits { get; }
+        public bool HasTransparency { get; }
+        public int TransparentIndex { get; }
+        public bool IsQuantized { get; }
+        public int RLevels { get; }
+        public int GLevels { get; }
+        public int BLevels { get; }
+    }
+
+    private static void WriteGlobalColorTable(Stream stream, List<int> palette, int tableSize) {
+        for (var i = 0; i < tableSize; i++) {
+            if (i < palette.Count) {
+                var color = palette[i];
+                stream.WriteByte((byte)((color >> 16) & 0xFF));
+                stream.WriteByte((byte)((color >> 8) & 0xFF));
+                stream.WriteByte((byte)(color & 0xFF));
+            } else {
+                stream.WriteByte(0);
+                stream.WriteByte(0);
+                stream.WriteByte(0);
+            }
+        }
+    }
+
+    private static byte[] LzwEncode(ReadOnlySpan<byte> data, int minCodeSize) {
+        if (data.Length == 0) return Array.Empty<byte>();
+        if (minCodeSize < 2 || minCodeSize > 8) throw new ArgumentOutOfRangeException(nameof(minCodeSize));
+
+        var clearCode = 1 << minCodeSize;
+        var endCode = clearCode + 1;
+        var codeSize = minCodeSize + 1;
+        var nextCode = endCode + 1;
+        var dict = new Dictionary<int, int>(4096);
+        var writer = new GifBitWriter(data.Length / 2 + 16);
+
+        writer.Write(clearCode, codeSize);
+        var prefix = data[0];
+        for (var i = 1; i < data.Length; i++) {
+            var c = data[i];
+            var key = (prefix << 8) | c;
+            if (dict.TryGetValue(key, out var code)) {
+                prefix = code;
+                continue;
+            }
+
+            writer.Write(prefix, codeSize);
+
+            if (nextCode < 4096) {
+                dict[key] = nextCode++;
+                if (nextCode == (1 << codeSize) && codeSize < 12) {
+                    codeSize++;
+                }
+            } else {
+                writer.Write(clearCode, codeSize);
+                dict.Clear();
+                codeSize = minCodeSize + 1;
+                nextCode = endCode + 1;
+            }
+
+            prefix = c;
+        }
+
+        writer.Write(prefix, codeSize);
+        writer.Write(endCode, codeSize);
+        return writer.ToArray();
+    }
+
+    private static void WriteSubBlocks(Stream stream, byte[] data) {
+        var offset = 0;
+        while (offset < data.Length) {
+            var size = Math.Min(255, data.Length - offset);
+            stream.WriteByte((byte)size);
+            stream.Write(data, offset, size);
+            offset += size;
+        }
+        stream.WriteByte(0);
+    }
+
+    private static void WriteUInt16(Stream stream, ushort value) {
+        stream.WriteByte((byte)value);
+        stream.WriteByte((byte)(value >> 8));
+    }
+
+    private static readonly byte[] GifHeader = { (byte)'G', (byte)'I', (byte)'F', (byte)'8', (byte)'9', (byte)'a' };
+
+    private sealed class GifBitWriter {
+        private readonly List<byte> _buffer;
+        private int _bitPos;
+        private byte _current;
+
+        public GifBitWriter(int capacity) {
+            _buffer = new List<byte>(capacity);
+        }
+
+        public void Write(int code, int size) {
+            for (var i = 0; i < size; i++) {
+                var bit = (code >> i) & 1;
+                if (bit != 0) {
+                    _current |= (byte)(1 << _bitPos);
+                }
+                _bitPos++;
+                if (_bitPos == 8) {
+                    _buffer.Add(_current);
+                    _current = 0;
+                    _bitPos = 0;
+                }
+            }
+        }
+
+        public byte[] ToArray() {
+            if (_bitPos > 0) {
+                _buffer.Add(_current);
+                _current = 0;
+                _bitPos = 0;
+            }
+            return _buffer.ToArray();
+        }
+    }
+}

--- a/CodeGlyphX/Rendering/Gif/GifWriter.cs
+++ b/CodeGlyphX/Rendering/Gif/GifWriter.cs
@@ -302,6 +302,32 @@ public static class GifWriter {
         return optimized;
     }
 
+    private static void FillCanvas(byte[] canvas, byte r, byte g, byte b, byte a) {
+        for (var i = 0; i < canvas.Length; i += 4) {
+            canvas[i + 0] = r;
+            canvas[i + 1] = g;
+            canvas[i + 2] = b;
+            canvas[i + 3] = a;
+        }
+    }
+
+    private static void ClearRect(byte[] canvas, int canvasW, int canvasH, int left, int top, int width, int height, byte r, byte g, byte b, byte a) {
+        for (var y = 0; y < height; y++) {
+            var dstY = top + y;
+            if ((uint)dstY >= (uint)canvasH) continue;
+            var dstRow = dstY * canvasW * 4;
+            for (var x = 0; x < width; x++) {
+                var dstX = left + x;
+                if ((uint)dstX >= (uint)canvasW) continue;
+                var dst = dstRow + dstX * 4;
+                canvas[dst + 0] = r;
+                canvas[dst + 1] = g;
+                canvas[dst + 2] = b;
+                canvas[dst + 3] = a;
+            }
+        }
+    }
+
     private static bool TryComputeDiffBounds(
         byte[] canvas,
         int canvasWidth,
@@ -854,7 +880,7 @@ public static class GifWriter {
         var writer = new GifBitWriter(data.Length / 2 + 16);
 
         writer.Write(clearCode, codeSize);
-        var prefix = data[0];
+        var prefix = (int)data[0];
         for (var i = 1; i < data.Length; i++) {
             var c = data[i];
             var key = (prefix << 8) | c;

--- a/CodeGlyphX/Rendering/Gif/MatrixGifRenderer.cs
+++ b/CodeGlyphX/Rendering/Gif/MatrixGifRenderer.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Gif;
+
+/// <summary>
+/// Renders matrix codes to a GIF image (indexed color).
+/// </summary>
+public static class MatrixGifRenderer {
+    /// <summary>
+    /// Renders the module matrix to a GIF byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return GifWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a GIF stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        GifWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a GIF file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
+        var gif = Render(modules, opts);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a GIF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
+        var gif = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF from multiple module frames.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, GifAnimationOptions options = default) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (durationMs <= 0) throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+        var gifFrames = new GifAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var pixels = MatrixPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            gifFrames[i] = new GifAnimationFrame(pixels, widthPx, heightPx, stride, durationMs);
+        }
+
+        return GifWriter.WriteAnimation(canvasWidth, canvasHeight, gifFrames, options);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF from multiple module frames with per-frame durations.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, GifAnimationOptions options = default) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (durationsMs is null) throw new ArgumentNullException(nameof(durationsMs));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (frames.Length != durationsMs.Length) throw new ArgumentException("Durations must match frame count.", nameof(durationsMs));
+
+        var gifFrames = new GifAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var duration = durationsMs[i];
+            if (duration <= 0) throw new ArgumentOutOfRangeException(nameof(durationsMs));
+            var pixels = MatrixPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            gifFrames[i] = new GifAnimationFrame(pixels, widthPx, heightPx, stride, duration);
+        }
+
+        return GifWriter.WriteAnimation(canvasWidth, canvasHeight, gifFrames, options);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a stream from multiple module frames.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, Stream stream, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        stream.Write(gif, 0, gif.Length);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a stream from multiple module frames with per-frame durations.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, Stream stream, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        stream.Write(gif, 0, gif.Length);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file from multiple module frames.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, string path, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file from multiple module frames with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, string path, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file under the specified directory.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, string directory, string fileName, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file under the specified directory with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, string directory, string fileName, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+}

--- a/CodeGlyphX/Rendering/Gif/QrGifRenderer.cs
+++ b/CodeGlyphX/Rendering/Gif/QrGifRenderer.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Gif;
+
+/// <summary>
+/// Renders QR modules to a GIF image (indexed color).
+/// </summary>
+public static class QrGifRenderer {
+    /// <summary>
+    /// Renders the QR module matrix to a GIF byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return GifWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a GIF stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        GifWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a GIF file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
+        var gif = Render(modules, opts);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a GIF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
+        var gif = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF from multiple QR module frames.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, GifAnimationOptions options = default) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (durationMs <= 0) throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+        var gifFrames = new GifAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var pixels = QrPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            gifFrames[i] = new GifAnimationFrame(pixels, widthPx, heightPx, stride, durationMs);
+        }
+
+        return GifWriter.WriteAnimation(canvasWidth, canvasHeight, gifFrames, options);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF from multiple QR module frames with per-frame durations.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, GifAnimationOptions options = default) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (durationsMs is null) throw new ArgumentNullException(nameof(durationsMs));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (frames.Length != durationsMs.Length) throw new ArgumentException("Durations must match frame count.", nameof(durationsMs));
+
+        var gifFrames = new GifAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var duration = durationsMs[i];
+            if (duration <= 0) throw new ArgumentOutOfRangeException(nameof(durationsMs));
+            var pixels = QrPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            gifFrames[i] = new GifAnimationFrame(pixels, widthPx, heightPx, stride, duration);
+        }
+
+        return GifWriter.WriteAnimation(canvasWidth, canvasHeight, gifFrames, options);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a stream from multiple QR module frames.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, Stream stream, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        stream.Write(gif, 0, gif.Length);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a stream from multiple QR module frames with per-frame durations.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, Stream stream, GifAnimationOptions options = default) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        stream.Write(gif, 0, gif.Length);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file from multiple QR module frames.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, string path, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file from multiple QR module frames with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, string path, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        return RenderIO.WriteBinary(path, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file under the specified directory.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, string directory, string fileName, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationMs, options);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+
+    /// <summary>
+    /// Renders an animated GIF to a file under the specified directory with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, string directory, string fileName, GifAnimationOptions options = default) {
+        var gif = RenderAnimation(frames, opts, durationsMs, options);
+        return RenderIO.WriteBinary(directory, fileName, gif);
+    }
+}

--- a/CodeGlyphX/Rendering/ImageFormat.cs
+++ b/CodeGlyphX/Rendering/ImageFormat.cs
@@ -64,4 +64,12 @@ public enum ImageFormat {
     /// WebP image (managed VP8/VP8L stills; first-frame decode for animations).
     /// </summary>
     Webp,
+    /// <summary>
+    /// PDF document (image-only decode).
+    /// </summary>
+    Pdf,
+    /// <summary>
+    /// PSD image (flattened 8-bit grayscale/RGB).
+    /// </summary>
+    Psd,
 }

--- a/CodeGlyphX/Rendering/ImageReader.Info.cs
+++ b/CodeGlyphX/Rendering/ImageReader.Info.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Psd;
 using CodeGlyphX.Rendering.Tga;
 using CodeGlyphX.Rendering.Tiff;
 using CodeGlyphX.Rendering.Webp;
@@ -54,6 +56,10 @@ public static partial class ImageReader {
                 return TryReadJpegSize(data, out width, out height);
             case ImageFormat.Gif:
                 return TryReadGifSize(data, out width, out height);
+            case ImageFormat.Pdf:
+                return PdfReader.TryReadDimensions(data, out width, out height);
+            case ImageFormat.Psd:
+                return PsdReader.TryReadDimensions(data, out width, out height);
             case ImageFormat.Bmp:
                 return TryReadBmpSize(data, out width, out height);
             case ImageFormat.Pbm:

--- a/CodeGlyphX/Rendering/ImageReader.MultiFrame.cs
+++ b/CodeGlyphX/Rendering/ImageReader.MultiFrame.cs
@@ -1,0 +1,351 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Tiff;
+using CodeGlyphX.Rendering.Webp;
+
+namespace CodeGlyphX.Rendering;
+
+public static partial class ImageReader {
+    /// <summary>
+    /// Attempts to decode GIF animation frames into RGBA32 buffers.
+    /// </summary>
+    public static bool TryDecodeGifAnimationFrames(
+        byte[] data,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return TryDecodeGifAnimationFrames((ReadOnlySpan<byte>)data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode GIF animation frames into RGBA32 buffers.
+    /// </summary>
+    public static bool TryDecodeGifAnimationFrames(
+        ReadOnlySpan<byte> data,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        frames = Array.Empty<GifAnimationFrame>();
+        canvasWidth = 0;
+        canvasHeight = 0;
+        options = default;
+        if (!GifReader.IsGif(data)) return false;
+        return GifReader.TryDecodeAnimationFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes GIF animation frames into RGBA32 buffers.
+    /// </summary>
+    public static GifAnimationFrame[] DecodeGifAnimationFrames(
+        ReadOnlySpan<byte> data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (!GifReader.IsGif(data)) throw new FormatException("Invalid GIF data.");
+        return GifReader.DecodeAnimationFrames(data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes GIF animation frames into RGBA32 buffers.
+    /// </summary>
+    public static GifAnimationFrame[] DecodeGifAnimationFrames(
+        byte[] data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return DecodeGifAnimationFrames((ReadOnlySpan<byte>)data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode GIF animation frames composited onto the full canvas.
+    /// </summary>
+    public static bool TryDecodeGifAnimationCanvasFrames(
+        byte[] data,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return TryDecodeGifAnimationCanvasFrames((ReadOnlySpan<byte>)data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode GIF animation frames composited onto the full canvas.
+    /// </summary>
+    public static bool TryDecodeGifAnimationCanvasFrames(
+        ReadOnlySpan<byte> data,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        frames = Array.Empty<GifAnimationFrame>();
+        canvasWidth = 0;
+        canvasHeight = 0;
+        options = default;
+        if (!GifReader.IsGif(data)) return false;
+        return GifReader.TryDecodeAnimationCanvasFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes GIF animation frames composited onto the full canvas.
+    /// </summary>
+    public static GifAnimationFrame[] DecodeGifAnimationCanvasFrames(
+        ReadOnlySpan<byte> data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (!GifReader.IsGif(data)) throw new FormatException("Invalid GIF data.");
+        return GifReader.DecodeAnimationCanvasFrames(data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes GIF animation frames composited onto the full canvas.
+    /// </summary>
+    public static GifAnimationFrame[] DecodeGifAnimationCanvasFrames(
+        byte[] data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return DecodeGifAnimationCanvasFrames((ReadOnlySpan<byte>)data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode GIF animation frames from a stream.
+    /// </summary>
+    public static bool TryDecodeGifAnimationFrames(
+        Stream stream,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (stream is MemoryStream memory && memory.TryGetBuffer(out var buffer)) {
+            return TryDecodeGifAnimationFrames(buffer.AsSpan(), out frames, out canvasWidth, out canvasHeight, out options);
+        }
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeGifAnimationFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode GIF animation canvas frames from a stream.
+    /// </summary>
+    public static bool TryDecodeGifAnimationCanvasFrames(
+        Stream stream,
+        out GifAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out GifAnimationOptions options) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (stream is MemoryStream memory && memory.TryGetBuffer(out var buffer)) {
+            return TryDecodeGifAnimationCanvasFrames(buffer.AsSpan(), out frames, out canvasWidth, out canvasHeight, out options);
+        }
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeGifAnimationCanvasFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode WebP animation frames into RGBA32 buffers.
+    /// </summary>
+    public static bool TryDecodeWebpAnimationFrames(
+        byte[] data,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return TryDecodeWebpAnimationFrames((ReadOnlySpan<byte>)data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode WebP animation frames into RGBA32 buffers.
+    /// </summary>
+    public static bool TryDecodeWebpAnimationFrames(
+        ReadOnlySpan<byte> data,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        frames = Array.Empty<WebpAnimationFrame>();
+        canvasWidth = 0;
+        canvasHeight = 0;
+        options = default;
+        if (!WebpReader.IsWebp(data)) return false;
+        return WebpReader.TryDecodeAnimationFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes WebP animation frames into RGBA32 buffers.
+    /// </summary>
+    public static WebpAnimationFrame[] DecodeWebpAnimationFrames(
+        ReadOnlySpan<byte> data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (!WebpReader.IsWebp(data)) throw new FormatException("Invalid WebP data.");
+        return WebpReader.DecodeAnimationFrames(data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes WebP animation frames into RGBA32 buffers.
+    /// </summary>
+    public static WebpAnimationFrame[] DecodeWebpAnimationFrames(
+        byte[] data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return DecodeWebpAnimationFrames((ReadOnlySpan<byte>)data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode WebP animation frames composited onto the full canvas.
+    /// </summary>
+    public static bool TryDecodeWebpAnimationCanvasFrames(
+        byte[] data,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return TryDecodeWebpAnimationCanvasFrames((ReadOnlySpan<byte>)data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode WebP animation frames composited onto the full canvas.
+    /// </summary>
+    public static bool TryDecodeWebpAnimationCanvasFrames(
+        ReadOnlySpan<byte> data,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        frames = Array.Empty<WebpAnimationFrame>();
+        canvasWidth = 0;
+        canvasHeight = 0;
+        options = default;
+        if (!WebpReader.IsWebp(data)) return false;
+        return WebpReader.TryDecodeAnimationCanvasFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes WebP animation frames composited onto the full canvas.
+    /// </summary>
+    public static WebpAnimationFrame[] DecodeWebpAnimationCanvasFrames(
+        ReadOnlySpan<byte> data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (!WebpReader.IsWebp(data)) throw new FormatException("Invalid WebP data.");
+        return WebpReader.DecodeAnimationCanvasFrames(data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Decodes WebP animation frames composited onto the full canvas.
+    /// </summary>
+    public static WebpAnimationFrame[] DecodeWebpAnimationCanvasFrames(
+        byte[] data,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return DecodeWebpAnimationCanvasFrames((ReadOnlySpan<byte>)data, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode WebP animation frames from a stream.
+    /// </summary>
+    public static bool TryDecodeWebpAnimationFrames(
+        Stream stream,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (stream is MemoryStream memory && memory.TryGetBuffer(out var buffer)) {
+            return TryDecodeWebpAnimationFrames(buffer.AsSpan(), out frames, out canvasWidth, out canvasHeight, out options);
+        }
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeWebpAnimationFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode WebP animation canvas frames from a stream.
+    /// </summary>
+    public static bool TryDecodeWebpAnimationCanvasFrames(
+        Stream stream,
+        out WebpAnimationFrame[] frames,
+        out int canvasWidth,
+        out int canvasHeight,
+        out WebpAnimationOptions options) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (stream is MemoryStream memory && memory.TryGetBuffer(out var buffer)) {
+            return TryDecodeWebpAnimationCanvasFrames(buffer.AsSpan(), out frames, out canvasWidth, out canvasHeight, out options);
+        }
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeWebpAnimationCanvasFrames(data, out frames, out canvasWidth, out canvasHeight, out options);
+    }
+
+    /// <summary>
+    /// Attempts to decode all TIFF pages into RGBA32 buffers.
+    /// </summary>
+    public static bool TryDecodeTiffPagesRgba32(byte[] data, out TiffRgba32Page[] pages) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return TryDecodeTiffPagesRgba32((ReadOnlySpan<byte>)data, out pages);
+    }
+
+    /// <summary>
+    /// Attempts to decode all TIFF pages into RGBA32 buffers.
+    /// </summary>
+    public static bool TryDecodeTiffPagesRgba32(ReadOnlySpan<byte> data, out TiffRgba32Page[] pages) {
+        if (!TiffReader.IsTiff(data)) {
+            pages = Array.Empty<TiffRgba32Page>();
+            return false;
+        }
+        return TiffReader.TryDecodePagesRgba32(data, out pages);
+    }
+
+    /// <summary>
+    /// Attempts to decode all TIFF pages into RGBA32 buffers from a stream.
+    /// </summary>
+    public static bool TryDecodeTiffPagesRgba32(Stream stream, out TiffRgba32Page[] pages) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (stream is MemoryStream memory && memory.TryGetBuffer(out var buffer)) {
+            return TryDecodeTiffPagesRgba32(buffer.AsSpan(), out pages);
+        }
+        var data = RenderIO.ReadBinary(stream);
+        return TryDecodeTiffPagesRgba32(data, out pages);
+    }
+
+    /// <summary>
+    /// Decodes all TIFF pages into RGBA32 buffers.
+    /// </summary>
+    public static TiffRgba32Page[] DecodeTiffPagesRgba32(byte[] data) {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return DecodeTiffPagesRgba32((ReadOnlySpan<byte>)data);
+    }
+
+    /// <summary>
+    /// Decodes all TIFF pages into RGBA32 buffers.
+    /// </summary>
+    public static TiffRgba32Page[] DecodeTiffPagesRgba32(Stream stream) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (stream is MemoryStream memory && memory.TryGetBuffer(out var buffer)) {
+            return DecodeTiffPagesRgba32(buffer.AsSpan());
+        }
+        var data = RenderIO.ReadBinary(stream);
+        return DecodeTiffPagesRgba32(data);
+    }
+
+    /// <summary>
+    /// Decodes all TIFF pages into RGBA32 buffers.
+    /// </summary>
+    public static TiffRgba32Page[] DecodeTiffPagesRgba32(ReadOnlySpan<byte> data) {
+        return TiffReader.DecodePagesRgba32(data);
+    }
+}

--- a/CodeGlyphX/Rendering/ImageReader.cs
+++ b/CodeGlyphX/Rendering/ImageReader.cs
@@ -3,6 +3,8 @@ using System.IO;
 using CodeGlyphX.Rendering.Bmp;
 using CodeGlyphX.Rendering.Gif;
 using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Psd;
 using CodeGlyphX.Rendering.Pam;
 using CodeGlyphX.Rendering.Pgm;
 using CodeGlyphX.Rendering.Pbm;
@@ -43,6 +45,8 @@ public static partial class ImageReader {
         if (IcoReader.IsIco(data)) return IcoReader.DecodeRgba32(data, out width, out height);
         if (JpegReader.IsJpeg(data)) return JpegReader.DecodeRgba32(data, out width, out height);
         if (GifReader.IsGif(data)) return GifReader.DecodeRgba32(data, out width, out height);
+        if (PdfReader.IsPdf(data)) return PdfReader.DecodeRgba32(data, out width, out height);
+        if (PsdReader.IsPsd(data)) return PsdReader.DecodeRgba32(data, out width, out height);
         if (IsBmp(data)) return BmpReader.DecodeRgba32(data, out width, out height);
         if (IsPbm(data)) return PbmReader.DecodeRgba32(data, out width, out height);
         if (IsPgm(data)) return PgmReader.DecodeRgba32(data, out width, out height);
@@ -107,6 +111,8 @@ public static partial class ImageReader {
         if (IcoReader.IsIco(data)) { format = ImageFormat.Ico; return true; }
         if (JpegReader.IsJpeg(data)) { format = ImageFormat.Jpeg; return true; }
         if (GifReader.IsGif(data)) { format = ImageFormat.Gif; return true; }
+        if (PdfReader.IsPdf(data)) { format = ImageFormat.Pdf; return true; }
+        if (PsdReader.IsPsd(data)) { format = ImageFormat.Psd; return true; }
         if (IsBmp(data)) { format = ImageFormat.Bmp; return true; }
         if (IsPbm(data)) { format = ImageFormat.Pbm; return true; }
         if (IsPgm(data)) { format = ImageFormat.Pgm; return true; }

--- a/CodeGlyphX/Rendering/OutputFormat.cs
+++ b/CodeGlyphX/Rendering/OutputFormat.cs
@@ -79,5 +79,13 @@ public enum OutputFormat {
     /// <summary>
     /// ASCII art (text).
     /// </summary>
-    Ascii
+    Ascii,
+    /// <summary>
+    /// GIF image.
+    /// </summary>
+    Gif,
+    /// <summary>
+    /// TIFF image.
+    /// </summary>
+    Tiff
 }

--- a/CodeGlyphX/Rendering/OutputFormatInfo.cs
+++ b/CodeGlyphX/Rendering/OutputFormatInfo.cs
@@ -55,6 +55,8 @@ public static class OutputFormatInfo {
             OutputFormat.Pdf => "pdf",
             OutputFormat.Eps => "eps",
             OutputFormat.Ascii => "txt",
+            OutputFormat.Gif => "gif",
+            OutputFormat.Tiff => "tiff",
             _ => string.Empty
         };
     }
@@ -82,6 +84,8 @@ public static class OutputFormatInfo {
             OutputFormat.Pdf => "application/pdf",
             OutputFormat.Eps => "application/postscript",
             OutputFormat.Ascii => "text/plain",
+            OutputFormat.Gif => "image/gif",
+            OutputFormat.Tiff => "image/tiff",
             _ => "application/octet-stream"
         };
     }
@@ -125,6 +129,8 @@ public static class OutputFormatInfo {
                 return OutputFormat.Jpeg;
             case ".bmp":
                 return OutputFormat.Bmp;
+            case ".gif":
+                return OutputFormat.Gif;
             case ".ppm":
                 return OutputFormat.Ppm;
             case ".pbm":
@@ -141,6 +147,9 @@ public static class OutputFormatInfo {
                 return OutputFormat.Tga;
             case ".ico":
                 return OutputFormat.Ico;
+            case ".tif":
+            case ".tiff":
+                return OutputFormat.Tiff;
             case ".pdf":
                 return OutputFormat.Pdf;
             case ".eps":

--- a/CodeGlyphX/Rendering/Pdf/PdfReader.cs
+++ b/CodeGlyphX/Rendering/Pdf/PdfReader.cs
@@ -1,0 +1,429 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using CodeGlyphX.Rendering.Jpeg;
+
+namespace CodeGlyphX.Rendering.Pdf;
+
+/// <summary>
+/// Minimal PDF image decoder (image-only PDFs with embedded JPEG/Flate XObjects).
+/// </summary>
+public static class PdfReader {
+    private static readonly byte[] PdfSignature = { (byte)'%', (byte)'P', (byte)'D', (byte)'F', (byte)'-' };
+    private static readonly byte[] SubtypeToken = { (byte)'/', (byte)'S', (byte)'u', (byte)'b', (byte)'t', (byte)'y', (byte)'p', (byte)'e' };
+    private static readonly byte[] ImageToken = { (byte)'/', (byte)'I', (byte)'m', (byte)'a', (byte)'g', (byte)'e' };
+    private static readonly byte[] StreamToken = { (byte)'s', (byte)'t', (byte)'r', (byte)'e', (byte)'a', (byte)'m' };
+    private static readonly byte[] EndStreamToken = { (byte)'e', (byte)'n', (byte)'d', (byte)'s', (byte)'t', (byte)'r', (byte)'e', (byte)'a', (byte)'m' };
+
+    /// <summary>
+    /// Returns true when the buffer looks like a PDF file.
+    /// </summary>
+    public static bool IsPdf(ReadOnlySpan<byte> data) {
+        if (data.Length < PdfSignature.Length) return false;
+        for (var i = 0; i < PdfSignature.Length; i++) {
+            if (data[i] != PdfSignature[i]) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to read PDF image dimensions without decoding pixels.
+    /// </summary>
+    public static bool TryReadDimensions(ReadOnlySpan<byte> data, out int width, out int height) {
+        width = 0;
+        height = 0;
+        if (!IsPdf(data)) return false;
+        var offset = 0;
+        while (TryFindImage(data, ref offset, out var info, out _)) {
+            if (info.Width > 0 && info.Height > 0) {
+                width = info.Width;
+                height = info.Height;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to decode an image-only PDF to RGBA (embedded JPEG or Flate image XObject).
+    /// </summary>
+    public static bool TryDecodeRgba32(ReadOnlySpan<byte> data, out byte[] rgba, out int width, out int height) {
+        rgba = Array.Empty<byte>();
+        width = 0;
+        height = 0;
+        if (!IsPdf(data)) return false;
+
+        var offset = 0;
+        while (TryFindImage(data, ref offset, out var info, out var stream)) {
+            if (info.Filter is null) continue;
+            if (info.Filter.Equals("DCTDecode", StringComparison.OrdinalIgnoreCase) ||
+                info.Filter.Equals("DCT", StringComparison.OrdinalIgnoreCase)) {
+                try {
+                    rgba = JpegReader.DecodeRgba32(stream, out width, out height);
+                    return true;
+                } catch (FormatException) {
+                    continue;
+                }
+            }
+
+            if (info.Filter.Equals("FlateDecode", StringComparison.OrdinalIgnoreCase) ||
+                info.Filter.Equals("Fl", StringComparison.OrdinalIgnoreCase)) {
+                if (!TryDecodeFlate(info, stream, out rgba, out width, out height)) {
+                    continue;
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Decodes an image-only PDF to RGBA (embedded JPEG or Flate image XObject).
+    /// </summary>
+    public static byte[] DecodeRgba32(ReadOnlySpan<byte> data, out int width, out int height) {
+        if (!TryDecodeRgba32(data, out var rgba, out width, out height)) {
+            throw new FormatException("Unsupported or invalid PDF image.");
+        }
+        return rgba;
+    }
+
+    private static bool TryFindImage(ReadOnlySpan<byte> data, ref int offset, out PdfImageInfo info, out ReadOnlySpan<byte> stream) {
+        info = default;
+        stream = ReadOnlySpan<byte>.Empty;
+        while (offset < data.Length) {
+            var imageIdx = IndexOfToken(data, ImageToken, offset);
+            if (imageIdx < 0) return false;
+
+            var dictStart = LastIndexOfToken(data, (byte)'<', (byte)'<', imageIdx);
+            var dictEnd = IndexOfToken(data, (byte)'>', (byte)'>', imageIdx);
+            if (dictStart < 0 || dictEnd < 0 || dictEnd <= dictStart) {
+                offset = imageIdx + ImageToken.Length;
+                continue;
+            }
+
+            var dict = data.Slice(dictStart, dictEnd + 2 - dictStart);
+            if (IndexOfToken(dict, SubtypeToken, 0) < 0) {
+                offset = imageIdx + ImageToken.Length;
+                continue;
+            }
+
+            if (!TryParseImageInfo(dict, out info)) {
+                offset = dictEnd + 2;
+                continue;
+            }
+
+            if (!TryReadStream(data, dictEnd + 2, out stream, out var endOffset)) {
+                offset = dictEnd + 2;
+                continue;
+            }
+
+            offset = endOffset;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryParseImageInfo(ReadOnlySpan<byte> dict, out PdfImageInfo info) {
+        info = default;
+        if (!TryReadNumberAfterKey(dict, "/Width", out var width)) return false;
+        if (!TryReadNumberAfterKey(dict, "/Height", out var height)) return false;
+
+        var bits = 8;
+        if (TryReadNumberAfterKey(dict, "/BitsPerComponent", out var bpc)) {
+            bits = bpc;
+        }
+
+        string? filter = null;
+        if (TryReadNameAfterKey(dict, "/Filter", out var filterName)) {
+            filter = filterName;
+        }
+
+        string? colorSpace = null;
+        if (TryReadNameAfterKey(dict, "/ColorSpace", out var csName)) {
+            colorSpace = csName;
+        }
+
+        var predictor = 1;
+        if (TryReadNumberAfterKey(dict, "/Predictor", out var predictorValue)) {
+            predictor = predictorValue;
+        }
+
+        var colors = 0;
+        if (TryReadNumberAfterKey(dict, "/Colors", out var colorsValue)) {
+            colors = colorsValue;
+        }
+
+        info = new PdfImageInfo(width, height, bits, colors, colorSpace, filter, predictor);
+        return true;
+    }
+
+    private static bool TryDecodeFlate(PdfImageInfo info, ReadOnlySpan<byte> stream, out byte[] rgba, out int width, out int height) {
+        rgba = Array.Empty<byte>();
+        width = 0;
+        height = 0;
+
+        if (info.Width <= 0 || info.Height <= 0) return false;
+        if (info.BitsPerComponent != 8) return false;
+
+        var colors = info.Colors;
+        if (colors <= 0) {
+            if (string.Equals(info.ColorSpace, "DeviceRGB", StringComparison.OrdinalIgnoreCase)) colors = 3;
+            else if (string.Equals(info.ColorSpace, "DeviceGray", StringComparison.OrdinalIgnoreCase)) colors = 1;
+            else return false;
+        }
+        if (colors != 1 && colors != 3) return false;
+
+        var rowSize = checked(info.Width * colors);
+        var predictor = info.Predictor <= 0 ? 1 : info.Predictor;
+        var expected = predictor >= 10 ? checked((rowSize + 1) * info.Height) : checked(rowSize * info.Height);
+
+        byte[] inflated;
+        try {
+            inflated = DecompressFlate(stream, expected);
+        } catch (FormatException) {
+            return false;
+        }
+
+        if (predictor == 2) {
+            ApplyTiffPredictor(inflated, rowSize, info.Height, colors);
+        } else if (predictor >= 10) {
+            if (!TryApplyPngPredictor(inflated, info.Width, info.Height, colors, out var decoded)) return false;
+            inflated = decoded;
+        }
+
+        var pixelCount = info.Width * info.Height;
+        rgba = new byte[pixelCount * 4];
+        if (colors == 3) {
+            for (var i = 0; i < pixelCount; i++) {
+                var src = i * 3;
+                var dst = i * 4;
+                rgba[dst + 0] = inflated[src + 0];
+                rgba[dst + 1] = inflated[src + 1];
+                rgba[dst + 2] = inflated[src + 2];
+                rgba[dst + 3] = 255;
+            }
+        } else {
+            for (var i = 0; i < pixelCount; i++) {
+                var v = inflated[i];
+                var dst = i * 4;
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = 255;
+            }
+        }
+
+        width = info.Width;
+        height = info.Height;
+        return true;
+    }
+
+    private static bool TryReadStream(ReadOnlySpan<byte> data, int start, out ReadOnlySpan<byte> stream, out int endOffset) {
+        stream = ReadOnlySpan<byte>.Empty;
+        endOffset = start;
+        var streamIndex = IndexOfToken(data, StreamToken, start);
+        if (streamIndex < 0) return false;
+
+        var dataStart = streamIndex + StreamToken.Length;
+        if (dataStart < data.Length) {
+            if (data[dataStart] == '\r' && dataStart + 1 < data.Length && data[dataStart + 1] == '\n') {
+                dataStart += 2;
+            } else if (data[dataStart] == '\n' || data[dataStart] == '\r') {
+                dataStart += 1;
+            }
+        }
+
+        var endStreamIndex = IndexOfToken(data, EndStreamToken, dataStart);
+        if (endStreamIndex < 0) return false;
+
+        stream = data.Slice(dataStart, endStreamIndex - dataStart);
+        endOffset = endStreamIndex + EndStreamToken.Length;
+        return true;
+    }
+
+    private static int IndexOfToken(ReadOnlySpan<byte> data, ReadOnlySpan<byte> token, int start) {
+        var idx = data.Slice(start).IndexOf(token);
+        return idx < 0 ? -1 : start + idx;
+    }
+
+    private static int IndexOfToken(ReadOnlySpan<byte> data, byte a, byte b, int start) {
+        for (var i = start; i + 1 < data.Length; i++) {
+            if (data[i] == a && data[i + 1] == b) return i;
+        }
+        return -1;
+    }
+
+    private static int LastIndexOfToken(ReadOnlySpan<byte> data, byte a, byte b, int before) {
+        var start = Math.Min(before, data.Length - 2);
+        for (var i = start; i >= 0; i--) {
+            if (data[i] == a && data[i + 1] == b) return i;
+        }
+        return -1;
+    }
+
+    private static bool TryReadNumberAfterKey(ReadOnlySpan<byte> data, string key, out int value) {
+        value = 0;
+        var idx = data.IndexOf(System.Text.Encoding.ASCII.GetBytes(key));
+        if (idx < 0) return false;
+        var i = idx + key.Length;
+        while (i < data.Length && IsDelimiter(data[i])) i++;
+        var sign = 1;
+        if (i < data.Length && data[i] == '-') { sign = -1; i++; }
+        var found = false;
+        var result = 0;
+        while (i < data.Length && data[i] >= '0' && data[i] <= '9') {
+            found = true;
+            result = result * 10 + (data[i] - '0');
+            i++;
+        }
+        if (!found) return false;
+        value = result * sign;
+        return true;
+    }
+
+    private static bool TryReadNameAfterKey(ReadOnlySpan<byte> data, string key, out string name) {
+        name = string.Empty;
+        var idx = data.IndexOf(System.Text.Encoding.ASCII.GetBytes(key));
+        if (idx < 0) return false;
+        var i = idx + key.Length;
+        while (i < data.Length && IsDelimiter(data[i])) i++;
+        while (i < data.Length && data[i] != '/') {
+            if (!IsDelimiter(data[i])) return false;
+            i++;
+        }
+        if (i >= data.Length || data[i] != '/') return false;
+        i++;
+        var start = i;
+        while (i < data.Length && !IsDelimiter(data[i])) i++;
+        if (i <= start) return false;
+        name = System.Text.Encoding.ASCII.GetString(data.Slice(start, i - start));
+        return true;
+    }
+
+    private static bool IsDelimiter(byte b) {
+        return b == 0 || b == (byte)' ' || b == (byte)'\t' || b == (byte)'\r' || b == (byte)'\n'
+               || b == (byte)'/' || b == (byte)'<' || b == (byte)'>' || b == (byte)'[' || b == (byte)']'
+               || b == (byte)'(' || b == (byte)')';
+    }
+
+    private static byte[] DecompressFlate(ReadOnlySpan<byte> src, int expected) {
+        using var input = new MemoryStream(src.ToArray(), writable: false);
+#if NET8_0_OR_GREATER
+        Stream stream = LooksLikeZlib(src)
+            ? new ZLibStream(input, CompressionMode.Decompress, leaveOpen: true)
+            : new DeflateStream(input, CompressionMode.Decompress, leaveOpen: true);
+#else
+        Stream stream;
+        if (LooksLikeZlib(src)) {
+            if (src.Length < 6) throw new FormatException("Invalid PDF deflate stream.");
+            stream = new DeflateStream(new MemoryStream(src.Slice(2, src.Length - 6).ToArray(), writable: false), CompressionMode.Decompress, leaveOpen: true);
+        } else {
+            stream = new DeflateStream(input, CompressionMode.Decompress, leaveOpen: true);
+        }
+#endif
+        using (stream) {
+            var buffer = new byte[expected];
+            ReadExact(stream, buffer);
+            return buffer;
+        }
+    }
+
+    private static bool LooksLikeZlib(ReadOnlySpan<byte> data) {
+        if (data.Length < 2) return false;
+        var cmf = data[0];
+        var flg = data[1];
+        if ((cmf & 0x0F) != 8) return false;
+        return ((cmf << 8) + flg) % 31 == 0;
+    }
+
+    private static void ReadExact(Stream stream, byte[] buffer) {
+        var offset = 0;
+        while (offset < buffer.Length) {
+            var read = stream.Read(buffer, offset, buffer.Length - offset);
+            if (read <= 0) throw new FormatException("Truncated PDF image data.");
+            offset += read;
+        }
+    }
+
+    private static void ApplyTiffPredictor(byte[] data, int rowSize, int rows, int bytesPerPixel) {
+        if (bytesPerPixel <= 0) return;
+        for (var y = 0; y < rows; y++) {
+            var rowStart = y * rowSize;
+            for (var i = bytesPerPixel; i < rowSize; i++) {
+                data[rowStart + i] = unchecked((byte)(data[rowStart + i] + data[rowStart + i - bytesPerPixel]));
+            }
+        }
+    }
+
+    private static bool TryApplyPngPredictor(byte[] data, int width, int height, int colors, out byte[] output) {
+        output = new byte[width * height * colors];
+        var rowSize = width * colors;
+        var srcOffset = 0;
+        for (var y = 0; y < height; y++) {
+            if (srcOffset >= data.Length) return false;
+            var filter = data[srcOffset++];
+            if (srcOffset + rowSize > data.Length) return false;
+            var dstRow = y * rowSize;
+            var prevRow = y == 0 ? -1 : (y - 1) * rowSize;
+            for (var x = 0; x < rowSize; x++) {
+                var raw = data[srcOffset++];
+                var left = x >= colors ? output[dstRow + x - colors] : (byte)0;
+                var up = prevRow >= 0 ? output[prevRow + x] : (byte)0;
+                var upLeft = prevRow >= 0 && x >= colors ? output[prevRow + x - colors] : (byte)0;
+                byte value;
+                switch (filter) {
+                    case 0:
+                        value = raw;
+                        break;
+                    case 1:
+                        value = unchecked((byte)(raw + left));
+                        break;
+                    case 2:
+                        value = unchecked((byte)(raw + up));
+                        break;
+                    case 3:
+                        value = unchecked((byte)(raw + ((left + up) >> 1)));
+                        break;
+                    case 4:
+                        value = unchecked((byte)(raw + Paeth(left, up, upLeft)));
+                        break;
+                    default:
+                        return false;
+                }
+                output[dstRow + x] = value;
+            }
+        }
+        return true;
+    }
+
+    private static byte Paeth(byte a, byte b, byte c) {
+        var p = a + b - c;
+        var pa = Math.Abs(p - a);
+        var pb = Math.Abs(p - b);
+        var pc = Math.Abs(p - c);
+        if (pa <= pb && pa <= pc) return a;
+        if (pb <= pc) return b;
+        return c;
+    }
+
+    private readonly struct PdfImageInfo {
+        public PdfImageInfo(int width, int height, int bitsPerComponent, int colors, string? colorSpace, string? filter, int predictor) {
+            Width = width;
+            Height = height;
+            BitsPerComponent = bitsPerComponent;
+            Colors = colors;
+            ColorSpace = colorSpace;
+            Filter = filter;
+            Predictor = predictor;
+        }
+
+        public int Width { get; }
+        public int Height { get; }
+        public int BitsPerComponent { get; }
+        public int Colors { get; }
+        public string? ColorSpace { get; }
+        public string? Filter { get; }
+        public int Predictor { get; }
+    }
+}

--- a/CodeGlyphX/Rendering/Psd/PsdReader.cs
+++ b/CodeGlyphX/Rendering/Psd/PsdReader.cs
@@ -1,0 +1,178 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Psd;
+
+/// <summary>
+/// Minimal PSD decoder (flattened image only).
+/// </summary>
+public static class PsdReader {
+    private const uint Signature8Bps = 0x38425053; // "8BPS"
+
+    /// <summary>
+    /// Returns true when the data looks like a PSD file.
+    /// </summary>
+    public static bool IsPsd(ReadOnlySpan<byte> data) {
+        if (data.Length < 26) return false;
+        return ReadU32BE(data, 0) == Signature8Bps;
+    }
+
+    /// <summary>
+    /// Attempts to read PSD dimensions without decoding pixels.
+    /// </summary>
+    public static bool TryReadDimensions(ReadOnlySpan<byte> data, out int width, out int height) {
+        width = 0;
+        height = 0;
+        if (!IsPsd(data)) return false;
+        if (data.Length < 26) return false;
+        var version = ReadU16BE(data, 4);
+        if (version != 1 && version != 2) return false;
+        height = (int)ReadU32BE(data, 14);
+        width = (int)ReadU32BE(data, 18);
+        return width > 0 && height > 0;
+    }
+
+    /// <summary>
+    /// Decodes a PSD image to an RGBA buffer (flattened, 8-bit RGB/Grayscale only).
+    /// </summary>
+    public static byte[] DecodeRgba32(ReadOnlySpan<byte> data, out int width, out int height) {
+        if (!IsPsd(data)) throw new FormatException("Invalid PSD signature.");
+        if (data.Length < 26) throw new FormatException("Invalid PSD header.");
+
+        var version = ReadU16BE(data, 4);
+        if (version != 1 && version != 2) throw new FormatException("Unsupported PSD version.");
+
+        var channels = ReadU16BE(data, 12);
+        height = (int)ReadU32BE(data, 14);
+        width = (int)ReadU32BE(data, 18);
+        var depth = ReadU16BE(data, 22);
+        var colorMode = ReadU16BE(data, 24);
+
+        if (width <= 0 || height <= 0) throw new FormatException("Invalid PSD dimensions.");
+        if (channels <= 0) throw new FormatException("Invalid PSD channel count.");
+        if (depth != 8) throw new FormatException("Only 8-bit PSD images are supported.");
+        if (colorMode != 1 && colorMode != 3) throw new FormatException("Only Grayscale or RGB PSD images are supported.");
+        if (colorMode == 3 && channels < 3) throw new FormatException("RGB PSD must have at least 3 channels.");
+
+        var offset = 26;
+        offset = SkipSection(data, offset); // color mode data
+        offset = SkipSection(data, offset); // image resources
+        offset = SkipSection(data, offset); // layer and mask info
+        if (offset + 2 > data.Length) throw new FormatException("PSD image data is missing.");
+
+        var compression = ReadU16BE(data, offset);
+        offset += 2;
+        if (compression != 0 && compression != 1) throw new FormatException("Unsupported PSD compression.");
+
+        var pixelCount = checked(width * height);
+        var maxChannels = Math.Min(channels, 4);
+        var channelBuffers = new byte[maxChannels][];
+        for (var c = 0; c < maxChannels; c++) channelBuffers[c] = new byte[pixelCount];
+
+        if (compression == 0) {
+            var channelBytes = checked(width * height);
+            for (var c = 0; c < channels; c++) {
+                if (offset + channelBytes > data.Length) throw new FormatException("Truncated PSD data.");
+                if (c < maxChannels) {
+                    data.Slice(offset, channelBytes).CopyTo(channelBuffers[c]);
+                }
+                offset += channelBytes;
+            }
+        } else {
+            var rowCount = checked(channels * height);
+            var lengthsBytes = checked(rowCount * 2);
+            if (offset + lengthsBytes > data.Length) throw new FormatException("Truncated PSD RLE header.");
+            var rowLengths = new ushort[rowCount];
+            for (var i = 0; i < rowCount; i++) {
+                rowLengths[i] = ReadU16BE(data, offset + i * 2);
+            }
+            offset += lengthsBytes;
+
+            var rowBuffer = new byte[width];
+            for (var c = 0; c < channels; c++) {
+                for (var y = 0; y < height; y++) {
+                    var rowLength = rowLengths[c * height + y];
+                    if (offset + rowLength > data.Length) throw new FormatException("Truncated PSD RLE data.");
+                    var rowSpan = data.Slice(offset, rowLength);
+                    if (!TryDecodePackBitsRow(rowSpan, rowBuffer)) {
+                        throw new FormatException("Invalid PSD RLE data.");
+                    }
+                    if (c < maxChannels) {
+                        rowBuffer.CopyTo(channelBuffers[c].AsSpan(y * width, width));
+                    }
+                    offset += rowLength;
+                }
+            }
+        }
+
+        var rgba = new byte[pixelCount * 4];
+        if (colorMode == 3) {
+            var r = channelBuffers[0];
+            var g = channelBuffers[1];
+            var b = channelBuffers[2];
+            var a = channels > 3 ? channelBuffers[3] : null;
+            for (var i = 0; i < pixelCount; i++) {
+                var dst = i * 4;
+                rgba[dst + 0] = r[i];
+                rgba[dst + 1] = g[i];
+                rgba[dst + 2] = b[i];
+                rgba[dst + 3] = a is null ? (byte)255 : a[i];
+            }
+        } else {
+            var v = channelBuffers[0];
+            var a = channels > 1 ? channelBuffers[1] : null;
+            for (var i = 0; i < pixelCount; i++) {
+                var dst = i * 4;
+                var value = v[i];
+                rgba[dst + 0] = value;
+                rgba[dst + 1] = value;
+                rgba[dst + 2] = value;
+                rgba[dst + 3] = a is null ? (byte)255 : a[i];
+            }
+        }
+
+        return rgba;
+    }
+
+    private static int SkipSection(ReadOnlySpan<byte> data, int offset) {
+        if (offset + 4 > data.Length) throw new FormatException("Truncated PSD section.");
+        var length = (int)ReadU32BE(data, offset);
+        offset += 4;
+        if (length < 0 || offset + length > data.Length) throw new FormatException("Invalid PSD section length.");
+        return offset + length;
+    }
+
+    private static bool TryDecodePackBitsRow(ReadOnlySpan<byte> src, Span<byte> dst) {
+        var si = 0;
+        var di = 0;
+        while (si < src.Length && di < dst.Length) {
+            var n = unchecked((sbyte)src[si++]);
+            if (n >= 0) {
+                var count = n + 1;
+                if (si + count > src.Length || di + count > dst.Length) return false;
+                src.Slice(si, count).CopyTo(dst.Slice(di, count));
+                si += count;
+                di += count;
+            } else if (n != -128) {
+                var count = 1 - n;
+                if (si >= src.Length || di + count > dst.Length) return false;
+                var value = src[si++];
+                dst.Slice(di, count).Fill(value);
+                di += count;
+            }
+        }
+        return di == dst.Length;
+    }
+
+    private static ushort ReadU16BE(ReadOnlySpan<byte> data, int offset) {
+        if (offset < 0 || offset + 2 > data.Length) return 0;
+        return (ushort)((data[offset] << 8) | data[offset + 1]);
+    }
+
+    private static uint ReadU32BE(ReadOnlySpan<byte> data, int offset) {
+        if (offset < 0 || offset + 4 > data.Length) return 0;
+        return (uint)((data[offset] << 24)
+            | (data[offset + 1] << 16)
+            | (data[offset + 2] << 8)
+            | data[offset + 3]);
+    }
+}

--- a/CodeGlyphX/Rendering/Psd/PsdReader.cs
+++ b/CodeGlyphX/Rendering/Psd/PsdReader.cs
@@ -41,7 +41,7 @@ public static class PsdReader {
         var version = ReadU16BE(data, 4);
         if (version != 1 && version != 2) throw new FormatException("Unsupported PSD version.");
 
-        var channels = ReadU16BE(data, 12);
+        var channels = (int)ReadU16BE(data, 12);
         height = (int)ReadU32BE(data, 14);
         width = (int)ReadU32BE(data, 18);
         var depth = ReadU16BE(data, 22);

--- a/CodeGlyphX/Rendering/RenderExtensions.cs
+++ b/CodeGlyphX/Rendering/RenderExtensions.cs
@@ -156,6 +156,16 @@ public static class RenderExtensions {
     public static string ToWebpDataUri(this byte[] data) => data.ToDataUri("image/webp");
 
     /// <summary>
+    /// Encodes GIF bytes as a Base64 data URI.
+    /// </summary>
+    public static string ToGifDataUri(this byte[] data) => data.ToDataUri("image/gif");
+
+    /// <summary>
+    /// Encodes TIFF bytes as a Base64 data URI.
+    /// </summary>
+    public static string ToTiffDataUri(this byte[] data) => data.ToDataUri("image/tiff");
+
+    /// <summary>
     /// Encodes SVG content as a Base64 data URI.
     /// </summary>
     public static string ToSvgDataUri(this string svg, Encoding? encoding = null) {

--- a/CodeGlyphX/Rendering/RenderExtras.cs
+++ b/CodeGlyphX/Rendering/RenderExtras.cs
@@ -1,4 +1,7 @@
+using CodeGlyphX;
 using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Webp;
 
 namespace CodeGlyphX.Rendering;
 
@@ -25,4 +28,44 @@ public sealed class RenderExtras {
     /// ASCII render options for barcodes.
     /// </summary>
     public BarcodeAsciiRenderOptions? BarcodeAscii { get; set; }
+
+    /// <summary>
+    /// Optional GIF animation frames for matrix outputs.
+    /// </summary>
+    public BitMatrix[]? GifFrames { get; set; }
+
+    /// <summary>
+    /// Optional WebP animation frames for matrix outputs.
+    /// </summary>
+    public BitMatrix[]? WebpFrames { get; set; }
+
+    /// <summary>
+    /// Optional GIF animation frames for barcode outputs.
+    /// </summary>
+    public Barcode1D[]? BarcodeGifFrames { get; set; }
+
+    /// <summary>
+    /// Optional WebP animation frames for barcode outputs.
+    /// </summary>
+    public Barcode1D[]? BarcodeWebpFrames { get; set; }
+
+    /// <summary>
+    /// Optional per-frame durations (ms) for GIF/WebP animations.
+    /// </summary>
+    public int[]? AnimationDurationsMs { get; set; }
+
+    /// <summary>
+    /// Optional constant frame duration (ms) for GIF/WebP animations.
+    /// </summary>
+    public int AnimationDurationMs { get; set; } = 100;
+
+    /// <summary>
+    /// Optional GIF animation options.
+    /// </summary>
+    public GifAnimationOptions GifAnimationOptions { get; set; } = default;
+
+    /// <summary>
+    /// Optional WebP animation options.
+    /// </summary>
+    public WebpAnimationOptions WebpAnimationOptions { get; set; } = default;
 }

--- a/CodeGlyphX/Rendering/Tiff/BarcodeTiffRenderer.cs
+++ b/CodeGlyphX/Rendering/Tiff/BarcodeTiffRenderer.cs
@@ -1,0 +1,339 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Tiff;
+
+/// <summary>
+/// Renders 1D barcodes to a TIFF image (baseline, uncompressed).
+/// </summary>
+public static class BarcodeTiffRenderer {
+    /// <summary>
+    /// Renders the barcode to a TIFF byte array.
+    /// </summary>
+    public static byte[] Render(Barcode1D barcode, BarcodePngRenderOptions opts) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        return TiffWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF byte array.
+    /// </summary>
+    public static byte[] RenderBilevel(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevelFromRgba(ms, widthPx, heightPx, pixels, stride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, threshold, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF byte array using direct bar packing (label is ignored).
+    /// </summary>
+    public static byte[] RenderBilevelFromBars(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelBarcode(barcode, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevel(ms, widthPx, heightPx, packed, packedStride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF byte array.
+    /// </summary>
+    public static byte[] RenderBilevelTiled(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevelTiledFromRgba(ms, widthPx, heightPx, pixels, stride, tileWidth, tileHeight, compression, threshold, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF byte array using direct bar packing (label is ignored).
+    /// </summary>
+    public static byte[] RenderBilevelTiledFromBars(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelBarcode(barcode, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevelTiled(ms, widthPx, heightPx, packed, packedStride, tileWidth, tileHeight, compression, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the barcode to a TIFF stream.
+    /// </summary>
+    public static void RenderToStream(Barcode1D barcode, BarcodePngRenderOptions opts, Stream stream) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF stream.
+    /// </summary>
+    public static void RenderBilevelToStream(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        Stream stream,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteBilevelFromRgba(stream, widthPx, heightPx, pixels, stride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, threshold, photometric);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF stream using direct bar packing (label is ignored).
+    /// </summary>
+    public static void RenderBilevelFromBarsToStream(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        Stream stream,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelBarcode(barcode, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        TiffWriter.WriteBilevel(stream, widthPx, heightPx, packed, packedStride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, photometric);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF stream.
+    /// </summary>
+    public static void RenderBilevelTiledToStream(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        Stream stream,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = BarcodePngRenderer.RenderPixels(barcode, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteBilevelTiledFromRgba(stream, widthPx, heightPx, pixels, stride, tileWidth, tileHeight, compression, threshold, photometric);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF stream using direct bar packing (label is ignored).
+    /// </summary>
+    public static void RenderBilevelTiledFromBarsToStream(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        Stream stream,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelBarcode(barcode, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        TiffWriter.WriteBilevelTiled(stream, widthPx, heightPx, packed, packedStride, tileWidth, tileHeight, compression, photometric);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a TIFF file.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string path) {
+        var tiff = Render(barcode, opts);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF file.
+    /// </summary>
+    public static string RenderBilevelToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string path,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevel(barcode, opts, rowsPerStrip, compression, threshold, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF file using direct bar packing (label is ignored).
+    /// </summary>
+    public static string RenderBilevelFromBarsToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string path,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelFromBars(barcode, opts, rowsPerStrip, compression, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF file.
+    /// </summary>
+    public static string RenderBilevelTiledToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string path,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiled(barcode, opts, tileWidth, tileHeight, compression, threshold, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF file using direct bar packing (label is ignored).
+    /// </summary>
+    public static string RenderBilevelTiledFromBarsToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string path,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiledFromBars(barcode, opts, tileWidth, tileHeight, compression, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName) {
+        var tiff = Render(barcode, opts);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderBilevelToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string directory,
+        string fileName,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevel(barcode, opts, rowsPerStrip, compression, threshold, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) TIFF file under the specified directory using direct bar packing (label is ignored).
+    /// </summary>
+    public static string RenderBilevelFromBarsToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string directory,
+        string fileName,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelFromBars(barcode, opts, rowsPerStrip, compression, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderBilevelTiledToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string directory,
+        string fileName,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiled(barcode, opts, tileWidth, tileHeight, compression, threshold, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the barcode to a bilevel (1-bit) tiled TIFF file under the specified directory using direct bar packing (label is ignored).
+    /// </summary>
+    public static string RenderBilevelTiledFromBarsToFile(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        string directory,
+        string fileName,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiledFromBars(barcode, opts, tileWidth, tileHeight, compression, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    private static byte[] PackBilevelBarcode(
+        Barcode1D barcode,
+        BarcodePngRenderOptions opts,
+        ushort photometric,
+        out int widthPx,
+        out int heightPx,
+        out int packedStride) {
+        if (barcode is null) throw new ArgumentNullException(nameof(barcode));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+        if (opts.HeightModules <= 0) throw new ArgumentOutOfRangeException(nameof(opts.HeightModules));
+
+        var moduleSize = opts.ModuleSize;
+        var quiet = opts.QuietZone;
+        widthPx = checked((barcode.TotalModules + quiet * 2) * moduleSize);
+        heightPx = checked(opts.HeightModules * moduleSize);
+        packedStride = (widthPx + 7) / 8;
+
+        var fgLuma = (opts.Foreground.R * 77 + opts.Foreground.G * 150 + opts.Foreground.B * 29) >> 8;
+        var bgLuma = (opts.Background.R * 77 + opts.Background.G * 150 + opts.Background.B * 29) >> 8;
+        var foregroundIsDark = fgLuma <= bgLuma;
+
+        var packed = new byte[packedStride * heightPx];
+        var barMap = new bool[barcode.TotalModules];
+        var idx = 0;
+        foreach (var segment in barcode.Segments) {
+            for (var i = 0; i < segment.Modules && idx < barMap.Length; i++) {
+                barMap[idx++] = segment.IsBar;
+            }
+        }
+
+        for (var y = 0; y < heightPx; y++) {
+            var rowOffset = y * packedStride;
+            for (var x = 0; x < widthPx; x++) {
+                var moduleX = x / moduleSize - quiet;
+                var isBar = moduleX >= 0 && moduleX < barMap.Length && barMap[moduleX];
+                var isBlack = isBar ? foregroundIsDark : !foregroundIsDark;
+                var bit = photometric == 0 ? (isBlack ? 1 : 0) : (isBlack ? 0 : 1);
+                if (bit != 0) {
+                    packed[rowOffset + (x >> 3)] |= (byte)(1 << (7 - (x & 7)));
+                }
+            }
+        }
+
+        return packed;
+    }
+}

--- a/CodeGlyphX/Rendering/Tiff/MatrixTiffRenderer.cs
+++ b/CodeGlyphX/Rendering/Tiff/MatrixTiffRenderer.cs
@@ -1,0 +1,334 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Tiff;
+
+/// <summary>
+/// Renders matrix codes to a TIFF image (baseline, uncompressed).
+/// </summary>
+public static class MatrixTiffRenderer {
+    /// <summary>
+    /// Renders the module matrix to a TIFF byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, MatrixPngRenderOptions opts) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return TiffWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF byte array.
+    /// </summary>
+    public static byte[] RenderBilevel(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevelFromRgba(ms, widthPx, heightPx, pixels, stride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, threshold, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF byte array using direct module packing.
+    /// </summary>
+    public static byte[] RenderBilevelFromModules(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelModules(modules, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevel(ms, widthPx, heightPx, packed, packedStride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF byte array.
+    /// </summary>
+    public static byte[] RenderBilevelTiled(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevelTiledFromRgba(ms, widthPx, heightPx, pixels, stride, tileWidth, tileHeight, compression, threshold, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF byte array using direct module packing.
+    /// </summary>
+    public static byte[] RenderBilevelTiledFromModules(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelModules(modules, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        using var ms = new MemoryStream();
+        TiffWriter.WriteBilevelTiled(ms, widthPx, heightPx, packed, packedStride, tileWidth, tileHeight, compression, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a TIFF stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, MatrixPngRenderOptions opts, Stream stream) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF stream.
+    /// </summary>
+    public static void RenderBilevelToStream(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        Stream stream,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteBilevelFromRgba(stream, widthPx, heightPx, pixels, stride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, threshold, photometric);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF stream using direct module packing.
+    /// </summary>
+    public static void RenderBilevelFromModulesToStream(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        Stream stream,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelModules(modules, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        TiffWriter.WriteBilevel(stream, widthPx, heightPx, packed, packedStride, rowsPerStrip <= 0 ? heightPx : rowsPerStrip, compression, photometric);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF stream.
+    /// </summary>
+    public static void RenderBilevelTiledToStream(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        Stream stream,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var pixels = MatrixPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteBilevelTiledFromRgba(stream, widthPx, heightPx, pixels, stride, tileWidth, tileHeight, compression, threshold, photometric);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF stream using direct module packing.
+    /// </summary>
+    public static void RenderBilevelTiledFromModulesToStream(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        Stream stream,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var packed = PackBilevelModules(modules, opts, photometric, out var widthPx, out var heightPx, out var packedStride);
+        TiffWriter.WriteBilevelTiled(stream, widthPx, heightPx, packed, packedStride, tileWidth, tileHeight, compression, photometric);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a TIFF file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string path) {
+        var tiff = Render(modules, opts);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF file.
+    /// </summary>
+    public static string RenderBilevelToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string path,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevel(modules, opts, rowsPerStrip, compression, threshold, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF file using direct module packing.
+    /// </summary>
+    public static string RenderBilevelFromModulesToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string path,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelFromModules(modules, opts, rowsPerStrip, compression, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF file.
+    /// </summary>
+    public static string RenderBilevelTiledToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string path,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiled(modules, opts, tileWidth, tileHeight, compression, threshold, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF file using direct module packing.
+    /// </summary>
+    public static string RenderBilevelTiledFromModulesToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string path,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiledFromModules(modules, opts, tileWidth, tileHeight, compression, photometric);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName) {
+        var tiff = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderBilevelToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string directory,
+        string fileName,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevel(modules, opts, rowsPerStrip, compression, threshold, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) TIFF file under the specified directory using direct module packing.
+    /// </summary>
+    public static string RenderBilevelFromModulesToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string directory,
+        string fileName,
+        int rowsPerStrip = 0,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelFromModules(modules, opts, rowsPerStrip, compression, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderBilevelTiledToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string directory,
+        string fileName,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiled(modules, opts, tileWidth, tileHeight, compression, threshold, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    /// <summary>
+    /// Renders the module matrix to a bilevel (1-bit) tiled TIFF file under the specified directory using direct module packing.
+    /// </summary>
+    public static string RenderBilevelTiledFromModulesToFile(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        string directory,
+        string fileName,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        ushort photometric = 1) {
+        var tiff = RenderBilevelTiledFromModules(modules, opts, tileWidth, tileHeight, compression, photometric);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+
+    private static byte[] PackBilevelModules(
+        BitMatrix modules,
+        MatrixPngRenderOptions opts,
+        ushort photometric,
+        out int widthPx,
+        out int heightPx,
+        out int packedStride) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (opts is null) throw new ArgumentNullException(nameof(opts));
+        if (opts.ModuleSize <= 0) throw new ArgumentOutOfRangeException(nameof(opts.ModuleSize));
+        if (opts.QuietZone < 0) throw new ArgumentOutOfRangeException(nameof(opts.QuietZone));
+
+        var moduleSize = opts.ModuleSize;
+        var quiet = opts.QuietZone;
+        widthPx = checked((modules.Width + quiet * 2) * moduleSize);
+        heightPx = checked((modules.Height + quiet * 2) * moduleSize);
+        packedStride = (widthPx + 7) / 8;
+
+        var fgLuma = (opts.Foreground.R * 77 + opts.Foreground.G * 150 + opts.Foreground.B * 29) >> 8;
+        var bgLuma = (opts.Background.R * 77 + opts.Background.G * 150 + opts.Background.B * 29) >> 8;
+        var foregroundIsDark = fgLuma <= bgLuma;
+
+        var packed = new byte[packedStride * heightPx];
+        for (var y = 0; y < heightPx; y++) {
+            var moduleY = y / moduleSize - quiet;
+            var inY = moduleY >= 0 && moduleY < modules.Height;
+            var rowOffset = y * packedStride;
+            for (var x = 0; x < widthPx; x++) {
+                var moduleX = x / moduleSize - quiet;
+                var inX = moduleX >= 0 && moduleX < modules.Width;
+                var moduleOn = inX && inY && modules[moduleX, moduleY];
+                var isBlack = moduleOn ? foregroundIsDark : !foregroundIsDark;
+                var bit = photometric == 0 ? (isBlack ? 1 : 0) : (isBlack ? 0 : 1);
+                if (bit != 0) {
+                    var dst = rowOffset + (x >> 3);
+                    packed[dst] |= (byte)(1 << (7 - (x & 7)));
+                }
+            }
+        }
+
+        return packed;
+    }
+}

--- a/CodeGlyphX/Rendering/Tiff/QrTiffRenderer.cs
+++ b/CodeGlyphX/Rendering/Tiff/QrTiffRenderer.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Rendering.Tiff;
+
+/// <summary>
+/// Renders QR modules to a TIFF image (baseline, uncompressed).
+/// </summary>
+public static class QrTiffRenderer {
+    /// <summary>
+    /// Renders the QR module matrix to a TIFF byte array.
+    /// </summary>
+    public static byte[] Render(BitMatrix modules, QrPngRenderOptions opts) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        return TiffWriter.WriteRgba32(widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a TIFF stream.
+    /// </summary>
+    public static void RenderToStream(BitMatrix modules, QrPngRenderOptions opts, Stream stream) {
+        var pixels = QrPngRenderer.RenderPixels(modules, opts, out var widthPx, out var heightPx, out var stride);
+        TiffWriter.WriteRgba32(stream, widthPx, heightPx, pixels, stride);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a TIFF file.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string path) {
+        var tiff = Render(modules, opts);
+        return RenderIO.WriteBinary(path, tiff);
+    }
+
+    /// <summary>
+    /// Renders the QR module matrix to a TIFF file under the specified directory.
+    /// </summary>
+    public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName) {
+        var tiff = Render(modules, opts);
+        return RenderIO.WriteBinary(directory, fileName, tiff);
+    }
+}

--- a/CodeGlyphX/Rendering/Tiff/TiffCompression.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffCompression.cs
@@ -1,0 +1,26 @@
+namespace CodeGlyphX.Rendering.Tiff;
+
+/// <summary>
+/// TIFF compression options supported by the writer.
+/// </summary>
+public enum TiffCompression {
+    /// <summary>
+    /// No compression.
+    /// </summary>
+    None = 1,
+    /// <summary>
+    /// Deflate compression (zlib).
+    /// </summary>
+    /// <summary>
+    /// LZW compression.
+    /// </summary>
+    Lzw = 5,
+    /// <summary>
+    /// Deflate compression (zlib).
+    /// </summary>
+    Deflate = 8,
+    /// <summary>
+    /// PackBits compression.
+    /// </summary>
+    PackBits = 32773
+}

--- a/CodeGlyphX/Rendering/Tiff/TiffReader.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffReader.cs
@@ -5,9 +5,9 @@ using System.IO.Compression;
 namespace CodeGlyphX.Rendering.Tiff;
 
 /// <summary>
-/// Minimal TIFF decoder for uncompressed baseline images.
+/// Minimal TIFF decoder for baseline images (strips/tiles).
 /// </summary>
-internal static class TiffReader {
+public static class TiffReader {
     private const ushort Magic = 42;
     private const ushort TagImageWidth = 256;
     private const ushort TagImageLength = 257;
@@ -22,6 +22,10 @@ internal static class TiffReader {
     private const ushort TagPredictor = 317;
     private const ushort TagExtraSamples = 338;
     private const ushort TagColorMap = 320;
+    private const ushort TagTileWidth = 322;
+    private const ushort TagTileLength = 323;
+    private const ushort TagTileOffsets = 324;
+    private const ushort TagTileByteCounts = 325;
 
     private const ushort TypeByte = 1;
     private const ushort TypeShort = 3;
@@ -41,6 +45,39 @@ internal static class TiffReader {
         return ReadU16(data, 2, little) == Magic;
     }
 
+    /// <summary>
+    /// Attempts to decode all TIFF pages to RGBA buffers.
+    /// </summary>
+    public static bool TryDecodePagesRgba32(ReadOnlySpan<byte> data, out TiffRgba32Page[] pages) {
+        try {
+            pages = DecodePagesRgba32(data);
+            return true;
+        } catch (FormatException) {
+            pages = Array.Empty<TiffRgba32Page>();
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Decodes all TIFF pages to RGBA buffers.
+    /// </summary>
+    public static TiffRgba32Page[] DecodePagesRgba32(ReadOnlySpan<byte> data) {
+        if (!IsTiff(data)) throw new FormatException("Not a TIFF image.");
+
+        var little = data[0] == (byte)'I';
+        var ifdOffset = ReadU32(data, 4, little);
+        if (ifdOffset > data.Length - 2) throw new FormatException("Invalid TIFF IFD offset.");
+
+        var pages = new System.Collections.Generic.List<TiffRgba32Page>();
+        while (ifdOffset != 0) {
+            var rgba = DecodeRgba32Internal(data, little, (int)ifdOffset, out var width, out var height, out var nextIfdOffset);
+            pages.Add(new TiffRgba32Page(rgba, width, height, width * 4));
+            ifdOffset = nextIfdOffset <= 0 ? 0 : (uint)nextIfdOffset;
+        }
+
+        return pages.ToArray();
+    }
+
     public static byte[] DecodeRgba32(ReadOnlySpan<byte> data, out int width, out int height) {
         if (!IsTiff(data)) throw new FormatException("Not a TIFF image.");
 
@@ -48,8 +85,14 @@ internal static class TiffReader {
         var ifdOffset = ReadU32(data, 4, little);
         if (ifdOffset > data.Length - 2) throw new FormatException("Invalid TIFF IFD offset.");
 
-        var entryCount = ReadU16(data, (int)ifdOffset, little);
-        var entriesOffset = (int)ifdOffset + 2;
+        return DecodeRgba32Internal(data, little, (int)ifdOffset, out width, out height, out _);
+    }
+
+    private static byte[] DecodeRgba32Internal(ReadOnlySpan<byte> data, bool little, int ifdOffset, out int width, out int height, out int nextIfdOffset) {
+        if (ifdOffset < 0 || ifdOffset > data.Length - 2) throw new FormatException("Invalid TIFF IFD offset.");
+
+        var entryCount = ReadU16(data, ifdOffset, little);
+        var entriesOffset = ifdOffset + 2;
         var maxEntries = Math.Min(entryCount, (ushort)((data.Length - entriesOffset) / 12));
 
         width = 0;
@@ -65,6 +108,10 @@ internal static class TiffReader {
         int[]? stripByteCounts = null;
         ushort[]? colorMap = null;
         var hasExtraSamples = false;
+        var tileWidth = 0;
+        var tileLength = 0;
+        int[]? tileOffsets = null;
+        int[]? tileByteCounts = null;
 
         for (var i = 0; i < maxEntries; i++) {
             var entryOffset = entriesOffset + i * 12;
@@ -114,7 +161,25 @@ internal static class TiffReader {
                 case TagColorMap:
                     colorMap = ReadValuesUShort(valueSpan, type, little, (int)count);
                     break;
+                case TagTileWidth:
+                    tileWidth = (int)ReadValue(valueSpan, type, little, 0);
+                    break;
+                case TagTileLength:
+                    tileLength = (int)ReadValue(valueSpan, type, little, 0);
+                    break;
+                case TagTileOffsets:
+                    tileOffsets = ReadValuesInt(valueSpan, type, little, (int)count);
+                    break;
+                case TagTileByteCounts:
+                    tileByteCounts = ReadValuesInt(valueSpan, type, little, (int)count);
+                    break;
             }
+        }
+
+        nextIfdOffset = 0;
+        var ifdEnd = entriesOffset + entryCount * 12;
+        if (ifdEnd >= 0 && ifdEnd + 4 <= data.Length) {
+            nextIfdOffset = (int)ReadU32(data, ifdEnd, little);
         }
 
         if (width <= 0 || height <= 0) throw new FormatException("Invalid TIFF dimensions.");
@@ -125,7 +190,7 @@ internal static class TiffReader {
             && compression != CompressionDeflateAdobe) {
             throw new FormatException("Unsupported TIFF compression.");
         }
-        if (planar != 1) throw new FormatException("Unsupported TIFF planar configuration.");
+        if (planar != 1 && planar != 2) throw new FormatException("Unsupported TIFF planar configuration.");
 
         if (samplesPerPixel <= 0) {
             samplesPerPixel = bitsPerSample?.Length ?? 1;
@@ -138,144 +203,494 @@ internal static class TiffReader {
         for (var i = 1; i < bitsPerSample.Length; i++) {
             if (bitsPerSample[i] != bitsPerSampleValue) throw new FormatException("Mixed TIFF sample sizes are not supported.");
         }
-        if (bitsPerSampleValue != 8 && bitsPerSampleValue != 16) {
-            throw new FormatException("Only 8-bit or 16-bit TIFF samples are supported.");
+        var isPacked1 = bitsPerSampleValue == 1;
+        if (!isPacked1 && bitsPerSampleValue != 8 && bitsPerSampleValue != 16) {
+            throw new FormatException("Only 1-bit, 8-bit, or 16-bit TIFF samples are supported.");
+        }
+        if (isPacked1 && samplesPerPixel != 1) {
+            throw new FormatException("Packed 1-bit TIFF samples with multiple channels are not supported.");
+        }
+        if (isPacked1 && predictor == 2) {
+            throw new FormatException("TIFF predictor is not supported for 1-bit samples.");
         }
 
-        if (stripOffsets is null || stripByteCounts is null || stripOffsets.Length == 0) {
-            throw new FormatException("Missing TIFF strip data.");
+        var useTiles = tileOffsets is not null && tileByteCounts is not null && tileOffsets.Length > 0;
+        if (!useTiles) {
+            if (stripOffsets is null || stripByteCounts is null || stripOffsets.Length == 0) {
+                throw new FormatException("Missing TIFF strip data.");
+            }
+        } else if (tileWidth <= 0 || tileLength <= 0) {
+            throw new FormatException("Invalid TIFF tile dimensions.");
         }
         if (rowsPerStrip <= 0) rowsPerStrip = height;
 
         var rgba = new byte[width * height * 4];
-        var bytesPerSample = bitsPerSampleValue / 8;
-        var bytesPerPixel = samplesPerPixel * bytesPerSample;
-        var bytesPerRow = width * bytesPerPixel;
-        var row = 0;
         var paletteSize = colorMap is not null ? colorMap.Length / 3 : 0;
         var paletteStride = paletteSize;
 
-        for (var s = 0; s < stripOffsets.Length && row < height; s++) {
-            var offset = stripOffsets[s];
-            var count = stripByteCounts[Math.Min(s, stripByteCounts.Length - 1)];
-            if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF strip offset.");
-            if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF strip length.");
-
-            var rowsInStrip = Math.Min(rowsPerStrip, height - row);
-            var expected = rowsInStrip * bytesPerRow;
-            var src = data.Slice(offset, count);
-            if (compression == 1 && count < expected) throw new FormatException("TIFF strip too short.");
-
-            byte[]? decompressed = null;
-            ReadOnlySpan<byte> stripSpan;
-            if (compression == CompressionNone) {
-                if (predictor == 2) {
-                    decompressed = src.Slice(0, expected).ToArray();
-                    stripSpan = decompressed;
-                } else {
-                    stripSpan = src.Slice(0, expected);
+        if (isPacked1) {
+            if (photometric == 3 && paletteSize == 0) {
+                throw new FormatException("Missing TIFF palette data.");
+            }
+            if (photometric != 0 && photometric != 1 && photometric != 3) {
+                throw new FormatException("Unsupported TIFF photometric for 1-bit samples.");
+            }
+            var bytesPerRowPacked = (width + 7) / 8;
+            if (!useTiles) {
+                if (stripOffsets is null || stripByteCounts is null || stripOffsets.Length == 0) {
+                    throw new FormatException("Missing TIFF strip data.");
                 }
-            } else if (compression == CompressionPackBits) {
-                decompressed = new byte[expected];
-                var written = DecompressPackBits(src, decompressed);
-                if (written != expected) throw new FormatException("Invalid TIFF PackBits data.");
-                stripSpan = decompressed;
-            } else if (compression == CompressionLzw) {
-                decompressed = DecompressLzwCompat(src, expected);
-                stripSpan = decompressed;
-            } else {
-                decompressed = DecompressDeflate(src, expected);
-                stripSpan = decompressed;
-            }
+                var row = 0;
+                for (var s = 0; s < stripOffsets.Length && row < height; s++) {
+                    var offset = stripOffsets[s];
+                    var count = stripByteCounts[Math.Min(s, stripByteCounts.Length - 1)];
+                    if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF strip offset.");
+                    if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF strip length.");
 
-            if (predictor == 2) {
-                if (decompressed is null) throw new FormatException("TIFF predictor requires mutable buffer.");
-                ApplyPredictor(decompressed, bytesPerRow, samplesPerPixel, bytesPerSample, little);
-                stripSpan = decompressed;
-            }
+                    var rowsInStrip = Math.Min(rowsPerStrip, height - row);
+                    var expected = rowsInStrip * bytesPerRowPacked;
+                    var stripSpan = DecodeChunk(data, offset, count, expected, compression, predictor, bytesPerRowPacked, 1, 1, little, out _);
 
-            var srcIndex = 0;
-            for (var r = 0; r < rowsInStrip; r++) {
-                var dstRow = (row + r) * width * 4;
-                for (var x = 0; x < width; x++) {
-                    if (photometric == 3 && paletteSize > 0) {
-                        var idx = bytesPerSample == 2 ? ReadU16(stripSpan, srcIndex, little) : stripSpan[srcIndex];
-                        if (idx < paletteSize) {
-                            var r0 = (byte)(colorMap![idx] >> 8);
-                            var g0 = (byte)(colorMap![idx + paletteStride] >> 8);
-                            var b0 = (byte)(colorMap![idx + 2 * paletteStride] >> 8);
-                            rgba[dstRow + x * 4 + 0] = r0;
-                            rgba[dstRow + x * 4 + 1] = g0;
-                            rgba[dstRow + x * 4 + 2] = b0;
-                            rgba[dstRow + x * 4 + 3] = 255;
-                        } else {
-                            rgba[dstRow + x * 4 + 3] = 255;
+                    for (var r = 0; r < rowsInStrip; r++) {
+                        var dstRow = (row + r) * width * 4;
+                        var rowOffset = r * bytesPerRowPacked;
+                        for (var x = 0; x < width; x++) {
+                            var byteIndex = rowOffset + (x >> 3);
+                            var bit = (stripSpan[byteIndex] >> (7 - (x & 7))) & 1;
+                            WritePixelBit(bit, photometric, colorMap, paletteSize, paletteStride, rgba, dstRow + x * 4);
                         }
-                    } else if (photometric == 2 && samplesPerPixel >= 3) {
-                        if (bytesPerSample == 2) {
-                            var r16 = ReadU16(stripSpan, srcIndex + 0, little);
-                            var g16 = ReadU16(stripSpan, srcIndex + 2, little);
-                            var b16 = ReadU16(stripSpan, srcIndex + 4, little);
-                            var a16 = samplesPerPixel >= 4 ? ReadU16(stripSpan, srcIndex + 6, little) : (ushort)65535;
-                            rgba[dstRow + x * 4 + 0] = Scale16To8(r16);
-                            rgba[dstRow + x * 4 + 1] = Scale16To8(g16);
-                            rgba[dstRow + x * 4 + 2] = Scale16To8(b16);
-                            rgba[dstRow + x * 4 + 3] = Scale16To8(a16);
-                        } else {
-                            var r0 = stripSpan[srcIndex + 0];
-                            var g0 = stripSpan[srcIndex + 1];
-                            var b0 = stripSpan[srcIndex + 2];
-                            var a0 = samplesPerPixel >= 4 ? stripSpan[srcIndex + 3] : (byte)255;
-                            rgba[dstRow + x * 4 + 0] = r0;
-                            rgba[dstRow + x * 4 + 1] = g0;
-                            rgba[dstRow + x * 4 + 2] = b0;
-                            rgba[dstRow + x * 4 + 3] = a0;
-                        }
-                    } else if (samplesPerPixel >= 2 && hasExtraSamples) {
-                        if (bytesPerSample == 2) {
-                            var v16 = ReadU16(stripSpan, srcIndex, little);
-                            var a16 = ReadU16(stripSpan, srcIndex + 2, little);
-                            if (photometric == 0) v16 = (ushort)(65535 - v16);
-                            rgba[dstRow + x * 4 + 0] = Scale16To8(v16);
-                            rgba[dstRow + x * 4 + 1] = Scale16To8(v16);
-                            rgba[dstRow + x * 4 + 2] = Scale16To8(v16);
-                            rgba[dstRow + x * 4 + 3] = Scale16To8(a16);
-                        } else {
-                            var v = stripSpan[srcIndex];
-                            var a0 = stripSpan[srcIndex + 1];
-                            if (photometric == 0) v = (byte)(255 - v);
-                            rgba[dstRow + x * 4 + 0] = v;
-                            rgba[dstRow + x * 4 + 1] = v;
-                            rgba[dstRow + x * 4 + 2] = v;
-                            rgba[dstRow + x * 4 + 3] = a0;
-                        }
-                    } else if (samplesPerPixel >= 1) {
-                        if (bytesPerSample == 2) {
-                            var v16 = ReadU16(stripSpan, srcIndex, little);
-                            if (photometric == 0) v16 = (ushort)(65535 - v16);
-                            var v = Scale16To8(v16);
-                            rgba[dstRow + x * 4 + 0] = v;
-                            rgba[dstRow + x * 4 + 1] = v;
-                            rgba[dstRow + x * 4 + 2] = v;
-                            rgba[dstRow + x * 4 + 3] = 255;
-                        } else {
-                            var v = stripSpan[srcIndex];
-                            if (photometric == 0) v = (byte)(255 - v);
-                            rgba[dstRow + x * 4 + 0] = v;
-                            rgba[dstRow + x * 4 + 1] = v;
-                            rgba[dstRow + x * 4 + 2] = v;
-                            rgba[dstRow + x * 4 + 3] = 255;
-                        }
-                    } else {
-                        rgba[dstRow + x * 4 + 3] = 255;
                     }
-                    srcIndex += bytesPerPixel;
+                    row += rowsInStrip;
+                }
+            } else {
+                var tilesAcross = (width + tileWidth - 1) / tileWidth;
+                var tilesDown = (height + tileLength - 1) / tileLength;
+                var tileCount = Math.Min(tileOffsets!.Length, tileByteCounts!.Length);
+                var bytesPerTileRow = (tileWidth + 7) / 8;
+                var expectedBytes = tileLength * bytesPerTileRow;
+
+                for (var t = 0; t < tileCount && t < tilesAcross * tilesDown; t++) {
+                    var offset = tileOffsets[t];
+                    var count = tileByteCounts[Math.Min(t, tileByteCounts.Length - 1)];
+                    if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF tile offset.");
+                    if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF tile length.");
+
+                    var tileSpan = DecodeChunk(data, offset, count, expectedBytes, compression, predictor, bytesPerTileRow, 1, 1, little, out _);
+
+                    var tileX = (t % tilesAcross) * tileWidth;
+                    var tileY = (t / tilesAcross) * tileLength;
+                    for (var ty = 0; ty < tileLength; ty++) {
+                        var dstY = tileY + ty;
+                        if (dstY >= height) break;
+                        var dstRow = dstY * width * 4;
+                        var rowOffset = ty * bytesPerTileRow;
+                        for (var tx = 0; tx < tileWidth; tx++) {
+                            var dstX = tileX + tx;
+                            if (dstX >= width) break;
+                            var byteIndex = rowOffset + (tx >> 3);
+                            var bit = (tileSpan[byteIndex] >> (7 - (tx & 7))) & 1;
+                            WritePixelBit(bit, photometric, colorMap, paletteSize, paletteStride, rgba, dstRow + dstX * 4);
+                        }
+                    }
                 }
             }
-            row += rowsInStrip;
+
+            return rgba;
+        }
+
+        var bytesPerSample = bitsPerSampleValue / 8;
+        var bytesPerPixel = samplesPerPixel * bytesPerSample;
+        var bytesPerRow = width * bytesPerPixel;
+        var planeRowBytes = width * bytesPerSample;
+
+        if (!useTiles && planar == 1) {
+            var row = 0;
+            for (var s = 0; s < stripOffsets!.Length && row < height; s++) {
+                var offset = stripOffsets[s];
+                var count = stripByteCounts![Math.Min(s, stripByteCounts.Length - 1)];
+                if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF strip offset.");
+                if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF strip length.");
+
+                var rowsInStrip = Math.Min(rowsPerStrip, height - row);
+                var expected = rowsInStrip * bytesPerRow;
+                var stripSpan = DecodeChunk(data, offset, count, expected, compression, predictor, bytesPerRow, samplesPerPixel, bytesPerSample, little, out _);
+
+                var srcIndex = 0;
+                for (var r = 0; r < rowsInStrip; r++) {
+                    var dstRow = (row + r) * width * 4;
+                    for (var x = 0; x < width; x++) {
+                        WritePixel(stripSpan, srcIndex, photometric, samplesPerPixel, bytesPerSample, hasExtraSamples, little, colorMap, paletteSize, paletteStride, rgba, dstRow + x * 4);
+                        srcIndex += bytesPerPixel;
+                    }
+                }
+                row += rowsInStrip;
+            }
+        } else if (!useTiles && planar == 2) {
+            if (stripOffsets is null || stripByteCounts is null) throw new FormatException("Missing TIFF strip data.");
+            var stripsPerPlane = (height + rowsPerStrip - 1) / rowsPerStrip;
+            var expectedEntries = stripsPerPlane * samplesPerPixel;
+            if (stripOffsets.Length < expectedEntries || stripByteCounts.Length < expectedEntries) {
+                throw new FormatException("Invalid TIFF planar strip layout.");
+            }
+
+            var row = 0;
+            for (var s = 0; s < stripsPerPlane && row < height; s++) {
+                var rowsInStrip = Math.Min(rowsPerStrip, height - row);
+                var expected = rowsInStrip * planeRowBytes;
+
+                var planes = new byte[samplesPerPixel][];
+                for (var p = 0; p < samplesPerPixel; p++) {
+                    var index = p * stripsPerPlane + s;
+                    var offset = stripOffsets[index];
+                    var count = stripByteCounts[index];
+                    if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF strip offset.");
+                    if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF strip length.");
+                    var span = DecodeChunk(data, offset, count, expected, compression, predictor, planeRowBytes, 1, bytesPerSample, little, out var buffer);
+                    planes[p] = buffer ?? span.ToArray();
+                }
+
+                for (var r = 0; r < rowsInStrip; r++) {
+                    var dstRow = (row + r) * width * 4;
+                    var rowOffset = r * planeRowBytes;
+                    for (var x = 0; x < width; x++) {
+                        var srcIndex = rowOffset + x * bytesPerSample;
+                        WritePixelPlanar(planes, srcIndex, photometric, samplesPerPixel, bytesPerSample, hasExtraSamples, little, colorMap, paletteSize, paletteStride, rgba, dstRow + x * 4);
+                    }
+                }
+
+                row += rowsInStrip;
+            }
+        } else {
+            var tilesAcross = (width + tileWidth - 1) / tileWidth;
+            var tilesDown = (height + tileLength - 1) / tileLength;
+            var tileCount = Math.Min(tileOffsets!.Length, tileByteCounts!.Length);
+            var tileRowBytes = tileWidth * bytesPerPixel;
+            var expected = tileWidth * tileLength * bytesPerPixel;
+
+            if (planar == 1) {
+                for (var t = 0; t < tileCount && t < tilesAcross * tilesDown; t++) {
+                    var offset = tileOffsets[t];
+                    var count = tileByteCounts[Math.Min(t, tileByteCounts.Length - 1)];
+                    if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF tile offset.");
+                    if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF tile length.");
+
+                    var tileSpan = DecodeChunk(data, offset, count, expected, compression, predictor, tileRowBytes, samplesPerPixel, bytesPerSample, little, out _);
+
+                    var tileX = (t % tilesAcross) * tileWidth;
+                    var tileY = (t / tilesAcross) * tileLength;
+                    for (var ty = 0; ty < tileLength; ty++) {
+                        var dstY = tileY + ty;
+                        if (dstY >= height) break;
+                        var dstRow = dstY * width * 4;
+                        var srcRow = ty * tileRowBytes;
+                        for (var tx = 0; tx < tileWidth; tx++) {
+                            var dstX = tileX + tx;
+                            if (dstX >= width) break;
+                            var srcIndex = srcRow + tx * bytesPerPixel;
+                            WritePixel(tileSpan, srcIndex, photometric, samplesPerPixel, bytesPerSample, hasExtraSamples, little, colorMap, paletteSize, paletteStride, rgba, dstRow + dstX * 4);
+                        }
+                    }
+                }
+            } else {
+                var tilesPerPlane = tilesAcross * tilesDown;
+                var expectedEntries = tilesPerPlane * samplesPerPixel;
+                if (tileOffsets.Length < expectedEntries || tileByteCounts.Length < expectedEntries) {
+                    throw new FormatException("Invalid TIFF planar tile layout.");
+                }
+                var planeTileRowBytes = tileWidth * bytesPerSample;
+                var expectedPlane = tileWidth * tileLength * bytesPerSample;
+
+                for (var t = 0; t < tilesPerPlane; t++) {
+                    var planes = new byte[samplesPerPixel][];
+                    for (var p = 0; p < samplesPerPixel; p++) {
+                        var index = p * tilesPerPlane + t;
+                        var offset = tileOffsets[index];
+                        var count = tileByteCounts[index];
+                        if (offset < 0 || offset >= data.Length) throw new FormatException("Invalid TIFF tile offset.");
+                        if (count < 0 || offset + count > data.Length) throw new FormatException("Invalid TIFF tile length.");
+                        var span = DecodeChunk(data, offset, count, expectedPlane, compression, predictor, planeTileRowBytes, 1, bytesPerSample, little, out var buffer);
+                        planes[p] = buffer ?? span.ToArray();
+                    }
+
+                    var tileX = (t % tilesAcross) * tileWidth;
+                    var tileY = (t / tilesAcross) * tileLength;
+                    for (var ty = 0; ty < tileLength; ty++) {
+                        var dstY = tileY + ty;
+                        if (dstY >= height) break;
+                        var dstRow = dstY * width * 4;
+                        var srcRow = ty * planeTileRowBytes;
+                        for (var tx = 0; tx < tileWidth; tx++) {
+                            var dstX = tileX + tx;
+                            if (dstX >= width) break;
+                            var srcIndex = srcRow + tx * bytesPerSample;
+                            WritePixelPlanar(planes, srcIndex, photometric, samplesPerPixel, bytesPerSample, hasExtraSamples, little, colorMap, paletteSize, paletteStride, rgba, dstRow + dstX * 4);
+                        }
+                    }
+                }
+            }
         }
 
         return rgba;
+    }
+
+    private static ReadOnlySpan<byte> DecodeChunk(
+        ReadOnlySpan<byte> data,
+        int offset,
+        int count,
+        int expected,
+        int compression,
+        int predictor,
+        int bytesPerRow,
+        int samplesPerPixel,
+        int bytesPerSample,
+        bool little,
+        out byte[]? buffer) {
+        buffer = null;
+        var src = data.Slice(offset, count);
+        if (compression == CompressionNone) {
+            if (count < expected) throw new FormatException("TIFF strip too short.");
+            if (predictor == 2) {
+                buffer = src.Slice(0, expected).ToArray();
+                ApplyPredictor(buffer, bytesPerRow, samplesPerPixel, bytesPerSample, little);
+                return buffer;
+            }
+            return src.Slice(0, expected);
+        }
+
+        if (compression == CompressionPackBits) {
+            buffer = new byte[expected];
+            var written = DecompressPackBits(src, buffer);
+            if (written != expected) throw new FormatException("Invalid TIFF PackBits data.");
+        } else if (compression == CompressionLzw) {
+            buffer = DecompressLzwCompat(src, expected);
+        } else {
+            buffer = DecompressDeflate(src, expected);
+        }
+
+        if (predictor == 2) {
+            ApplyPredictor(buffer, bytesPerRow, samplesPerPixel, bytesPerSample, little);
+        }
+
+        return buffer;
+    }
+
+    private static void WritePixel(
+        ReadOnlySpan<byte> source,
+        int srcIndex,
+        int photometric,
+        int samplesPerPixel,
+        int bytesPerSample,
+        bool hasExtraSamples,
+        bool little,
+        ushort[]? colorMap,
+        int paletteSize,
+        int paletteStride,
+        byte[] rgba,
+        int dst) {
+        if (photometric == 3 && paletteSize > 0) {
+            var idx = bytesPerSample == 2 ? ReadU16(source, srcIndex, little) : source[srcIndex];
+            if (idx < paletteSize) {
+                var r0 = (byte)(colorMap![idx] >> 8);
+                var g0 = (byte)(colorMap[idx + paletteStride] >> 8);
+                var b0 = (byte)(colorMap[idx + 2 * paletteStride] >> 8);
+                rgba[dst + 0] = r0;
+                rgba[dst + 1] = g0;
+                rgba[dst + 2] = b0;
+                rgba[dst + 3] = 255;
+            } else {
+                rgba[dst + 3] = 255;
+            }
+        } else if (photometric == 2 && samplesPerPixel >= 3) {
+            if (bytesPerSample == 2) {
+                var r16 = ReadU16(source, srcIndex + 0, little);
+                var g16 = ReadU16(source, srcIndex + 2, little);
+                var b16 = ReadU16(source, srcIndex + 4, little);
+                var a16 = samplesPerPixel >= 4 ? ReadU16(source, srcIndex + 6, little) : (ushort)65535;
+                rgba[dst + 0] = Scale16To8(r16);
+                rgba[dst + 1] = Scale16To8(g16);
+                rgba[dst + 2] = Scale16To8(b16);
+                rgba[dst + 3] = Scale16To8(a16);
+            } else {
+                var r0 = source[srcIndex + 0];
+                var g0 = source[srcIndex + 1];
+                var b0 = source[srcIndex + 2];
+                var a0 = samplesPerPixel >= 4 ? source[srcIndex + 3] : (byte)255;
+                rgba[dst + 0] = r0;
+                rgba[dst + 1] = g0;
+                rgba[dst + 2] = b0;
+                rgba[dst + 3] = a0;
+            }
+        } else if (samplesPerPixel >= 2 && hasExtraSamples) {
+            if (bytesPerSample == 2) {
+                var v16 = ReadU16(source, srcIndex, little);
+                var a16 = ReadU16(source, srcIndex + 2, little);
+                if (photometric == 0) v16 = (ushort)(65535 - v16);
+                rgba[dst + 0] = Scale16To8(v16);
+                rgba[dst + 1] = Scale16To8(v16);
+                rgba[dst + 2] = Scale16To8(v16);
+                rgba[dst + 3] = Scale16To8(a16);
+            } else {
+                var v = source[srcIndex];
+                var a0 = source[srcIndex + 1];
+                if (photometric == 0) v = (byte)(255 - v);
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = a0;
+            }
+        } else if (samplesPerPixel >= 1) {
+            if (bytesPerSample == 2) {
+                var v16 = ReadU16(source, srcIndex, little);
+                if (photometric == 0) v16 = (ushort)(65535 - v16);
+                var v = Scale16To8(v16);
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = 255;
+            } else {
+                var v = source[srcIndex];
+                if (photometric == 0) v = (byte)(255 - v);
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = 255;
+            }
+        } else {
+            rgba[dst + 3] = 255;
+        }
+    }
+
+    private static void WritePixelBit(
+        int bit,
+        int photometric,
+        ushort[]? colorMap,
+        int paletteSize,
+        int paletteStride,
+        byte[] rgba,
+        int dst) {
+        if (photometric == 3 && paletteSize > 0) {
+            var idx = bit & 1;
+            if (idx < paletteSize) {
+                var r0 = (byte)(colorMap![idx] >> 8);
+                var g0 = (byte)(colorMap[idx + paletteStride] >> 8);
+                var b0 = (byte)(colorMap[idx + 2 * paletteStride] >> 8);
+                rgba[dst + 0] = r0;
+                rgba[dst + 1] = g0;
+                rgba[dst + 2] = b0;
+                rgba[dst + 3] = 255;
+            } else {
+                rgba[dst + 3] = 255;
+            }
+            return;
+        }
+
+        var v = (bit & 1) == 0 ? 0 : 255;
+        if (photometric == 0) v = 255 - v;
+        rgba[dst + 0] = (byte)v;
+        rgba[dst + 1] = (byte)v;
+        rgba[dst + 2] = (byte)v;
+        rgba[dst + 3] = 255;
+    }
+
+    private static void WritePixelPlanar(
+        byte[][] planes,
+        int srcIndex,
+        int photometric,
+        int samplesPerPixel,
+        int bytesPerSample,
+        bool hasExtraSamples,
+        bool little,
+        ushort[]? colorMap,
+        int paletteSize,
+        int paletteStride,
+        byte[] rgba,
+        int dst) {
+        if (planes.Length == 0) {
+            rgba[dst + 3] = 255;
+            return;
+        }
+
+        if (photometric == 3 && paletteSize > 0) {
+            var idx = bytesPerSample == 2 ? ReadU16(planes[0], srcIndex, little) : planes[0][srcIndex];
+            if (idx < paletteSize) {
+                var r0 = (byte)(colorMap![idx] >> 8);
+                var g0 = (byte)(colorMap[idx + paletteStride] >> 8);
+                var b0 = (byte)(colorMap[idx + 2 * paletteStride] >> 8);
+                rgba[dst + 0] = r0;
+                rgba[dst + 1] = g0;
+                rgba[dst + 2] = b0;
+                rgba[dst + 3] = 255;
+            } else {
+                rgba[dst + 3] = 255;
+            }
+            return;
+        }
+
+        if (photometric == 2 && samplesPerPixel >= 3 && planes.Length >= 3) {
+            if (bytesPerSample == 2) {
+                var r16 = ReadU16(planes[0], srcIndex, little);
+                var g16 = ReadU16(planes[1], srcIndex, little);
+                var b16 = ReadU16(planes[2], srcIndex, little);
+                var a16 = (samplesPerPixel >= 4 && planes.Length >= 4) ? ReadU16(planes[3], srcIndex, little) : (ushort)65535;
+                rgba[dst + 0] = Scale16To8(r16);
+                rgba[dst + 1] = Scale16To8(g16);
+                rgba[dst + 2] = Scale16To8(b16);
+                rgba[dst + 3] = Scale16To8(a16);
+            } else {
+                var r0 = planes[0][srcIndex];
+                var g0 = planes[1][srcIndex];
+                var b0 = planes[2][srcIndex];
+                var a0 = (samplesPerPixel >= 4 && planes.Length >= 4) ? planes[3][srcIndex] : (byte)255;
+                rgba[dst + 0] = r0;
+                rgba[dst + 1] = g0;
+                rgba[dst + 2] = b0;
+                rgba[dst + 3] = a0;
+            }
+            return;
+        }
+
+        if (samplesPerPixel >= 2 && hasExtraSamples && planes.Length >= 2) {
+            if (bytesPerSample == 2) {
+                var v16 = ReadU16(planes[0], srcIndex, little);
+                var a16 = ReadU16(planes[1], srcIndex, little);
+                if (photometric == 0) v16 = (ushort)(65535 - v16);
+                rgba[dst + 0] = Scale16To8(v16);
+                rgba[dst + 1] = Scale16To8(v16);
+                rgba[dst + 2] = Scale16To8(v16);
+                rgba[dst + 3] = Scale16To8(a16);
+            } else {
+                var v = planes[0][srcIndex];
+                var a0 = planes[1][srcIndex];
+                if (photometric == 0) v = (byte)(255 - v);
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = a0;
+            }
+            return;
+        }
+
+        if (samplesPerPixel >= 1) {
+            if (bytesPerSample == 2) {
+                var v16 = ReadU16(planes[0], srcIndex, little);
+                if (photometric == 0) v16 = (ushort)(65535 - v16);
+                var v = Scale16To8(v16);
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = 255;
+            } else {
+                var v = planes[0][srcIndex];
+                if (photometric == 0) v = (byte)(255 - v);
+                rgba[dst + 0] = v;
+                rgba[dst + 1] = v;
+                rgba[dst + 2] = v;
+                rgba[dst + 3] = 255;
+            }
+            return;
+        }
+
+        rgba[dst + 3] = 255;
     }
 
     private static int DecompressPackBits(ReadOnlySpan<byte> src, Span<byte> dst) {

--- a/CodeGlyphX/Rendering/Tiff/TiffReader.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffReader.cs
@@ -37,6 +37,9 @@ public static class TiffReader {
     private const int CompressionPackBits = 32773;
     private const int CompressionDeflateAdobe = 32946;
 
+    /// <summary>
+    /// Checks if the data starts with a valid TIFF header.
+    /// </summary>
     public static bool IsTiff(ReadOnlySpan<byte> data) {
         if (data.Length < 8) return false;
         var little = data[0] == (byte)'I' && data[1] == (byte)'I';
@@ -78,6 +81,9 @@ public static class TiffReader {
         return pages.ToArray();
     }
 
+    /// <summary>
+    /// Decodes the first TIFF page to an RGBA buffer.
+    /// </summary>
     public static byte[] DecodeRgba32(ReadOnlySpan<byte> data, out int width, out int height) {
         if (!IsTiff(data)) throw new FormatException("Not a TIFF image.");
 

--- a/CodeGlyphX/Rendering/Tiff/TiffRgba32Page.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffRgba32Page.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace CodeGlyphX.Rendering.Tiff;
+
+/// <summary>
+/// Describes a decoded TIFF page backed by an RGBA32 buffer.
+/// </summary>
+public readonly struct TiffRgba32Page {
+    /// <summary>
+    /// Creates a TIFF page backed by an RGBA32 buffer.
+    /// </summary>
+    public TiffRgba32Page(byte[] rgba, int width, int height, int stride) {
+        Rgba = rgba ?? throw new ArgumentNullException(nameof(rgba));
+        Width = width;
+        Height = height;
+        Stride = stride;
+    }
+
+    /// <summary>
+    /// RGBA32 pixel buffer.
+    /// </summary>
+    public byte[] Rgba { get; }
+
+    /// <summary>
+    /// Page width in pixels.
+    /// </summary>
+    public int Width { get; }
+
+    /// <summary>
+    /// Page height in pixels.
+    /// </summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Page stride in bytes.
+    /// </summary>
+    public int Stride { get; }
+}

--- a/CodeGlyphX/Rendering/Tiff/TiffWriter.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffWriter.cs
@@ -1,0 +1,1658 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+
+namespace CodeGlyphX.Rendering.Tiff;
+
+/// <summary>
+/// Writes TIFF images from RGBA buffers (baseline RGBA, optional PackBits/Deflate/LZW).
+/// </summary>
+public static class TiffWriter {
+    private const ushort EntryCount = 11;
+    private const ushort BilevelEntryCount = 9;
+    private const ushort BilevelTileEntryCount = 10;
+    private const ushort PredictorTag = 317;
+    private const int BitsPerSampleSize = 8;
+
+    /// <summary>
+    /// Writes a TIFF byte array from an RGBA buffer (single page).
+    /// </summary>
+    public static byte[] WriteRgba32(int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        using var ms = new MemoryStream();
+        WriteRgba32(ms, width, height, rgba, stride, height, TiffCompression.None);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page).
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        WriteRgba32(stream, width, height, rgba, stride, height, TiffCompression.None);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip.
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride, int rowsPerStrip) {
+        WriteRgba32(stream, width, height, rgba, stride, rowsPerStrip, TiffCompression.None);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip and compression.
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride, int rowsPerStrip, TiffCompression compression) {
+        WriteRgba32(stream, width, height, rgba, stride, rowsPerStrip, compression, usePredictor: false);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page) with configurable rows per strip, compression, and predictor.
+    /// </summary>
+    public static void WriteRgba32(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride, int rowsPerStrip, TiffCompression compression, bool usePredictor) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+        if (rowsPerStrip <= 0) throw new ArgumentOutOfRangeException(nameof(rowsPerStrip));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+
+        var rowSize = width * 4;
+        var stripRows = Math.Min(rowsPerStrip, height);
+        var stripCount = (height + stripRows - 1) / stripRows;
+        var imageSize = (long)rowSize * height;
+        if (imageSize > uint.MaxValue) throw new ArgumentException("TIFF image exceeds 4GB.");
+
+        var entryCount = (ushort)(EntryCount + (usePredictor ? 1 : 0));
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var bitsPerSampleOffset = 8 + ifdSize;
+        var offset = bitsPerSampleOffset + BitsPerSampleSize;
+        var stripOffsetsValue = 0u;
+        var stripByteCountsValue = 0u;
+        uint[]? stripOffsets = null;
+        uint[]? stripByteCounts = null;
+        byte[][]? stripData = null;
+        uint imageOffset;
+
+        if (compression != TiffCompression.None) {
+            stripData = new byte[stripCount][];
+            for (var s = 0; s < stripCount; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                var raw = new byte[rowsInStrip * rowSize];
+                for (var y = 0; y < rowsInStrip; y++) {
+                    var srcRow = (s * stripRows + y) * stride;
+                    rgba.Slice(srcRow, rowSize).CopyTo(raw.AsSpan(y * rowSize, rowSize));
+                }
+                if (usePredictor) {
+                    ApplyHorizontalPredictor(raw, rowSize, rowsInStrip, bytesPerPixel: 4);
+                }
+                var encoded = EncodeCompressed(raw, compression);
+                stripData[s] = encoded;
+            }
+            if (stripCount == 1) {
+                imageOffset = (uint)offset;
+                stripOffsetsValue = imageOffset;
+                stripByteCountsValue = (uint)stripData[0].Length;
+            } else {
+                stripOffsets = new uint[stripCount];
+                stripByteCounts = new uint[stripCount];
+                stripOffsetsValue = (uint)offset;
+                offset += stripCount * 4;
+                stripByteCountsValue = (uint)offset;
+                offset += stripCount * 4;
+                imageOffset = (uint)offset;
+
+                var current = imageOffset;
+                for (var s = 0; s < stripCount; s++) {
+                    stripOffsets[s] = current;
+                    stripByteCounts[s] = (uint)stripData[s].Length;
+                    current += stripByteCounts[s];
+                }
+            }
+        } else if (stripCount == 1) {
+            imageOffset = (uint)offset;
+            stripOffsetsValue = imageOffset;
+            stripByteCountsValue = (uint)imageSize;
+        } else {
+            stripOffsetsValue = (uint)offset;
+            offset += stripCount * 4;
+            stripByteCountsValue = (uint)offset;
+            offset += stripCount * 4;
+            imageOffset = (uint)offset;
+
+            stripOffsets = new uint[stripCount];
+            stripByteCounts = new uint[stripCount];
+            var current = imageOffset;
+            for (var s = 0; s < stripCount; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                var count = (uint)(rowSize * rowsInStrip);
+                stripOffsets[s] = current;
+                stripByteCounts[s] = count;
+                current += count;
+            }
+        }
+
+        WriteHeader(stream);
+        WriteUInt16(stream, entryCount);
+
+        WriteEntry(stream, 256, 4, 1, (uint)width); // ImageWidth
+        WriteEntry(stream, 257, 4, 1, (uint)height); // ImageLength
+        WriteEntry(stream, 258, 3, 4, (uint)bitsPerSampleOffset); // BitsPerSample
+        WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+        WriteEntry(stream, 262, 3, 1, 2); // PhotometricInterpretation (RGB)
+        WriteEntry(stream, 273, 4, (uint)stripCount, stripOffsetsValue); // StripOffsets
+        WriteEntry(stream, 277, 3, 1, 4); // SamplesPerPixel
+        WriteEntry(stream, 278, 4, 1, (uint)stripRows); // RowsPerStrip
+        WriteEntry(stream, 279, 4, (uint)stripCount, stripByteCountsValue); // StripByteCounts
+        WriteEntry(stream, 284, 3, 1, 1); // PlanarConfiguration (contiguous)
+        WriteEntry(stream, 338, 3, 1, 1); // ExtraSamples (unassociated alpha)
+        if (usePredictor) {
+            WriteEntry(stream, PredictorTag, 3, 1, 2); // Predictor (horizontal)
+        }
+
+        WriteUInt32(stream, 0); // next IFD
+
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+
+        if (stripCount > 1) {
+            for (var s = 0; s < stripCount; s++) {
+                WriteUInt32(stream, stripOffsets![s]);
+            }
+            for (var s = 0; s < stripCount; s++) {
+                WriteUInt32(stream, stripByteCounts![s]);
+            }
+        }
+
+        if (compression != TiffCompression.None) {
+            for (var s = 0; s < stripCount; s++) {
+                var encoded = stripData![s];
+                stream.Write(encoded, 0, encoded.Length);
+            }
+        } else {
+            var rowBuffer = new byte[rowSize];
+            for (var s = 0; s < stripCount; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                for (var y = 0; y < rowsInStrip; y++) {
+                    var srcRow = (s * stripRows + y) * stride;
+                    rgba.Slice(srcRow, rowSize).CopyTo(rowBuffer);
+                    if (usePredictor) {
+                        ApplyHorizontalPredictor(rowBuffer, rowSize, rows: 1, bytesPerPixel: 4);
+                    }
+                    stream.Write(rowBuffer, 0, rowBuffer.Length);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from a packed 1-bit buffer (single page).
+    /// </summary>
+    public static byte[] WriteBilevel(int width, int height, ReadOnlySpan<byte> packed, int stride) {
+        using var ms = new MemoryStream();
+        WriteBilevel(ms, width, height, packed, stride, height, TiffCompression.None, photometric: 1);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from a packed 1-bit buffer (single page).
+    /// </summary>
+    public static void WriteBilevel(Stream stream, int width, int height, ReadOnlySpan<byte> packed, int stride) {
+        WriteBilevel(stream, width, height, packed, stride, height, TiffCompression.None, photometric: 1);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from a packed 1-bit buffer (single page) with configurable rows per strip.
+    /// </summary>
+    public static void WriteBilevel(Stream stream, int width, int height, ReadOnlySpan<byte> packed, int stride, int rowsPerStrip) {
+        WriteBilevel(stream, width, height, packed, stride, rowsPerStrip, TiffCompression.None, photometric: 1);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from a packed 1-bit buffer (single page) with configurable rows per strip and compression.
+    /// </summary>
+    public static void WriteBilevel(
+        Stream stream,
+        int width,
+        int height,
+        ReadOnlySpan<byte> packed,
+        int stride,
+        int rowsPerStrip,
+        TiffCompression compression,
+        ushort photometric = 1) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (rowsPerStrip <= 0) throw new ArgumentOutOfRangeException(nameof(rowsPerStrip));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+        if (photometric != 0 && photometric != 1) {
+            throw new ArgumentOutOfRangeException(nameof(photometric));
+        }
+
+        var rowSize = (width + 7) / 8;
+        if (stride < rowSize) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (packed.Length < (height - 1) * stride + rowSize) throw new ArgumentException("Packed buffer is too small.", nameof(packed));
+
+        var stripRows = Math.Min(rowsPerStrip, height);
+        var stripCount = (height + stripRows - 1) / stripRows;
+        var imageSize = (long)rowSize * height;
+        if (imageSize > uint.MaxValue) throw new ArgumentException("TIFF image exceeds 4GB.");
+
+        var entryCount = BilevelEntryCount;
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var offset = 8 + ifdSize;
+        var stripOffsetsValue = 0u;
+        var stripByteCountsValue = 0u;
+        uint[]? stripOffsets = null;
+        uint[]? stripByteCounts = null;
+        byte[][]? stripData = null;
+        uint imageOffset;
+
+        if (compression != TiffCompression.None) {
+            stripData = new byte[stripCount][];
+            for (var s = 0; s < stripCount; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                var raw = new byte[rowsInStrip * rowSize];
+                for (var y = 0; y < rowsInStrip; y++) {
+                    var srcRow = (s * stripRows + y) * stride;
+                    packed.Slice(srcRow, rowSize).CopyTo(raw.AsSpan(y * rowSize, rowSize));
+                }
+                var encoded = EncodeCompressed(raw, compression);
+                stripData[s] = encoded;
+            }
+            if (stripCount == 1) {
+                imageOffset = (uint)offset;
+                stripOffsetsValue = imageOffset;
+                stripByteCountsValue = (uint)stripData[0].Length;
+            } else {
+                stripOffsets = new uint[stripCount];
+                stripByteCounts = new uint[stripCount];
+                stripOffsetsValue = (uint)offset;
+                offset += stripCount * 4;
+                stripByteCountsValue = (uint)offset;
+                offset += stripCount * 4;
+                imageOffset = (uint)offset;
+
+                var current = imageOffset;
+                for (var s = 0; s < stripCount; s++) {
+                    stripOffsets[s] = current;
+                    stripByteCounts[s] = (uint)stripData[s].Length;
+                    current += stripByteCounts[s];
+                }
+            }
+        } else if (stripCount == 1) {
+            imageOffset = (uint)offset;
+            stripOffsetsValue = imageOffset;
+            stripByteCountsValue = (uint)imageSize;
+        } else {
+            stripOffsetsValue = (uint)offset;
+            offset += stripCount * 4;
+            stripByteCountsValue = (uint)offset;
+            offset += stripCount * 4;
+            imageOffset = (uint)offset;
+
+            stripOffsets = new uint[stripCount];
+            stripByteCounts = new uint[stripCount];
+            var current = imageOffset;
+            for (var s = 0; s < stripCount; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                var count = (uint)(rowSize * rowsInStrip);
+                stripOffsets[s] = current;
+                stripByteCounts[s] = count;
+                current += count;
+            }
+        }
+
+        WriteHeader(stream);
+        WriteUInt16(stream, entryCount);
+
+        WriteEntry(stream, 256, 4, 1, (uint)width); // ImageWidth
+        WriteEntry(stream, 257, 4, 1, (uint)height); // ImageLength
+        WriteEntry(stream, 258, 3, 1, 1); // BitsPerSample
+        WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+        WriteEntry(stream, 262, 3, 1, photometric); // PhotometricInterpretation
+        WriteEntry(stream, 273, 4, (uint)stripCount, stripOffsetsValue); // StripOffsets
+        WriteEntry(stream, 277, 3, 1, 1); // SamplesPerPixel
+        WriteEntry(stream, 278, 4, 1, (uint)stripRows); // RowsPerStrip
+        WriteEntry(stream, 279, 4, (uint)stripCount, stripByteCountsValue); // StripByteCounts
+
+        WriteUInt32(stream, 0); // next IFD
+
+        if (stripCount > 1) {
+            for (var s = 0; s < stripCount; s++) {
+                WriteUInt32(stream, stripOffsets![s]);
+            }
+            for (var s = 0; s < stripCount; s++) {
+                WriteUInt32(stream, stripByteCounts![s]);
+            }
+        }
+
+        if (compression != TiffCompression.None) {
+            for (var s = 0; s < stripCount; s++) {
+                var encoded = stripData![s];
+                stream.Write(encoded, 0, encoded.Length);
+            }
+        } else {
+            var rowBuffer = new byte[rowSize];
+            for (var s = 0; s < stripCount; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                for (var y = 0; y < rowsInStrip; y++) {
+                    var srcRow = (s * stripRows + y) * stride;
+                    packed.Slice(srcRow, rowSize).CopyTo(rowBuffer);
+                    stream.Write(rowBuffer, 0, rowBuffer.Length);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from an RGBA buffer (single page) as a 1-bit bilevel image.
+    /// </summary>
+    public static byte[] WriteBilevelFromRgba(int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        using var ms = new MemoryStream();
+        WriteBilevelFromRgba(ms, width, height, rgba, stride, height, TiffCompression.None, threshold: 128, photometric: 1);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page) as a 1-bit bilevel image.
+    /// </summary>
+    public static void WriteBilevelFromRgba(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        WriteBilevelFromRgba(stream, width, height, rgba, stride, height, TiffCompression.None, threshold: 128, photometric: 1);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page) as a 1-bit bilevel image with configurable rows per strip, compression, and threshold.
+    /// </summary>
+    public static void WriteBilevelFromRgba(
+        Stream stream,
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int rowsPerStrip,
+        TiffCompression compression,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+        if (photometric != 0 && photometric != 1) throw new ArgumentOutOfRangeException(nameof(photometric));
+
+        var packedStride = (width + 7) / 8;
+        var packed = PackBilevelFromRgba(width, height, rgba, stride, packedStride, threshold, photometric);
+        WriteBilevel(stream, width, height, packed, packedStride, rowsPerStrip <= 0 ? height : rowsPerStrip, compression, photometric);
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from a packed 1-bit buffer (single page) as tiled data.
+    /// </summary>
+    public static byte[] WriteBilevelTiled(int width, int height, ReadOnlySpan<byte> packed, int stride, int tileWidth, int tileHeight) {
+        using var ms = new MemoryStream();
+        WriteBilevelTiled(ms, width, height, packed, stride, tileWidth, tileHeight, TiffCompression.None, photometric: 1);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from a packed 1-bit buffer (single page) as tiled data with compression.
+    /// </summary>
+    public static byte[] WriteBilevelTiled(
+        int width,
+        int height,
+        ReadOnlySpan<byte> packed,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression,
+        ushort photometric = 1) {
+        using var ms = new MemoryStream();
+        WriteBilevelTiled(ms, width, height, packed, stride, tileWidth, tileHeight, compression, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from a packed 1-bit buffer (single page) as tiled data.
+    /// </summary>
+    public static void WriteBilevelTiled(Stream stream, int width, int height, ReadOnlySpan<byte> packed, int stride, int tileWidth, int tileHeight) {
+        WriteBilevelTiled(stream, width, height, packed, stride, tileWidth, tileHeight, TiffCompression.None, photometric: 1);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from a packed 1-bit buffer (single page) as tiled data with compression.
+    /// </summary>
+    public static void WriteBilevelTiled(
+        Stream stream,
+        int width,
+        int height,
+        ReadOnlySpan<byte> packed,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression,
+        ushort photometric = 1) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (tileWidth <= 0) throw new ArgumentOutOfRangeException(nameof(tileWidth));
+        if (tileHeight <= 0) throw new ArgumentOutOfRangeException(nameof(tileHeight));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+        if (photometric != 0 && photometric != 1) {
+            throw new ArgumentOutOfRangeException(nameof(photometric));
+        }
+
+        var rowSize = (width + 7) / 8;
+        if (stride < rowSize) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (packed.Length < (height - 1) * stride + rowSize) throw new ArgumentException("Packed buffer is too small.", nameof(packed));
+
+        var tilesAcross = (width + tileWidth - 1) / tileWidth;
+        var tilesDown = (height + tileHeight - 1) / tileHeight;
+        if (tilesAcross <= 0 || tilesDown <= 0) throw new ArgumentOutOfRangeException(nameof(tileWidth));
+        var tileCount = checked(tilesAcross * tilesDown);
+
+        var tileRowBytes = (tileWidth + 7) / 8;
+        var tileBytesLong = (long)tileRowBytes * tileHeight;
+        if (tileBytesLong > int.MaxValue) throw new ArgumentException("Tile size is too large.");
+        var tileBytes = (int)tileBytesLong;
+
+        var entryCount = BilevelTileEntryCount;
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var offset = 8 + ifdSize;
+        var tileOffsetsValue = 0u;
+        var tileByteCountsValue = 0u;
+        uint[]? tileOffsets = null;
+        uint[]? tileByteCounts = null;
+        byte[][]? tileData = null;
+
+        if (tileCount == 1) {
+            tileOffsetsValue = (uint)offset;
+            if (compression == TiffCompression.None) {
+                tileByteCountsValue = (uint)tileBytes;
+            }
+        } else {
+            tileOffsetsValue = (uint)offset;
+            offset += tileCount * 4;
+            tileByteCountsValue = (uint)offset;
+            offset += tileCount * 4;
+            tileOffsets = new uint[tileCount];
+            tileByteCounts = new uint[tileCount];
+        }
+
+        if (compression != TiffCompression.None) {
+            tileData = new byte[tileCount][];
+            var tileBuffer = new byte[tileBytes];
+            var current = (uint)offset;
+            for (var t = 0; t < tileCount; t++) {
+                FillTileBilevel(packed, width, height, stride, tileWidth, tileHeight, tilesAcross, t, tileBuffer, photometric);
+                var encoded = EncodeCompressed(tileBuffer, compression);
+                tileData[t] = encoded;
+                if (tileCount > 1) {
+                    tileOffsets![t] = current;
+                    tileByteCounts![t] = (uint)encoded.Length;
+                    current += tileByteCounts[t];
+                } else {
+                    tileByteCountsValue = (uint)encoded.Length;
+                }
+            }
+        } else if (tileCount > 1) {
+            var current = (uint)offset;
+            for (var t = 0; t < tileCount; t++) {
+                tileOffsets![t] = current;
+                tileByteCounts![t] = (uint)tileBytes;
+                current += (uint)tileBytes;
+            }
+        }
+
+        WriteHeader(stream);
+        WriteUInt16(stream, entryCount);
+        WriteEntry(stream, 256, 4, 1, (uint)width); // ImageWidth
+        WriteEntry(stream, 257, 4, 1, (uint)height); // ImageLength
+        WriteEntry(stream, 258, 3, 1, 1); // BitsPerSample
+        WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+        WriteEntry(stream, 262, 3, 1, photometric); // PhotometricInterpretation
+        WriteEntry(stream, 277, 3, 1, 1); // SamplesPerPixel
+        WriteEntry(stream, 322, 4, 1, (uint)tileWidth); // TileWidth
+        WriteEntry(stream, 323, 4, 1, (uint)tileHeight); // TileLength
+        WriteEntry(stream, 324, 4, (uint)tileCount, tileOffsetsValue); // TileOffsets
+        WriteEntry(stream, 325, 4, (uint)tileCount, tileByteCountsValue); // TileByteCounts
+
+        WriteUInt32(stream, 0); // next IFD
+
+        if (tileCount > 1) {
+            for (var t = 0; t < tileCount; t++) {
+                WriteUInt32(stream, tileOffsets![t]);
+            }
+            for (var t = 0; t < tileCount; t++) {
+                WriteUInt32(stream, tileByteCounts![t]);
+            }
+        }
+
+        if (compression != TiffCompression.None) {
+            for (var t = 0; t < tileCount; t++) {
+                var encoded = tileData![t];
+                stream.Write(encoded, 0, encoded.Length);
+            }
+        } else {
+            var tileBuffer = new byte[tileBytes];
+            for (var t = 0; t < tileCount; t++) {
+                FillTileBilevel(packed, width, height, stride, tileWidth, tileHeight, tilesAcross, t, tileBuffer, photometric);
+                stream.Write(tileBuffer, 0, tileBuffer.Length);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from an RGBA buffer (single page) as tiled bilevel data.
+    /// </summary>
+    public static byte[] WriteBilevelTiledFromRgba(
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        using var ms = new MemoryStream();
+        WriteBilevelTiledFromRgba(ms, width, height, rgba, stride, tileWidth, tileHeight, compression, threshold, photometric);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from an RGBA buffer (single page) as tiled bilevel data.
+    /// </summary>
+    public static void WriteBilevelTiledFromRgba(
+        Stream stream,
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression = TiffCompression.None,
+        byte threshold = 128,
+        ushort photometric = 1) {
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+        if (photometric != 0 && photometric != 1) throw new ArgumentOutOfRangeException(nameof(photometric));
+
+        var packedStride = (width + 7) / 8;
+        var packed = PackBilevelFromRgba(width, height, rgba, stride, packedStride, threshold, photometric);
+        WriteBilevelTiled(stream, width, height, packed, packedStride, tileWidth, tileHeight, compression, photometric);
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF byte array from an RGBA buffer (single page).
+    /// </summary>
+    public static byte[] WriteRgba32Tiled(int width, int height, ReadOnlySpan<byte> rgba, int stride, int tileWidth, int tileHeight) {
+        using var ms = new MemoryStream();
+        WriteRgba32Tiled(ms, width, height, rgba, stride, tileWidth, tileHeight, TiffCompression.None, usePredictor: false);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF byte array from an RGBA buffer (single page) with compression and predictor.
+    /// </summary>
+    public static byte[] WriteRgba32Tiled(
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression,
+        bool usePredictor) {
+        using var ms = new MemoryStream();
+        WriteRgba32Tiled(ms, width, height, rgba, stride, tileWidth, tileHeight, compression, usePredictor);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF to a stream from an RGBA buffer (single page).
+    /// </summary>
+    public static void WriteRgba32Tiled(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride, int tileWidth, int tileHeight) {
+        WriteRgba32Tiled(stream, width, height, rgba, stride, tileWidth, tileHeight, TiffCompression.None, usePredictor: false);
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF to a stream from an RGBA buffer (single page) with compression and predictor.
+    /// </summary>
+    public static void WriteRgba32Tiled(
+        Stream stream,
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression,
+        bool usePredictor) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+        if (tileWidth <= 0) throw new ArgumentOutOfRangeException(nameof(tileWidth));
+        if (tileHeight <= 0) throw new ArgumentOutOfRangeException(nameof(tileHeight));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+
+        var tilesAcross = (width + tileWidth - 1) / tileWidth;
+        var tilesDown = (height + tileHeight - 1) / tileHeight;
+        if (tilesAcross <= 0 || tilesDown <= 0) throw new ArgumentOutOfRangeException(nameof(tileWidth));
+        var tileCount = checked(tilesAcross * tilesDown);
+
+        var tileRowBytes = checked(tileWidth * 4);
+        var tileBytesLong = (long)tileRowBytes * tileHeight;
+        if (tileBytesLong > int.MaxValue) throw new ArgumentException("Tile size is too large.");
+        var tileBytes = (int)tileBytesLong;
+
+        var entryCount = (ushort)(12 + (usePredictor ? 1 : 0));
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var bitsPerSampleOffset = 8 + ifdSize;
+        var offset = bitsPerSampleOffset + BitsPerSampleSize;
+        var tileOffsetsValue = 0u;
+        var tileByteCountsValue = 0u;
+        uint[]? tileOffsets = null;
+        uint[]? tileByteCounts = null;
+        byte[][]? tileData = null;
+
+        if (tileCount == 1) {
+            tileOffsetsValue = (uint)offset;
+            if (compression == TiffCompression.None) {
+                tileByteCountsValue = (uint)tileBytes;
+            }
+        } else {
+            tileOffsetsValue = (uint)offset;
+            offset += tileCount * 4;
+            tileByteCountsValue = (uint)offset;
+            offset += tileCount * 4;
+            tileOffsets = new uint[tileCount];
+            tileByteCounts = new uint[tileCount];
+        }
+
+        if (compression != TiffCompression.None) {
+            tileData = new byte[tileCount][];
+            var tileBuffer = new byte[tileBytes];
+            var current = (uint)offset;
+            for (var t = 0; t < tileCount; t++) {
+                FillTileRgba(rgba, width, height, stride, tileWidth, tileHeight, tilesAcross, t, tileBuffer);
+                if (usePredictor) {
+                    ApplyHorizontalPredictor(tileBuffer, tileRowBytes, tileHeight, bytesPerPixel: 4);
+                }
+                var encoded = EncodeCompressed(tileBuffer, compression);
+                tileData[t] = encoded;
+                if (tileCount > 1) {
+                    tileOffsets![t] = current;
+                    tileByteCounts![t] = (uint)encoded.Length;
+                    current += tileByteCounts[t];
+                } else {
+                    tileByteCountsValue = (uint)encoded.Length;
+                }
+            }
+        } else if (tileCount > 1) {
+            var current = (uint)offset;
+            for (var t = 0; t < tileCount; t++) {
+                tileOffsets![t] = current;
+                tileByteCounts![t] = (uint)tileBytes;
+                current += (uint)tileBytes;
+            }
+        }
+
+        WriteHeader(stream);
+        WriteUInt16(stream, entryCount);
+        WriteEntry(stream, 256, 4, 1, (uint)width); // ImageWidth
+        WriteEntry(stream, 257, 4, 1, (uint)height); // ImageLength
+        WriteEntry(stream, 258, 3, 4, (uint)bitsPerSampleOffset); // BitsPerSample
+        WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+        WriteEntry(stream, 262, 3, 1, 2); // PhotometricInterpretation (RGB)
+        WriteEntry(stream, 277, 3, 1, 4); // SamplesPerPixel
+        WriteEntry(stream, 322, 4, 1, (uint)tileWidth); // TileWidth
+        WriteEntry(stream, 323, 4, 1, (uint)tileHeight); // TileLength
+        WriteEntry(stream, 324, 4, (uint)tileCount, tileOffsetsValue); // TileOffsets
+        WriteEntry(stream, 325, 4, (uint)tileCount, tileByteCountsValue); // TileByteCounts
+        WriteEntry(stream, 284, 3, 1, 1); // PlanarConfiguration (contiguous)
+        WriteEntry(stream, 338, 3, 1, 1); // ExtraSamples (unassociated alpha)
+        if (usePredictor) {
+            WriteEntry(stream, PredictorTag, 3, 1, 2); // Predictor (horizontal)
+        }
+
+        WriteUInt32(stream, 0); // next IFD
+
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+
+        if (tileCount > 1) {
+            for (var t = 0; t < tileCount; t++) {
+                WriteUInt32(stream, tileOffsets![t]);
+            }
+            for (var t = 0; t < tileCount; t++) {
+                WriteUInt32(stream, tileByteCounts![t]);
+            }
+        }
+
+        if (compression != TiffCompression.None) {
+            for (var t = 0; t < tileCount; t++) {
+                var encoded = tileData![t];
+                stream.Write(encoded, 0, encoded.Length);
+            }
+        } else {
+            var tileBuffer = new byte[tileBytes];
+            for (var t = 0; t < tileCount; t++) {
+                FillTileRgba(rgba, width, height, stride, tileWidth, tileHeight, tilesAcross, t, tileBuffer);
+                if (usePredictor) {
+                    ApplyHorizontalPredictor(tileBuffer, tileRowBytes, tileHeight, bytesPerPixel: 4);
+                }
+                stream.Write(tileBuffer, 0, tileBuffer.Length);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a planar TIFF byte array from an RGBA buffer (single page).
+    /// </summary>
+    public static byte[] WriteRgba32Planar(int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        using var ms = new MemoryStream();
+        WriteRgba32Planar(ms, width, height, rgba, stride);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a planar TIFF byte array from an RGBA buffer (single page) with rows per strip, compression, and predictor.
+    /// </summary>
+    public static byte[] WriteRgba32Planar(
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int rowsPerStrip,
+        TiffCompression compression,
+        bool usePredictor) {
+        using var ms = new MemoryStream();
+        WriteRgba32Planar(ms, width, height, rgba, stride, rowsPerStrip, compression, usePredictor);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a planar TIFF to a stream from an RGBA buffer (single page).
+    /// </summary>
+    public static void WriteRgba32Planar(Stream stream, int width, int height, ReadOnlySpan<byte> rgba, int stride) {
+        WriteRgba32Planar(stream, width, height, rgba, stride, height, TiffCompression.None, usePredictor: false);
+    }
+
+    /// <summary>
+    /// Writes a planar TIFF to a stream from an RGBA buffer with rows per strip, compression, and predictor.
+    /// </summary>
+    public static void WriteRgba32Planar(
+        Stream stream,
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int rowsPerStrip,
+        TiffCompression compression,
+        bool usePredictor) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height));
+        if (stride < width * 4) throw new ArgumentOutOfRangeException(nameof(stride));
+        if (rgba.Length < (height - 1) * stride + width * 4) throw new ArgumentException("RGBA buffer is too small.", nameof(rgba));
+        if (rowsPerStrip <= 0) throw new ArgumentOutOfRangeException(nameof(rowsPerStrip));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+
+        var planeRowBytes = width;
+        var stripRows = Math.Min(rowsPerStrip, height);
+        var stripsPerPlane = (height + stripRows - 1) / stripRows;
+        var totalStrips = stripsPerPlane * 4;
+        var entryCount = (ushort)(EntryCount + (usePredictor ? 1 : 0));
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var bitsPerSampleOffset = 8 + ifdSize;
+        var stripOffsetsOffset = bitsPerSampleOffset + BitsPerSampleSize;
+        var stripByteCountsOffset = stripOffsetsOffset + totalStrips * 4;
+        var dataOffset = stripByteCountsOffset + totalStrips * 4;
+
+        var offsets = new uint[totalStrips];
+        var counts = new uint[totalStrips];
+        byte[][]? stripData = compression == TiffCompression.None ? null : new byte[totalStrips][];
+
+        var current = (uint)dataOffset;
+        for (var plane = 0; plane < 4; plane++) {
+            for (var s = 0; s < stripsPerPlane; s++) {
+                var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                var rawSize = rowsInStrip * planeRowBytes;
+                var raw = new byte[rawSize];
+                for (var y = 0; y < rowsInStrip; y++) {
+                    var srcRow = (s * stripRows + y) * stride;
+                    for (var x = 0; x < width; x++) {
+                        raw[y * planeRowBytes + x] = rgba[srcRow + x * 4 + plane];
+                    }
+                }
+                if (usePredictor) {
+                    ApplyHorizontalPredictor(raw, planeRowBytes, rowsInStrip, bytesPerPixel: 1);
+                }
+
+                var index = plane * stripsPerPlane + s;
+                if (compression == TiffCompression.None) {
+                    counts[index] = (uint)raw.Length;
+                    offsets[index] = current;
+                    current += counts[index];
+                } else {
+                    var encoded = EncodeCompressed(raw, compression);
+                    stripData![index] = encoded;
+                    counts[index] = (uint)encoded.Length;
+                    offsets[index] = current;
+                    current += counts[index];
+                }
+            }
+        }
+
+        WriteHeader(stream);
+        WriteUInt16(stream, entryCount);
+
+        WriteEntry(stream, 256, 4, 1, (uint)width); // ImageWidth
+        WriteEntry(stream, 257, 4, 1, (uint)height); // ImageLength
+        WriteEntry(stream, 258, 3, 4, (uint)bitsPerSampleOffset); // BitsPerSample
+        WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+        WriteEntry(stream, 262, 3, 1, 2); // PhotometricInterpretation (RGB)
+        WriteEntry(stream, 273, 4, (uint)totalStrips, (uint)stripOffsetsOffset); // StripOffsets
+        WriteEntry(stream, 277, 3, 1, 4); // SamplesPerPixel
+        WriteEntry(stream, 278, 4, 1, (uint)stripRows); // RowsPerStrip
+        WriteEntry(stream, 279, 4, (uint)totalStrips, (uint)stripByteCountsOffset); // StripByteCounts
+        WriteEntry(stream, 284, 3, 1, 2); // PlanarConfiguration (separate)
+        WriteEntry(stream, 338, 3, 1, 1); // ExtraSamples (unassociated alpha)
+        if (usePredictor) {
+            WriteEntry(stream, PredictorTag, 3, 1, 2); // Predictor (horizontal)
+        }
+
+        WriteUInt32(stream, 0); // next IFD
+
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+        WriteUInt16(stream, 8);
+
+        for (var i = 0; i < totalStrips; i++) {
+            WriteUInt32(stream, offsets[i]);
+        }
+        for (var i = 0; i < totalStrips; i++) {
+            WriteUInt32(stream, counts[i]);
+        }
+
+        if (compression == TiffCompression.None) {
+            var rowBuffer = new byte[planeRowBytes];
+            for (var plane = 0; plane < 4; plane++) {
+                for (var s = 0; s < stripsPerPlane; s++) {
+                    var rowsInStrip = Math.Min(stripRows, height - s * stripRows);
+                    for (var y = 0; y < rowsInStrip; y++) {
+                        var srcRow = (s * stripRows + y) * stride;
+                        for (var x = 0; x < width; x++) {
+                            rowBuffer[x] = rgba[srcRow + x * 4 + plane];
+                        }
+                        if (usePredictor) {
+                            ApplyHorizontalPredictor(rowBuffer, planeRowBytes, rows: 1, bytesPerPixel: 1);
+                        }
+                        stream.Write(rowBuffer, 0, rowBuffer.Length);
+                    }
+                }
+            }
+        } else {
+            for (var i = 0; i < totalStrips; i++) {
+                var encoded = stripData![i];
+                stream.Write(encoded, 0, encoded.Length);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from RGBA buffers (multi-page).
+    /// </summary>
+    public static byte[] WriteRgba32Pages(params TiffRgba32Page[] pages) {
+        using var ms = new MemoryStream();
+        WriteRgba32Pages(ms, pages, int.MaxValue, TiffCompression.None, usePredictor: false);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from RGBA buffers (multi-page).
+    /// </summary>
+    public static void WriteRgba32Pages(Stream stream, TiffRgba32Page[] pages) {
+        WriteRgba32Pages(stream, pages, int.MaxValue, TiffCompression.None, usePredictor: false);
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from RGBA buffers (multi-page) with compression and predictor.
+    /// </summary>
+    public static byte[] WriteRgba32Pages(TiffCompression compression, bool usePredictor, params TiffRgba32Page[] pages) {
+        using var ms = new MemoryStream();
+        WriteRgba32Pages(ms, pages, int.MaxValue, compression, usePredictor);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF byte array from RGBA buffers (multi-page) with rows per strip, compression, and predictor.
+    /// </summary>
+    public static byte[] WriteRgba32Pages(int rowsPerStrip, TiffCompression compression, bool usePredictor, params TiffRgba32Page[] pages) {
+        using var ms = new MemoryStream();
+        WriteRgba32Pages(ms, pages, rowsPerStrip, compression, usePredictor);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from RGBA buffers (multi-page) with compression and predictor.
+    /// </summary>
+    public static void WriteRgba32Pages(Stream stream, TiffRgba32Page[] pages, TiffCompression compression, bool usePredictor) {
+        WriteRgba32Pages(stream, pages, int.MaxValue, compression, usePredictor);
+    }
+
+    /// <summary>
+    /// Writes a TIFF to a stream from RGBA buffers (multi-page) with rows per strip, compression, and predictor.
+    /// </summary>
+    public static void WriteRgba32Pages(Stream stream, TiffRgba32Page[] pages, int rowsPerStrip, TiffCompression compression, bool usePredictor) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (pages is null) throw new ArgumentNullException(nameof(pages));
+        if (pages.Length == 0) throw new ArgumentException("At least one page is required.", nameof(pages));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+        if (rowsPerStrip <= 0) throw new ArgumentOutOfRangeException(nameof(rowsPerStrip));
+
+        var entryCount = (ushort)(EntryCount + (usePredictor ? 1 : 0));
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var pageCount = pages.Length;
+        var ifdOffsets = new uint[pageCount];
+        var bitsOffsets = new uint[pageCount];
+        var imageSizes = new uint[pageCount];
+        var nextOffsets = new uint[pageCount];
+        var stripCounts = new int[pageCount];
+        var stripOffsetsValues = new uint[pageCount];
+        var stripByteCountsValues = new uint[pageCount];
+        uint[][]? stripOffsets = null;
+        uint[][]? stripByteCounts = null;
+        byte[][][]? stripData = null;
+
+        long cursor = 8;
+        for (var i = 0; i < pageCount; i++) {
+            var page = pages[i];
+            ValidatePage(page);
+
+            var rowSize = page.Width * 4;
+            var stripRows = Math.Min(rowsPerStrip, page.Height);
+            var stripCount = (page.Height + stripRows - 1) / stripRows;
+            stripCounts[i] = stripCount;
+            var useArrays = stripCount > 1;
+            var dataOffset = cursor + ifdSize + BitsPerSampleSize + (useArrays ? stripCount * 8L : 0);
+
+            if (dataOffset > uint.MaxValue) throw new ArgumentException("TIFF content exceeds 4GB.");
+            ifdOffsets[i] = (uint)cursor;
+            bitsOffsets[i] = (uint)(cursor + ifdSize);
+            stripOffsetsValues[i] = useArrays ? (uint)(cursor + ifdSize + BitsPerSampleSize) : (uint)dataOffset;
+            stripByteCountsValues[i] = useArrays ? (uint)(cursor + ifdSize + BitsPerSampleSize + stripCount * 4L) : 0;
+
+            if (compression != TiffCompression.None) {
+                stripData ??= new byte[pageCount][][];
+                stripByteCounts ??= new uint[pageCount][];
+                stripOffsets ??= new uint[pageCount][];
+                stripData[i] = new byte[stripCount][];
+                stripByteCounts[i] = new uint[stripCount];
+                stripOffsets[i] = useArrays ? new uint[stripCount] : Array.Empty<uint>();
+                for (var s = 0; s < stripCount; s++) {
+                    var rowsInStrip = Math.Min(stripRows, page.Height - s * stripRows);
+                    var rawSize = (long)rowsInStrip * rowSize;
+                    if (rawSize > int.MaxValue) throw new ArgumentException("TIFF image exceeds 2GB for compressed pages.");
+                    var raw = new byte[(int)rawSize];
+                    for (var y = 0; y < rowsInStrip; y++) {
+                        var srcRow = (s * stripRows + y) * page.Stride;
+                        page.Rgba.AsSpan(srcRow, rowSize).CopyTo(raw.AsSpan(y * rowSize, rowSize));
+                    }
+                    if (usePredictor) {
+                        ApplyHorizontalPredictor(raw, rowSize, rowsInStrip, bytesPerPixel: 4);
+                    }
+                    var encoded = EncodeCompressed(raw, compression);
+                    stripData[i][s] = encoded;
+                    stripByteCounts[i][s] = (uint)encoded.Length;
+                }
+
+                var current = (uint)dataOffset;
+                for (var s = 0; s < stripCount; s++) {
+                    if (useArrays) stripOffsets![i][s] = current;
+                    current += stripByteCounts[i][s];
+                }
+                imageSizes[i] = current - (uint)dataOffset;
+                if (stripCount == 1) {
+                    stripOffsetsValues[i] = (uint)dataOffset;
+                    stripByteCountsValues[i] = stripByteCounts[i][0];
+                }
+            } else {
+                var imageSize = (long)rowSize * page.Height;
+                if (imageSize > uint.MaxValue) throw new ArgumentException("TIFF image exceeds 4GB.");
+                imageSizes[i] = (uint)imageSize;
+                if (useArrays) {
+                    stripOffsets ??= new uint[pageCount][];
+                    stripByteCounts ??= new uint[pageCount][];
+                    stripOffsets[i] = new uint[stripCount];
+                    stripByteCounts[i] = new uint[stripCount];
+                    var current = (uint)dataOffset;
+                    for (var s = 0; s < stripCount; s++) {
+                        var rowsInStrip = Math.Min(stripRows, page.Height - s * stripRows);
+                        var count = (uint)(rowsInStrip * rowSize);
+                        stripOffsets[i][s] = current;
+                        stripByteCounts[i][s] = count;
+                        current += count;
+                    }
+                    imageSizes[i] = current - (uint)dataOffset;
+                } else {
+                    stripByteCountsValues[i] = (uint)imageSize;
+                }
+            }
+
+            cursor = dataOffset + imageSizes[i];
+            if (cursor > uint.MaxValue) throw new ArgumentException("TIFF content exceeds 4GB.");
+        }
+
+        for (var i = 0; i < pageCount; i++) {
+            nextOffsets[i] = i < pageCount - 1 ? ifdOffsets[i + 1] : 0;
+        }
+
+        WriteHeader(stream);
+        for (var i = 0; i < pageCount; i++) {
+            var page = pages[i];
+            var stripCount = stripCounts[i];
+            var stripRows = Math.Min(rowsPerStrip, page.Height);
+            var useArrays = stripCount > 1;
+            WriteUInt16(stream, entryCount);
+
+            WriteEntry(stream, 256, 4, 1, (uint)page.Width); // ImageWidth
+            WriteEntry(stream, 257, 4, 1, (uint)page.Height); // ImageLength
+            WriteEntry(stream, 258, 3, 4, bitsOffsets[i]); // BitsPerSample
+            WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+            WriteEntry(stream, 262, 3, 1, 2); // PhotometricInterpretation (RGB)
+            WriteEntry(stream, 273, 4, (uint)stripCount, stripOffsetsValues[i]); // StripOffsets
+            WriteEntry(stream, 277, 3, 1, 4); // SamplesPerPixel
+            WriteEntry(stream, 278, 4, 1, (uint)stripRows); // RowsPerStrip
+            WriteEntry(stream, 279, 4, (uint)stripCount, stripByteCountsValues[i]); // StripByteCounts
+            WriteEntry(stream, 284, 3, 1, 1); // PlanarConfiguration (contiguous)
+            WriteEntry(stream, 338, 3, 1, 1); // ExtraSamples (unassociated alpha)
+            if (usePredictor) {
+                WriteEntry(stream, PredictorTag, 3, 1, 2); // Predictor (horizontal)
+            }
+
+            WriteUInt32(stream, nextOffsets[i]); // next IFD
+
+            WriteUInt16(stream, 8);
+            WriteUInt16(stream, 8);
+            WriteUInt16(stream, 8);
+            WriteUInt16(stream, 8);
+
+            if (useArrays) {
+                var offsets = stripOffsets![i];
+                var counts = stripByteCounts![i];
+                for (var s = 0; s < stripCount; s++) {
+                    WriteUInt32(stream, offsets[s]);
+                }
+                for (var s = 0; s < stripCount; s++) {
+                    WriteUInt32(stream, counts[s]);
+                }
+            }
+
+            if (compression != TiffCompression.None) {
+                var encoded = stripData![i];
+                for (var s = 0; s < stripCount; s++) {
+                    var data = encoded[s];
+                    stream.Write(data, 0, data.Length);
+                }
+            } else {
+                var rowBytes = page.Width * 4;
+                var rowBuffer = usePredictor ? new byte[rowBytes] : null;
+                for (var s = 0; s < stripCount; s++) {
+                    var rowsInStrip = Math.Min(stripRows, page.Height - s * stripRows);
+                    for (var y = 0; y < rowsInStrip; y++) {
+                        var srcRow = (s * stripRows + y) * page.Stride;
+                        if (usePredictor) {
+                            page.Rgba.AsSpan(srcRow, rowBytes).CopyTo(rowBuffer);
+                            ApplyHorizontalPredictor(rowBuffer!, rowBytes, rows: 1, bytesPerPixel: 4);
+                            stream.Write(rowBuffer!, 0, rowBuffer!.Length);
+                        } else {
+                            stream.Write(page.Rgba, srcRow, rowBytes);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF byte array from RGBA buffers (multi-page).
+    /// </summary>
+    public static byte[] WriteRgba32PagesTiled(int tileWidth, int tileHeight, params TiffRgba32Page[] pages) {
+        using var ms = new MemoryStream();
+        WriteRgba32PagesTiled(ms, pages, tileWidth, tileHeight, TiffCompression.None, usePredictor: false);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF byte array from RGBA buffers (multi-page) with compression and predictor.
+    /// </summary>
+    public static byte[] WriteRgba32PagesTiled(
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression,
+        bool usePredictor,
+        params TiffRgba32Page[] pages) {
+        using var ms = new MemoryStream();
+        WriteRgba32PagesTiled(ms, pages, tileWidth, tileHeight, compression, usePredictor);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a tiled TIFF to a stream from RGBA buffers (multi-page) with compression and predictor.
+    /// </summary>
+    public static void WriteRgba32PagesTiled(
+        Stream stream,
+        TiffRgba32Page[] pages,
+        int tileWidth,
+        int tileHeight,
+        TiffCompression compression,
+        bool usePredictor) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        if (pages is null) throw new ArgumentNullException(nameof(pages));
+        if (pages.Length == 0) throw new ArgumentException("At least one page is required.", nameof(pages));
+        if (tileWidth <= 0) throw new ArgumentOutOfRangeException(nameof(tileWidth));
+        if (tileHeight <= 0) throw new ArgumentOutOfRangeException(nameof(tileHeight));
+        if (compression != TiffCompression.None && compression != TiffCompression.PackBits && compression != TiffCompression.Deflate && compression != TiffCompression.Lzw) {
+            throw new ArgumentOutOfRangeException(nameof(compression));
+        }
+
+        var entryCount = (ushort)(12 + (usePredictor ? 1 : 0));
+        var ifdSize = 2 + entryCount * 12 + 4;
+        var pageCount = pages.Length;
+        var ifdOffsets = new uint[pageCount];
+        var bitsOffsets = new uint[pageCount];
+        var tileCounts = new int[pageCount];
+        var tileOffsetsValues = new uint[pageCount];
+        var tileByteCountsValues = new uint[pageCount];
+        var nextOffsets = new uint[pageCount];
+        uint[][]? tileOffsets = null;
+        uint[][]? tileByteCounts = null;
+        byte[][][]? tileData = null;
+
+        long cursor = 8;
+        for (var i = 0; i < pageCount; i++) {
+            var page = pages[i];
+            ValidatePage(page);
+
+            var tilesAcross = (page.Width + tileWidth - 1) / tileWidth;
+            var tilesDown = (page.Height + tileHeight - 1) / tileHeight;
+            if (tilesAcross <= 0 || tilesDown <= 0) throw new ArgumentOutOfRangeException(nameof(tileWidth));
+
+            var tileCount = checked(tilesAcross * tilesDown);
+            tileCounts[i] = tileCount;
+
+            var tileRowBytes = checked(tileWidth * 4);
+            var tileBytesLong = (long)tileRowBytes * tileHeight;
+            if (tileBytesLong > int.MaxValue) throw new ArgumentException("Tile size is too large.");
+            var tileBytes = (int)tileBytesLong;
+
+            ifdOffsets[i] = (uint)cursor;
+            bitsOffsets[i] = (uint)(cursor + ifdSize);
+            var tableOffset = cursor + ifdSize + BitsPerSampleSize;
+            var dataOffset = tableOffset + (tileCount > 1 ? tileCount * 8L : 0L);
+            if (dataOffset > uint.MaxValue) throw new ArgumentException("TIFF content exceeds 4GB.");
+
+            tileOffsetsValues[i] = tileCount > 1 ? (uint)tableOffset : (uint)dataOffset;
+            tileByteCountsValues[i] = tileCount > 1 ? (uint)(tableOffset + tileCount * 4L) : 0u;
+
+            if (compression != TiffCompression.None) {
+                tileData ??= new byte[pageCount][][];
+                tileByteCounts ??= new uint[pageCount][];
+                tileOffsets ??= new uint[pageCount][];
+                tileData[i] = new byte[tileCount][];
+                tileByteCounts[i] = new uint[tileCount];
+                tileOffsets[i] = tileCount > 1 ? new uint[tileCount] : Array.Empty<uint>();
+                var tileBuffer = new byte[tileBytes];
+                var current = (uint)dataOffset;
+                for (var t = 0; t < tileCount; t++) {
+                    FillTileRgba(page.Rgba, page.Width, page.Height, page.Stride, tileWidth, tileHeight, tilesAcross, t, tileBuffer);
+                    if (usePredictor) {
+                        ApplyHorizontalPredictor(tileBuffer, tileRowBytes, tileHeight, bytesPerPixel: 4);
+                    }
+                    var encoded = EncodeCompressed(tileBuffer, compression);
+                    tileData[i][t] = encoded;
+                    tileByteCounts[i][t] = (uint)encoded.Length;
+                    if (tileCount > 1) {
+                        tileOffsets[i][t] = current;
+                        current += tileByteCounts[i][t];
+                    } else {
+                        tileByteCountsValues[i] = tileByteCounts[i][t];
+                    }
+                }
+                cursor = current;
+            } else {
+                if (tileCount > 1) {
+                    tileOffsets ??= new uint[pageCount][];
+                    tileByteCounts ??= new uint[pageCount][];
+                    tileOffsets[i] = new uint[tileCount];
+                    tileByteCounts[i] = new uint[tileCount];
+                    var current = (uint)dataOffset;
+                    for (var t = 0; t < tileCount; t++) {
+                        tileOffsets[i][t] = current;
+                        tileByteCounts[i][t] = (uint)tileBytes;
+                        current += (uint)tileBytes;
+                    }
+                    cursor = current;
+                } else {
+                    tileByteCountsValues[i] = (uint)tileBytes;
+                    cursor = dataOffset + tileBytes;
+                }
+            }
+
+            if (cursor > uint.MaxValue) throw new ArgumentException("TIFF content exceeds 4GB.");
+        }
+
+        for (var i = 0; i < pageCount; i++) {
+            nextOffsets[i] = i < pageCount - 1 ? ifdOffsets[i + 1] : 0;
+        }
+
+        WriteHeader(stream);
+        for (var i = 0; i < pageCount; i++) {
+            var page = pages[i];
+            var tileCount = tileCounts[i];
+            var tilesAcross = (page.Width + tileWidth - 1) / tileWidth;
+            var tileRowBytes = tileWidth * 4;
+            var tileBytes = tileRowBytes * tileHeight;
+
+            WriteUInt16(stream, entryCount);
+            WriteEntry(stream, 256, 4, 1, (uint)page.Width); // ImageWidth
+            WriteEntry(stream, 257, 4, 1, (uint)page.Height); // ImageLength
+            WriteEntry(stream, 258, 3, 4, bitsOffsets[i]); // BitsPerSample
+            WriteEntry(stream, 259, 3, 1, (uint)compression); // Compression
+            WriteEntry(stream, 262, 3, 1, 2); // PhotometricInterpretation (RGB)
+            WriteEntry(stream, 277, 3, 1, 4); // SamplesPerPixel
+            WriteEntry(stream, 322, 4, 1, (uint)tileWidth); // TileWidth
+            WriteEntry(stream, 323, 4, 1, (uint)tileHeight); // TileLength
+            WriteEntry(stream, 324, 4, (uint)tileCount, tileOffsetsValues[i]); // TileOffsets
+            WriteEntry(stream, 325, 4, (uint)tileCount, tileByteCountsValues[i]); // TileByteCounts
+            WriteEntry(stream, 284, 3, 1, 1); // PlanarConfiguration (contiguous)
+            WriteEntry(stream, 338, 3, 1, 1); // ExtraSamples (unassociated alpha)
+            if (usePredictor) {
+                WriteEntry(stream, PredictorTag, 3, 1, 2); // Predictor (horizontal)
+            }
+
+            WriteUInt32(stream, nextOffsets[i]); // next IFD
+
+            WriteUInt16(stream, 8);
+            WriteUInt16(stream, 8);
+            WriteUInt16(stream, 8);
+            WriteUInt16(stream, 8);
+
+            if (tileCount > 1) {
+                var offsets = tileOffsets![i];
+                var counts = tileByteCounts![i];
+                for (var t = 0; t < tileCount; t++) {
+                    WriteUInt32(stream, offsets[t]);
+                }
+                for (var t = 0; t < tileCount; t++) {
+                    WriteUInt32(stream, counts[t]);
+                }
+            }
+
+            if (compression != TiffCompression.None) {
+                var encoded = tileData![i];
+                for (var t = 0; t < tileCount; t++) {
+                    var data = encoded[t];
+                    stream.Write(data, 0, data.Length);
+                }
+            } else {
+                var tileBuffer = new byte[tileBytes];
+                for (var t = 0; t < tileCount; t++) {
+                    FillTileRgba(page.Rgba, page.Width, page.Height, page.Stride, tileWidth, tileHeight, tilesAcross, t, tileBuffer);
+                    if (usePredictor) {
+                        ApplyHorizontalPredictor(tileBuffer, tileRowBytes, tileHeight, bytesPerPixel: 4);
+                    }
+                    stream.Write(tileBuffer, 0, tileBuffer.Length);
+                }
+            }
+        }
+    }
+
+    private static void WriteHeader(Stream stream) {
+        stream.WriteByte((byte)'I');
+        stream.WriteByte((byte)'I');
+        WriteUInt16(stream, 42);
+        WriteUInt32(stream, 8);
+    }
+
+    private static void WriteEntry(Stream stream, ushort tag, ushort type, uint count, uint value) {
+        WriteUInt16(stream, tag);
+        WriteUInt16(stream, type);
+        WriteUInt32(stream, count);
+        WriteUInt32(stream, value);
+    }
+
+    private static void WriteUInt16(Stream stream, ushort value) {
+        stream.WriteByte((byte)value);
+        stream.WriteByte((byte)(value >> 8));
+    }
+
+    private static void WriteUInt32(Stream stream, uint value) {
+        stream.WriteByte((byte)value);
+        stream.WriteByte((byte)(value >> 8));
+        stream.WriteByte((byte)(value >> 16));
+        stream.WriteByte((byte)(value >> 24));
+    }
+
+    private static byte[] PackBitsEncode(ReadOnlySpan<byte> data) {
+        var output = new byte[data.Length * 2 + 16];
+        var outIndex = 0;
+        var i = 0;
+        while (i < data.Length) {
+            var runStart = i;
+            var runValue = data[i];
+            var runLength = 1;
+            while (runStart + runLength < data.Length && runLength < 128 && data[runStart + runLength] == runValue) {
+                runLength++;
+            }
+
+            if (runLength >= 3) {
+                output[outIndex++] = (byte)(257 - runLength);
+                output[outIndex++] = runValue;
+                i += runLength;
+                continue;
+            }
+
+            var literalStart = i;
+            var literalLength = 0;
+            while (i < data.Length && literalLength < 128) {
+                if (i + 2 < data.Length && data[i] == data[i + 1] && data[i] == data[i + 2]) {
+                    break;
+                }
+                i++;
+                literalLength++;
+            }
+
+            output[outIndex++] = (byte)(literalLength - 1);
+            for (var l = 0; l < literalLength; l++) {
+                output[outIndex++] = data[literalStart + l];
+            }
+        }
+
+        var result = new byte[outIndex];
+        Buffer.BlockCopy(output, 0, result, 0, outIndex);
+        return result;
+    }
+
+    private static byte[] EncodeCompressed(byte[] data, TiffCompression compression) {
+        return compression switch {
+            TiffCompression.PackBits => PackBitsEncode(data),
+            TiffCompression.Deflate => DeflateEncode(data),
+            TiffCompression.Lzw => LzwEncode(data),
+            _ => throw new ArgumentOutOfRangeException(nameof(compression))
+        };
+    }
+
+    private static byte[] LzwEncode(ReadOnlySpan<byte> data) {
+        const int clear = 256;
+        const int eoi = 257;
+        const int maxCode = 4096;
+        const int earlyChange = 1;
+
+        var writer = new LzwBitWriter(data.Length);
+        var dict = new Dictionary<int, int>(4096);
+        var codeSize = 9;
+        var nextCode = 258;
+
+        writer.Write(clear, codeSize);
+        if (data.IsEmpty) {
+            writer.Write(eoi, codeSize);
+            return writer.ToArray();
+        }
+
+        var prefix = data[0];
+        for (var i = 1; i < data.Length; i++) {
+            var b = data[i];
+            var key = (prefix << 8) | b;
+            if (dict.TryGetValue(key, out var code)) {
+                prefix = code;
+                continue;
+            }
+
+            writer.Write(prefix, codeSize);
+            if (nextCode < maxCode) {
+                dict[key] = nextCode++;
+                if (nextCode == (1 << codeSize) - earlyChange && codeSize < 12) {
+                    codeSize++;
+                }
+            } else {
+                writer.Write(clear, codeSize);
+                dict.Clear();
+                codeSize = 9;
+                nextCode = 258;
+            }
+            prefix = b;
+        }
+
+        writer.Write(prefix, codeSize);
+        writer.Write(eoi, codeSize);
+        return writer.ToArray();
+    }
+
+    private sealed class LzwBitWriter {
+        private readonly List<byte> _output;
+        private uint _buffer;
+        private int _bitCount;
+
+        public LzwBitWriter(int dataLength) {
+            _output = new List<byte>(Math.Max(16, dataLength));
+        }
+
+        public void Write(int code, int codeSize) {
+            _buffer = (_buffer << codeSize) | (uint)code;
+            _bitCount += codeSize;
+            while (_bitCount >= 8) {
+                var shift = _bitCount - 8;
+                _output.Add((byte)(_buffer >> shift));
+                _bitCount -= 8;
+                if (_bitCount == 0) {
+                    _buffer = 0;
+                } else {
+                    _buffer &= (1u << _bitCount) - 1u;
+                }
+            }
+        }
+
+        public byte[] ToArray() {
+            if (_bitCount > 0) {
+                _output.Add((byte)(_buffer << (8 - _bitCount)));
+            }
+            return _output.ToArray();
+        }
+    }
+
+    private static byte[] PackBilevelFromRgba(
+        int width,
+        int height,
+        ReadOnlySpan<byte> rgba,
+        int stride,
+        int packedStride,
+        byte threshold,
+        ushort photometric) {
+        var packed = new byte[packedStride * height];
+        for (var y = 0; y < height; y++) {
+            var srcRow = y * stride;
+            var dstRow = y * packedStride;
+            for (var x = 0; x < width; x++) {
+                var src = srcRow + x * 4;
+                var a = rgba[src + 3];
+                int luminance;
+                if (a == 0) {
+                    luminance = 255;
+                } else {
+                    var r = rgba[src + 0];
+                    var g = rgba[src + 1];
+                    var b = rgba[src + 2];
+                    luminance = (r * 77 + g * 150 + b * 29) >> 8;
+                }
+
+                var isBlack = luminance < threshold;
+                var bit = photometric == 0 ? (isBlack ? 1 : 0) : (isBlack ? 0 : 1);
+                if (bit != 0) {
+                    var dst = dstRow + (x >> 3);
+                    packed[dst] |= (byte)(1 << (7 - (x & 7)));
+                }
+            }
+        }
+        return packed;
+    }
+
+    private static void FillTileRgba(
+        ReadOnlySpan<byte> rgba,
+        int width,
+        int height,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        int tilesAcross,
+        int tileIndex,
+        byte[] tileBuffer) {
+        tileBuffer.AsSpan().Clear();
+        var tileX = tileIndex % tilesAcross;
+        var tileY = tileIndex / tilesAcross;
+        var startX = tileX * tileWidth;
+        var startY = tileY * tileHeight;
+        if (startX >= width || startY >= height) return;
+
+        var copyWidth = Math.Min(tileWidth, width - startX);
+        var copyHeight = Math.Min(tileHeight, height - startY);
+        var rowBytes = copyWidth * 4;
+        for (var y = 0; y < copyHeight; y++) {
+            var srcOffset = (startY + y) * stride + startX * 4;
+            var dstOffset = y * tileWidth * 4;
+            rgba.Slice(srcOffset, rowBytes).CopyTo(tileBuffer.AsSpan(dstOffset, rowBytes));
+        }
+    }
+
+    private static void FillTileBilevel(
+        ReadOnlySpan<byte> packed,
+        int width,
+        int height,
+        int stride,
+        int tileWidth,
+        int tileHeight,
+        int tilesAcross,
+        int tileIndex,
+        byte[] tileBuffer,
+        ushort photometric) {
+        var fill = photometric == 0 ? (byte)0x00 : (byte)0xFF;
+        Array.Fill(tileBuffer, fill);
+        var tileX = tileIndex % tilesAcross;
+        var tileY = tileIndex / tilesAcross;
+        var startX = tileX * tileWidth;
+        var startY = tileY * tileHeight;
+        if (startX >= width || startY >= height) return;
+
+        var copyWidth = Math.Min(tileWidth, width - startX);
+        var copyHeight = Math.Min(tileHeight, height - startY);
+        var tileRowBytes = (tileWidth + 7) / 8;
+
+        for (var y = 0; y < copyHeight; y++) {
+            var srcRow = (startY + y) * stride;
+            var dstRow = y * tileRowBytes;
+            for (var x = 0; x < copyWidth; x++) {
+                var srcByte = packed[srcRow + ((startX + x) >> 3)];
+                var bit = (srcByte >> (7 - ((startX + x) & 7))) & 1;
+                var dstIndex = dstRow + (x >> 3);
+                var mask = (byte)(1 << (7 - (x & 7)));
+                if (bit != 0) {
+                    tileBuffer[dstIndex] |= mask;
+                } else {
+                    tileBuffer[dstIndex] &= (byte)~mask;
+                }
+            }
+        }
+    }
+
+    private static void ApplyHorizontalPredictor(byte[] data, int rowSize, int rows, int bytesPerPixel) {
+        if (bytesPerPixel <= 0) return;
+        for (var y = 0; y < rows; y++) {
+            var rowStart = y * rowSize;
+            for (var i = bytesPerPixel; i < rowSize; i++) {
+                var value = data[rowStart + i];
+                var prev = data[rowStart + i - bytesPerPixel];
+                data[rowStart + i] = unchecked((byte)(value - prev));
+            }
+        }
+    }
+
+    private static byte[] DeflateEncode(byte[] data) {
+        using var ms = new MemoryStream();
+#if NET8_0_OR_GREATER
+        using (var zlib = new ZLibStream(ms, CompressionLevel.Optimal, leaveOpen: true)) {
+            zlib.Write(data, 0, data.Length);
+        }
+#else
+        WriteZlibHeader(ms);
+        using (var deflate = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true)) {
+            deflate.Write(data, 0, data.Length);
+        }
+        var adler = ComputeAdler32(data);
+        WriteUInt32BE(ms, adler);
+#endif
+        return ms.ToArray();
+    }
+
+#if !NET8_0_OR_GREATER
+    private static void WriteZlibHeader(Stream stream) {
+        stream.WriteByte(0x78);
+        stream.WriteByte(0x9C);
+    }
+
+    private static uint ComputeAdler32(byte[] buffer) {
+        const uint mod = 65521;
+        uint a = 1;
+        uint b = 0;
+        var offset = 0;
+        while (offset < buffer.Length) {
+            var n = Math.Min(5552, buffer.Length - offset);
+            var limit = offset + n;
+            while (offset < limit) {
+                a += buffer[offset++];
+                b += a;
+            }
+            a %= mod;
+            b %= mod;
+        }
+        return (b << 16) | a;
+    }
+
+    private static void WriteUInt32BE(Stream stream, uint value) {
+        stream.WriteByte((byte)((value >> 24) & 0xFF));
+        stream.WriteByte((byte)((value >> 16) & 0xFF));
+        stream.WriteByte((byte)((value >> 8) & 0xFF));
+        stream.WriteByte((byte)(value & 0xFF));
+    }
+#endif
+
+    private static void ValidatePage(TiffRgba32Page page) {
+        if (page.Width <= 0) throw new ArgumentOutOfRangeException(nameof(page.Width));
+        if (page.Height <= 0) throw new ArgumentOutOfRangeException(nameof(page.Height));
+        if (page.Stride < page.Width * 4) throw new ArgumentOutOfRangeException(nameof(page.Stride));
+        if (page.Rgba.Length < (page.Height - 1) * page.Stride + page.Width * 4) {
+            throw new ArgumentException("RGBA buffer is too small.", nameof(page.Rgba));
+        }
+    }
+}

--- a/CodeGlyphX/Rendering/Tiff/TiffWriter.cs
+++ b/CodeGlyphX/Rendering/Tiff/TiffWriter.cs
@@ -1422,7 +1422,7 @@ public static class TiffWriter {
             return writer.ToArray();
         }
 
-        var prefix = data[0];
+        var prefix = (int)data[0];
         for (var i = 1; i < data.Length; i++) {
             var b = data[i];
             var key = (prefix << 8) | b;

--- a/CodeGlyphX/Rendering/Webp/BarcodeWebpRenderer.cs
+++ b/CodeGlyphX/Rendering/Webp/BarcodeWebpRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
@@ -87,6 +88,113 @@ public static class BarcodeWebpRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(Barcode1D barcode, BarcodePngRenderOptions opts, string directory, string fileName, int quality = 100) {
         var webp = Render(barcode, opts, quality);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP from multiple barcode frames.
+    /// </summary>
+    public static byte[] RenderAnimation(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, WebpAnimationOptions options = default, int quality = 100) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (durationMs <= 0) throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+        var webpFrames = new WebpAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var pixels = BarcodePngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            webpFrames[i] = new WebpAnimationFrame(pixels, widthPx, heightPx, stride, durationMs);
+        }
+
+        return quality >= 100
+            ? WebpWriter.WriteAnimationRgba32(canvasWidth, canvasHeight, webpFrames, options)
+            : WebpWriter.WriteAnimationRgba32Lossy(canvasWidth, canvasHeight, webpFrames, options, quality);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP from multiple barcode frames with per-frame durations.
+    /// </summary>
+    public static byte[] RenderAnimation(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, WebpAnimationOptions options = default, int quality = 100) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (durationsMs is null) throw new ArgumentNullException(nameof(durationsMs));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (frames.Length != durationsMs.Length) throw new ArgumentException("Durations must match frame count.", nameof(durationsMs));
+
+        var webpFrames = new WebpAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var duration = durationsMs[i];
+            if (duration <= 0) throw new ArgumentOutOfRangeException(nameof(durationsMs));
+            var pixels = BarcodePngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            webpFrames[i] = new WebpAnimationFrame(pixels, widthPx, heightPx, stride, duration);
+        }
+
+        return quality >= 100
+            ? WebpWriter.WriteAnimationRgba32(canvasWidth, canvasHeight, webpFrames, options)
+            : WebpWriter.WriteAnimationRgba32Lossy(canvasWidth, canvasHeight, webpFrames, options, quality);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a stream from multiple barcode frames.
+    /// </summary>
+    public static void RenderAnimationToStream(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, Stream stream, WebpAnimationOptions options = default, int quality = 100) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a stream from multiple barcode frames with per-frame durations.
+    /// </summary>
+    public static void RenderAnimationToStream(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, Stream stream, WebpAnimationOptions options = default, int quality = 100) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file from multiple barcode frames.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, string path, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file from multiple barcode frames with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, string path, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file under the specified directory.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int durationMs, string directory, string fileName, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file under the specified directory with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(Barcode1D[] frames, BarcodePngRenderOptions opts, int[] durationsMs, string directory, string fileName, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
         return RenderIO.WriteBinary(directory, fileName, webp);
     }
 }

--- a/CodeGlyphX/Rendering/Webp/MatrixWebpRenderer.cs
+++ b/CodeGlyphX/Rendering/Webp/MatrixWebpRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
@@ -87,6 +88,113 @@ public static class MatrixWebpRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(BitMatrix modules, MatrixPngRenderOptions opts, string directory, string fileName, int quality = 100) {
         var webp = Render(modules, opts, quality);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP from multiple matrix frames.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, WebpAnimationOptions options = default, int quality = 100) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (durationMs <= 0) throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+        var webpFrames = new WebpAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var pixels = MatrixPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            webpFrames[i] = new WebpAnimationFrame(pixels, widthPx, heightPx, stride, durationMs);
+        }
+
+        return quality >= 100
+            ? WebpWriter.WriteAnimationRgba32(canvasWidth, canvasHeight, webpFrames, options)
+            : WebpWriter.WriteAnimationRgba32Lossy(canvasWidth, canvasHeight, webpFrames, options, quality);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP from multiple matrix frames with per-frame durations.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, WebpAnimationOptions options = default, int quality = 100) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (durationsMs is null) throw new ArgumentNullException(nameof(durationsMs));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (frames.Length != durationsMs.Length) throw new ArgumentException("Durations must match frame count.", nameof(durationsMs));
+
+        var webpFrames = new WebpAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var duration = durationsMs[i];
+            if (duration <= 0) throw new ArgumentOutOfRangeException(nameof(durationsMs));
+            var pixels = MatrixPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            webpFrames[i] = new WebpAnimationFrame(pixels, widthPx, heightPx, stride, duration);
+        }
+
+        return quality >= 100
+            ? WebpWriter.WriteAnimationRgba32(canvasWidth, canvasHeight, webpFrames, options)
+            : WebpWriter.WriteAnimationRgba32Lossy(canvasWidth, canvasHeight, webpFrames, options, quality);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a stream from multiple matrix frames.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, Stream stream, WebpAnimationOptions options = default, int quality = 100) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a stream from multiple matrix frames with per-frame durations.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, Stream stream, WebpAnimationOptions options = default, int quality = 100) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file from multiple matrix frames.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, string path, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file from multiple matrix frames with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, string path, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file under the specified directory.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int durationMs, string directory, string fileName, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file under the specified directory with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, MatrixPngRenderOptions opts, int[] durationsMs, string directory, string fileName, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
         return RenderIO.WriteBinary(directory, fileName, webp);
     }
 }

--- a/CodeGlyphX/Rendering/Webp/QrWebpRenderer.cs
+++ b/CodeGlyphX/Rendering/Webp/QrWebpRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
@@ -87,6 +88,118 @@ public static class QrWebpRenderer {
     /// <returns>The output file path.</returns>
     public static string RenderToFile(BitMatrix modules, QrPngRenderOptions opts, string directory, string fileName, int quality = 100) {
         var webp = Render(modules, opts, quality);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP from multiple QR module frames.
+    /// </summary>
+    /// <param name="frames">QR module frames.</param>
+    /// <param name="opts">Rendering options.</param>
+    /// <param name="durationMs">Per-frame duration in milliseconds.</param>
+    /// <param name="options">Animation options.</param>
+    /// <param name="quality">Quality (0-100). Values &gt;= 100 use lossless VP8L.</param>
+    public static byte[] RenderAnimation(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, WebpAnimationOptions options = default, int quality = 100) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (durationMs <= 0) throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+        var webpFrames = new WebpAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var pixels = QrPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            webpFrames[i] = new WebpAnimationFrame(pixels, widthPx, heightPx, stride, durationMs);
+        }
+
+        return quality >= 100
+            ? WebpWriter.WriteAnimationRgba32(canvasWidth, canvasHeight, webpFrames, options)
+            : WebpWriter.WriteAnimationRgba32Lossy(canvasWidth, canvasHeight, webpFrames, options, quality);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP from multiple QR module frames with per-frame durations.
+    /// </summary>
+    public static byte[] RenderAnimation(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, WebpAnimationOptions options = default, int quality = 100) {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+        if (durationsMs is null) throw new ArgumentNullException(nameof(durationsMs));
+        if (frames.Length == 0) throw new ArgumentException("At least one frame is required.", nameof(frames));
+        if (frames.Length != durationsMs.Length) throw new ArgumentException("Durations must match frame count.", nameof(durationsMs));
+
+        var webpFrames = new WebpAnimationFrame[frames.Length];
+        var canvasWidth = 0;
+        var canvasHeight = 0;
+        for (var i = 0; i < frames.Length; i++) {
+            var duration = durationsMs[i];
+            if (duration <= 0) throw new ArgumentOutOfRangeException(nameof(durationsMs));
+            var pixels = QrPngRenderer.RenderPixels(frames[i], opts, out var widthPx, out var heightPx, out var stride);
+            if (i == 0) {
+                canvasWidth = widthPx;
+                canvasHeight = heightPx;
+            } else if (widthPx != canvasWidth || heightPx != canvasHeight) {
+                throw new ArgumentException("All frames must render to the same pixel size.", nameof(frames));
+            }
+            webpFrames[i] = new WebpAnimationFrame(pixels, widthPx, heightPx, stride, duration);
+        }
+
+        return quality >= 100
+            ? WebpWriter.WriteAnimationRgba32(canvasWidth, canvasHeight, webpFrames, options)
+            : WebpWriter.WriteAnimationRgba32Lossy(canvasWidth, canvasHeight, webpFrames, options, quality);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a stream from multiple QR module frames.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, Stream stream, WebpAnimationOptions options = default, int quality = 100) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a stream from multiple QR module frames with per-frame durations.
+    /// </summary>
+    public static void RenderAnimationToStream(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, Stream stream, WebpAnimationOptions options = default, int quality = 100) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
+        RenderIO.WriteBinary(stream, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file from multiple QR module frames.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, string path, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file from multiple QR module frames with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, string path, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
+        return RenderIO.WriteBinary(path, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file under the specified directory.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int durationMs, string directory, string fileName, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationMs, options, quality);
+        return RenderIO.WriteBinary(directory, fileName, webp);
+    }
+
+    /// <summary>
+    /// Renders an animated WebP to a file under the specified directory with per-frame durations.
+    /// </summary>
+    public static string RenderAnimationToFile(BitMatrix[] frames, QrPngRenderOptions opts, int[] durationsMs, string directory, string fileName, WebpAnimationOptions options = default, int quality = 100) {
+        var webp = RenderAnimation(frames, opts, durationsMs, options, quality);
         return RenderIO.WriteBinary(directory, fileName, webp);
     }
 }

--- a/CodeGlyphX/Rendering/Webp/WebpReader.cs
+++ b/CodeGlyphX/Rendering/Webp/WebpReader.cs
@@ -11,6 +11,7 @@ public static class WebpReader {
     private const uint FourCcVp8X = 0x58385056; // "VP8X"
     private const uint FourCcVp8L = 0x4C385056; // "VP8L"
     private const uint FourCcVp8 = 0x20385056;  // "VP8 "
+    private const uint FourCcAnmf = 0x464D4E41; // "ANMF"
     internal const int MaxWebpBytes = 256 * 1024 * 1024;
 
     /// <summary>
@@ -40,6 +41,8 @@ public static class WebpReader {
         if (riffLimit < 12) return false;
 
         var offset = 12;
+        var anmfWidth = 0;
+        var anmfHeight = 0;
         while ((long)offset + 8 <= riffLimit) {
             var fourCc = ReadU32LE(data, offset);
             var chunkSize = ReadU32LE(data, offset + 4);
@@ -55,11 +58,22 @@ public static class WebpReader {
             if (fourCc == FourCcVp8X && TryReadVp8XSize(chunk, out width, out height)) return true;
             if (fourCc == FourCcVp8L && TryReadVp8LSize(chunk, out width, out height)) return true;
             if (fourCc == FourCcVp8 && TryReadVp8Size(chunk, out width, out height)) return true;
+            if (fourCc == FourCcAnmf && anmfWidth == 0 && anmfHeight == 0) {
+                if (TryReadAnmfSize(chunk, out anmfWidth, out anmfHeight)) {
+                    // Keep scanning for VP8X/VP8/VP8L, but remember the first ANMF size.
+                }
+            }
 
             var padded = chunkLength + (chunkLength & 1);
             var nextOffset = dataOffset + padded;
             if (nextOffset < 0 || nextOffset > riffLimit || nextOffset > int.MaxValue) return false;
             offset = (int)nextOffset;
+        }
+
+        if (anmfWidth > 0 && anmfHeight > 0) {
+            width = anmfWidth;
+            height = anmfHeight;
+            return true;
         }
 
         return false;
@@ -170,6 +184,17 @@ public static class WebpReader {
         if (chunk[3] != 0x9D || chunk[4] != 0x01 || chunk[5] != 0x2A) return false;
         width = ReadU16LE(chunk, 6) & 0x3FFF;
         height = ReadU16LE(chunk, 8) & 0x3FFF;
+        return width > 0 && height > 0;
+    }
+
+    private static bool TryReadAnmfSize(ReadOnlySpan<byte> chunk, out int width, out int height) {
+        width = 0;
+        height = 0;
+        if (chunk.Length < 16) return false;
+        var widthMinus1 = ReadU24LE(chunk, 6);
+        var heightMinus1 = ReadU24LE(chunk, 9);
+        width = widthMinus1 + 1;
+        height = heightMinus1 + 1;
         return width > 0 && height > 0;
     }
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Status: Actively developed · Stable core · Expanding format support
 - Reliable QR decoding (ECI, FNC1/GS1, Kanji, structured append, Micro QR)
 - 1D barcode encoding/decoding (Code128/GS1-128, Code39, Code93, Code11, Codabar, MSI, Plessey, EAN/UPC, ITF-14)
 - 2D encoding/decoding (Data Matrix, MicroPDF417, PDF417, Aztec)
-- Renderers (SVG / SVGZ / HTML / PNG / JPEG / WebP / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII) and image decoding (PNG/JPEG/WebP/GIF/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/TIFF)
+- Renderers (SVG / SVGZ / HTML / PNG / JPEG / WebP / GIF / TIFF / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII) and image decoding (PNG/JPEG/WebP/GIF/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/TIFF/PSD/PDF)
 - OTP helpers (otpauth://totp + Base32)
 - WPF controls + demo apps
 
@@ -188,8 +188,8 @@ Runs wherever .NET runs (Windows, Linux, macOS). WPF controls are Windows-only.
 | Feature | Windows | Linux | macOS |
 | --- | --- | --- | --- |
 | Core encode/decode (QR/1D/2D) | ✅ | ✅ | ✅ |
-| Renderers (PNG/SVG/SVGZ/HTML/JPEG/WebP/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/PDF/EPS/ASCII) | ✅ | ✅ | ✅ |
-| Image decoding (PNG/JPEG/WebP/GIF/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/TIFF) | ✅ | ✅ | ✅ |
+| Renderers (PNG/SVG/SVGZ/HTML/JPEG/WebP/GIF/TIFF/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/PDF/EPS/ASCII) | ✅ | ✅ | ✅ |
+| Image decoding (PNG/JPEG/WebP/GIF/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/TIFF/PSD/PDF) | ✅ | ✅ | ✅ |
 | WPF controls | ✅ | ❌ | ❌ |
 
 ## Build Status
@@ -321,13 +321,13 @@ Matrix/stacked/4-state symbols use a `BitMatrix` + the `Matrix*` renderers.
 - [x] 1D barcode encode + decode
 - [x] Data Matrix + MicroPDF417 + PDF417 encode + decode
 - [x] Matrix/stacked/4-state encoding (Data Matrix / PDF417 / MicroPDF417 / Aztec / GS1 DataBar / postal + pharmacode) with dedicated matrix renderers
-- [x] SVG / SVGZ / HTML / PNG / JPEG / WebP / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII renderers
+- [x] SVG / SVGZ / HTML / PNG / JPEG / WebP / GIF / TIFF / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / PDF / EPS / ASCII renderers
 - [x] Image decode: PNG / JPEG / WebP / GIF / BMP / PPM / PBM / PGM / PAM / XBM / XPM / TGA / ICO / TIFF
 - [x] Base64 + data URI helpers for rendered outputs
 - [x] Payload helpers (URL, WiFi, Email, Phone/SMS/MMS, Contact, Calendar, OTP, payments, crypto, social)
 - [x] WPF controls and demo apps
 - [x] Aztec encode + decode (module matrix + pixel)
-- [x] Matrix render helpers for Aztec/DataMatrix/PDF417 (PNG/SVG/SVGZ/HTML/JPEG/WebP/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/PDF/EPS/ASCII)
+- [x] Matrix render helpers for Aztec/DataMatrix/PDF417 (PNG/SVG/SVGZ/HTML/JPEG/WebP/GIF/TIFF/BMP/PPM/PBM/PGM/PAM/XBM/XPM/TGA/ICO/PDF/EPS/ASCII)
 
 ## AOT & trimming
 
@@ -345,6 +345,8 @@ Use `.txt` for ASCII output and `.ps` as an EPS alias.
 | PNG | `.png` | Raster |
 | JPEG | `.jpg`, `.jpeg` | Raster, quality via options |
 | WebP | `.webp` | Raster, quality via options (lossless at quality 100) |
+| GIF | `.gif` | Raster (indexed, 256 colors max) |
+| TIFF | `.tif`, `.tiff` | Raster (baseline, uncompressed RGBA) |
 | BMP | `.bmp` | Raster |
 | PPM | `.ppm` | Raster (portable pixmap) |
 | PBM | `.pbm` | Raster (portable bitmap) |
@@ -415,10 +417,11 @@ Auto-detect helper: `QrPayloads.Detect("...")` builds the best-known payload for
 | --- | --- | --- | --- |
 | PNG | ✅ | ✅ |  |
 | JPEG | ✅ | ✅ |  |
-| WebP | ✅ | ✅ | Managed VP8/VP8L; ImageReader returns first animation frame (WebpReader exposes frames) |
+| WebP | ✅ | ✅ | Managed VP8/VP8L; ImageReader returns first animation frame (use WebpReader/ImageReader multi-frame helpers); animation via WebpWriter or Webp renderers RenderAnimation |
 | BMP | ✅ | ✅ |  |
-| GIF | ✖ | ✅ | First frame only |
-| TIFF | ✖ | ✅ | Baseline strips, 8/16-bit; compression: none/PackBits/LZW/Deflate |
+| GIF | ✅ | ✅ | Single-frame encode (indexed, <=256 colors; quantizes + dithers if needed); animation via GifReader/GifWriter.WriteAnimation or GIF renderers RenderAnimation (diff-cropped) |
+| TIFF | ✅ | ✅ | Baseline RGBA encode (multi-page via `TiffWriter.WriteRgba32Pages`, tiled multi-page via `WriteRgba32PagesTiled`, planar via `WriteRgba32Planar`, bilevel 1-bit via `WriteBilevel`/`WriteBilevelFromRgba` or `RenderBilevel`, direct matrix bilevel via `RenderBilevelFromModules`, direct barcode bilevel via `RenderBilevelFromBars`, tiled bilevel via `WriteBilevelTiled`/`WriteBilevelTiledFromRgba` or `RenderBilevelTiled`, tiled direct matrix bilevel via `RenderBilevelTiledFromModules`, tiled direct barcode bilevel via `RenderBilevelTiledFromBars`, strips via `rowsPerStrip`, tiles via `WriteRgba32Tiled`, PackBits/Deflate/LZW via `TiffCompression`, predictor via `usePredictor`); decode supports strips/tiles, planar config 1/2, 1/8/16-bit; compression: none/PackBits/LZW/Deflate |
+| PSD | ❌ | ✅ | Flattened PSD decode (8-bit grayscale/RGB, raw or RLE) |
 | PPM/PGM/PAM/PBM | ✅ | ✅ |  |
 | TGA | ✅ | ✅ |  |
 | ICO | ✅ | ✅ | PNG/BMP payloads (CUR decode supported) |
@@ -429,19 +432,19 @@ Auto-detect helper: `QrPayloads.Detect("...")` builds the best-known payload for
 | Format | Encode | Notes |
 | --- | --- | --- |
 | SVG / SVGZ | ✅ | Vector output |
-| PDF / EPS | ✅ | Vector by default, raster via RenderMode |
+| PDF / EPS | ✅ | Vector by default, raster via RenderMode (PDF decode: image-only JPEG/Flate) |
 | HTML | ✅ | Table-based output |
 | ASCII | ✅ | `.txt` output or `Render(..., OutputFormat.Ascii)` |
 | Raw RGBA | ✅ | Use `RenderPixels` APIs |
 
 ### Known gaps / not supported (decode)
 
-- ImageReader returns the first animation frame only (GIF/WebP); use WebpReader.* for raw or composited WebP frames
+- ImageReader.DecodeRgba32 returns the first animation frame only (GIF/WebP); use ImageReader.DecodeGifAnimationFrames / DecodeWebpAnimationFrames (or GifReader/WebpReader) for animation frames
 - Managed WebP decode supports VP8/VP8L stills; size limit is 256 MB
 - Managed WebP encode is VP8 (lossy intra-only) and VP8L (lossless)
-- AVIF, HEIC, JPEG2000, PSD are not supported
-- Multi-page / tiled TIFF is not supported (first IFD only)
-- PDF/PS decode is not supported (rasterize first)
+- AVIF, HEIC, JPEG2000 are not supported
+- ImageReader.DecodeRgba32 returns the first TIFF page only; use ImageReader.TryDecodeTiffPagesRgba32 (or TiffReader.DecodePagesRgba32) for multi-page
+- PDF decode supports image-only PDFs with embedded JPEG/Flate; PS decode is not supported (rasterize first)
 
 ### Format corpus (optional)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -674,12 +674,12 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.58.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
## Summary
- Small refinements to IO/decoder/format implementations.
- Minor updates to GIF/TIFF/PSD handling and QR decoder.
- package-lock.json adjustments.

## Testing
- Not run in this worktree.