### PR TITLE
chore(website): enable image pipeline v2 defaults

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -121,6 +121,11 @@
       "imageExtensions": [".png", ".jpg", ".jpeg", ".webp"],
       "imageQuality": 82,
       "imageStripMetadata": true,
+      "imageGenerateWebp": true,
+      "imagePreferNextGen": true,
+      "imageWidths": [480, 960, 1440],
+      "imageEnhanceTags": true,
+      "imageMaxTotalBytes": 70000000,
       "reportPath": "./_reports/optimize-report.json"
     },
     {


### PR DESCRIPTION
## Summary
- enable next-gen image generation in optimize step
- prefer generated next-gen assets in rewritten HTML
- add responsive width generation and image hinting
- add total image budget visibility for optimize stage

## Validation
- ./build.ps1 completed successfully
- optimize report includes image variant/rewrite/hint metrics