### PR TITLE
fix(website): correct docs edit links, API source links, and UI polish

### DIFF
--- a/Website/content/pages/index.scripts.html
+++ b/Website/content/pages/index.scripts.html
@@ -207,7 +207,15 @@
 
       const img = document.createElement('img');
       img.loading = 'lazy';
+      img.decoding = 'async';
       img.alt = item.name || 'QR style';
+      if (item.width && item.height) {
+        img.width = item.width;
+        img.height = item.height;
+      } else {
+        img.width = 400;
+        img.height = 400;
+      }
       img.src = base + item.file;
       card.appendChild(img);
 

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -70,6 +70,8 @@
       "headerHtml": "./static/api-fragments/header.html",
       "footerHtml": "./static/api-fragments/footer.html",
       "nav": "./site.json",
+      "sourceRoot": "../CodeGlyphX",
+      "sourceUrl": "https://github.com/EvotecIT/CodeGlyphX/blob/master/{path}#L{line}",
       "includeNamespace": "CodeGlyphX",
       "excludeType": "CodeGlyphX.Rendering.Gif.BarcodeGifRenderer,CodeGlyphX.Rendering.Gif.GifAnimationFrame,CodeGlyphX.Rendering.Gif.GifAnimationOptions,CodeGlyphX.Rendering.Gif.GifDisposal,CodeGlyphX.Rendering.Gif.GifWriter,CodeGlyphX.Rendering.Gif.MatrixGifRenderer,CodeGlyphX.Rendering.Gif.QrGifRenderer,CodeGlyphX.Rendering.Pdf.PdfReader,CodeGlyphX.Rendering.Psd.PsdReader,CodeGlyphX.Rendering.Tiff.BarcodeTiffRenderer,CodeGlyphX.Rendering.Tiff.MatrixTiffRenderer,CodeGlyphX.Rendering.Tiff.QrTiffRenderer,CodeGlyphX.Rendering.Tiff.TiffCompression,CodeGlyphX.Rendering.Tiff.TiffRgba32Page,CodeGlyphX.Rendering.Tiff.TiffWriter,CodeGlyphX.Rendering.Jpeg.JpegEncodeOptions,CodeGlyphX.Rendering.Jpeg.JpegMetadata,CodeGlyphX.Rendering.Jpeg.JpegSubsampling"
     },

--- a/Website/site.json
+++ b/Website/site.json
@@ -47,8 +47,8 @@
   },
   "EditLinks": {
     "Enabled": true,
-    "Template": "https://github.com/EvotecIT/PSPublishModule/edit/master/{path}",
-    "PathBase": "Samples/PowerForge.Web.CodeGlyphX.Sample"
+    "Template": "https://github.com/EvotecIT/CodeGlyphX/edit/master/{path}",
+    "PathBase": "Website"
   },
   "Redirects": [
     { "From": "/docs/api", "To": "/api/", "Status": 301, "MatchType": "Exact", "PreserveQuery": true },

--- a/Website/static/css/api.css
+++ b/Website/static/css/api.css
@@ -437,6 +437,29 @@
     margin-bottom: 1rem;
 }
 
