### PR TITLE
build: add net472 reference assemblies for non-windows

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,4 +14,9 @@
     <BaseIntermediateOutputPath>obj/$(TargetFramework)/</BaseIntermediateOutputPath>
     <MSBuildProjectExtensionsPath>obj/$(TargetFramework)/</MSBuildProjectExtensionsPath>
   </PropertyGroup>
+
+  <!-- Provide net472 reference assemblies on non-Windows hosts for compile-only builds. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' and '$(OS)' != 'Windows_NT'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary\n- add .NET Framework 4.7.2 reference assemblies package for non-Windows compile-only builds\n\n## Notes\n- Enables net472 compilation on Linux/macOS without running net472 tests/runtime\n