### PR TITLE
chore(web): enable image optimize stage settings

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -117,6 +117,10 @@
       "minifyHtml": true,
       "minifyCss": true,
       "minifyJs": true,
+      "optimizeImages": true,
+      "imageExtensions": [".png", ".jpg", ".jpeg", ".webp"],
+      "imageQuality": 82,
+      "imageStripMetadata": true,
       "reportPath": "./_reports/optimize-report.json"
     },
     {


### PR DESCRIPTION
## Summary
- enable image optimization in website optimize pipeline step
- keep existing minify settings unchanged
- expose image savings in optimize report and pipeline summary once PSPublishModule image optimizer lands

## Validation
- ./build.ps1 (pipeline completed)
- optimize summary now reports `images 88, images-saved 59536024B` in local run