+.type-actions {
+    margin-top: 0.65rem;
+}
+
+.type-source-action {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--api-accent-strong) 45%, transparent);
+    background: color-mix(in srgb, var(--api-accent-strong) 20%, var(--bg-input));
+    color: var(--text);
+    font-size: 0.75rem;
+    font-weight: 600;
+    transition: border-color 0.2s, background 0.2s, color 0.2s;
+}
+
+.type-source-action:hover {
+    border-color: var(--api-accent-strong);
+    background: color-mix(in srgb, var(--api-accent-strong) 28%, var(--bg-input));
+    color: #fff;
+}
+
 .type-badge {
     background: linear-gradient(135deg, var(--api-accent-strong), var(--primary));
     color: white;
@@ -828,10 +851,37 @@
 }
 
 .member-toggle input {
-    accent-color: var(--primary);
+    -webkit-appearance: none;
+    appearance: none;
     width: 14px;
     height: 14px;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    background: var(--bg-input);
     cursor: pointer;
+    position: relative;
+    transition: border-color 0.2s, background 0.2s;
+}
+
+.member-toggle input:hover {
+    border-color: var(--primary);
+}
+
+.member-toggle input:checked {
+    background: var(--primary);
+    border-color: var(--primary);
+}
+
+.member-toggle input:checked::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 4px;
+    height: 8px;
+    border: solid var(--bg);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
 }
 
 .member-actions {
@@ -1208,7 +1258,8 @@
 }
 
 [data-theme="light"] .member-toggle input {
-    accent-color: var(--primary);
+    border-color: color-mix(in srgb, var(--border) 80%, #fff);
+    background: #fff;
 }
 
 [data-theme="light"] .member-anchor:hover {

--- a/Website/static/data/style-board.json
+++ b/Website/static/data/style-board.json
@@ -1,222 +1,310 @@
-﻿[
+[
   {
     "name": "Neon Dot",
     "file": "neon-dot.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=neon-dot#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=neon-dot#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Neon Glow",
     "file": "neon-glow.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=neon-glow#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=neon-glow#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Liquid Glass",
     "file": "liquid-glass.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=liquid-glass#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=liquid-glass#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Card Frame",
     "file": "card-frame.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=card-frame#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=card-frame#styling-options",
+    "width": 467,
+    "height": 471
   },
   {
     "name": "Sticker Frame",
     "file": "sticker-frame.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=sticker-frame#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=sticker-frame#styling-options",
+    "width": 436,
+    "height": 440
   },
   {
     "name": "Top Badge",
     "file": "top-badge.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=top-badge#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=top-badge#styling-options",
+    "width": 446,
+    "height": 449
   },
   {
     "name": "Ribbon Tab",
     "file": "ribbon-tab.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=ribbon-tab#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=ribbon-tab#styling-options",
+    "width": 450,
+    "height": 453
   },
   {
     "name": "Gradient Frame",
     "file": "gradient-frame.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=gradient-frame#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=gradient-frame#styling-options",
+    "width": 417,
+    "height": 420
   },
   {
     "name": "Stitched Frame",
     "file": "stitched-frame.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=stitched-frame#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=stitched-frame#styling-options",
+    "width": 412,
+    "height": 415
   },
   {
     "name": "Quiet Band",
     "file": "quiet-band.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=quiet-band#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=quiet-band#styling-options",
+    "width": 433,
+    "height": 436
   },
   {
     "name": "Warm Harmony",
     "file": "warm-harmony.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=warm-harmony#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=warm-harmony#styling-options",
+    "width": 417,
+    "height": 420
   },
   {
     "name": "Eye Sparkle",
     "file": "eye-sparkle.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=eye-sparkle#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=eye-sparkle#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Candy Checker",
     "file": "candy-checker.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=candy-checker#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=candy-checker#styling-options",
+    "width": 391,
+    "height": 393
   },
   {
     "name": "Pastel Rings",
     "file": "pastel-rings.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=pastel-rings#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=pastel-rings#styling-options",
+    "width": 391,
+    "height": 393
   },
   {
     "name": "Inset Rings",
     "file": "inset-rings.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=inset-rings#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=inset-rings#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Ocean Grid",
     "file": "ocean-grid.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=ocean-grid#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=ocean-grid#styling-options",
+    "width": 420,
+    "height": 422
   },
   {
     "name": "Stripe Frame",
     "file": "stripe-frame.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=stripe-frame#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=stripe-frame#styling-options",
+    "width": 391,
+    "height": 393
   },
   {
     "name": "Crosshatch Pop",
     "file": "crosshatch-pop.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=crosshatch-pop#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=crosshatch-pop#styling-options",
+    "width": 391,
+    "height": 393
   },
   {
     "name": "Mono Badge",
     "file": "mono-badge.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=mono-badge#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=mono-badge#styling-options",
+    "width": 415,
+    "height": 417
   },
   {
     "name": "Bracket Tech",
     "file": "bracket-tech.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=bracket-tech#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=bracket-tech#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Cut Corner Tech",
     "file": "cut-corner-tech.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=cut-corner-tech#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=cut-corner-tech#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Sunset Sticker",
     "file": "sunset-sticker.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=sunset-sticker#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=sunset-sticker#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Aurora",
     "file": "aurora.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=aurora#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=aurora#styling-options",
+    "width": 420,
+    "height": 422
   },
   {
     "name": "Speckle Splash",
     "file": "speckle-splash.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=speckle-splash#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=speckle-splash#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Bead Cluster",
     "file": "bead-cluster.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=bead-cluster#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=bead-cluster#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Shape Blend",
     "file": "shape-blend.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=shape-blend#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=shape-blend#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Jittered Ink",
     "file": "jittered-ink.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=jittered-ink#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=jittered-ink#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Edge Drips",
     "file": "edge-drips.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=edge-drips#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=edge-drips#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Halftone Bloom",
     "file": "halftone-bloom.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=halftone-bloom#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=halftone-bloom#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Vignette Noir",
     "file": "vignette-noir.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=vignette-noir#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=vignette-noir#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Grain Paper",
     "file": "grain-paper.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=grain-paper#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=grain-paper#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Eye Accents",
     "file": "eye-accents.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=eye-accents#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=eye-accents#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Eye Rays",
     "file": "eye-rays.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=eye-rays#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=eye-rays#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Eye Stripes",
     "file": "eye-stripes.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=eye-stripes#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=eye-stripes#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Mint Board",
     "file": "mint-board.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=mint-board#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=mint-board#styling-options",
+    "width": 415,
+    "height": 417
   },
   {
     "name": "Deep Space",
     "file": "deep-space.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=deep-space#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=deep-space#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Leaf Bloom",
     "file": "leaf-bloom.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=leaf-bloom#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=leaf-bloom#styling-options",
+    "width": 425,
+    "height": 427
   },
   {
     "name": "Wave Pulse",
     "file": "wave-pulse.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=wave-pulse#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=wave-pulse#styling-options",
+    "width": 420,
+    "height": 422
   },
   {
     "name": "Ink Blob",
     "file": "ink-blob.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=ink-blob#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=ink-blob#styling-options",
+    "width": 415,
+    "height": 417
   },
   {
     "name": "Soft Diamond",
     "file": "soft-diamond.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=soft-diamond#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=soft-diamond#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Sticker Grid",
     "file": "sticker-grid.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=sticker-grid#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=sticker-grid#styling-options",
+    "width": 391,
+    "height": 393
   },
   {
     "name": "Connected Melt",
     "file": "connected-melt.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=connected-melt#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=connected-melt#styling-options",
+    "width": 396,
+    "height": 398
   },
   {
     "name": "Minimal Mono",
     "file": "minimal-mono.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=minimal-mono#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=minimal-mono#styling-options",
+    "width": 386,
+    "height": 388
   },
   {
     "name": "Center Pop",
     "file": "center-pop.png",
-    "payload": "https://codeglyphx.com/docs/qr?style=center-pop#styling-options"
+    "payload": "https://codeglyphx.com/docs/qr?style=center-pop#styling-options",
+    "width": 386,
+    "height": 388
   }
 ]


### PR DESCRIPTION
## Summary
- fix docs `Edit on GitHub` to point to `EvotecIT/CodeGlyphX` (`Website/...`) instead of `PSPublishModule/Samples/...`
- enable API source mapping in pipeline (`sourceRoot` + `sourceUrl`) so API pages link to exact `.cs` lines
- improve API type page UX for new source action button and styled inherited-members checkbox
- add explicit width/height metadata to style-board dataset and apply dimensions when runtime images are created
- add `decoding="async"` for style-board runtime images

## Validation
- `./build.ps1` (Website)
- optimize + audit steps completed successfully