### PR TITLE
Ensure 404 page always gets global assets and enforce CI check

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
           test -f Website/_site/docs/index.html
           test -f Website/_site/playground/index.html
           test -f Website/_site/404.html
-          grep -q '<link rel=stylesheet' Website/_site/404.html
+          grep -Eqi "<link[^>]+rel=[^>]*stylesheet" Website/_site/404.html
 
       # Playwright smoke coverage is handled by the PowerForge.Web audit step
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,6 +43,8 @@ jobs:
           test -f Website/_site/index.html
           test -f Website/_site/docs/index.html
           test -f Website/_site/playground/index.html
+          test -f Website/_site/404.html
+          grep -q '<link rel=stylesheet' Website/_site/404.html
 
       # Playwright smoke coverage is handled by the PowerForge.Web audit step
 

--- a/Website/site.json
+++ b/Website/site.json
@@ -68,7 +68,8 @@
       { "Match": "/showcase/**", "Bundles": ["global"] },
       { "Match": "/docs/**", "Bundles": ["global"] },
       { "Match": "/playground/**", "Bundles": ["global"] },
-      { "Match": "/pricing/**", "Bundles": ["global"] }
+      { "Match": "/pricing/**", "Bundles": ["global"] },
+      { "Match": "/**", "Bundles": ["global"] }
     ],
     "Preloads": [
       { "Rel": "preload", "Href": "/fonts/inter/Inter-400-latin.woff2", "As": "font", "Type": "font/woff2", "Crossorigin": "anonymous" },


### PR DESCRIPTION
## Summary
- add `AssetRegistry.RouteBundles` fallback `"/**" -> ["global"]` in `Website/site.json`
- keep existing explicit route mappings while guaranteeing 404/unknown routes receive full CSS/JS bundle
- extend Pages workflow verification to require `Website/_site/404.html` and stylesheet markup

## Why
- live unknown routes (for example `/playgroundf`) were rendering a degraded 404 because no route-bundle matched `/404`, so full assets were skipped

## Validation
- `./Website/build.ps1 -SkipBuildTool`
- confirmed `Website/_site/404.html` exists
- confirmed generated 404 includes preload/noscript stylesheet markup and site JS