### PR TITLE
Migrate docs pages from raw HTML to Markdown

### DIFF
--- a/Website/content/docs/aztec.md
+++ b/Website/content/docs/aztec.md
@@ -4,30 +4,36 @@ description: Aztec encoding basics and use cases.
 slug: aztec
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Aztec Code</h1>
-<p>Aztec is a 2D matrix barcode designed for high readability even when printed at low resolution or on curved surfaces.</p>
+# Aztec Code
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+Aztec is a 2D matrix barcode designed for high readability even when printed at low resolution or on curved surfaces.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Simple Aztec code
 AztecCode.Save("Ticket: CONF-2024-001", "aztec.png");
 
 // With error correction percentage
-AztecCode.Save("Ticket data", "aztec.png", errorCorrectionPercent: 33);</pre>
+AztecCode.Save("Ticket data", "aztec.png", errorCorrectionPercent: 33);
+```
 
-<h2>Use Cases</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>Transportation</strong> - Train and airline tickets</li>
-<li><strong>Event tickets</strong> - Mobile ticketing apps</li>
-<li><strong>Patient wristbands</strong> - Healthcare identification</li>
-<li><strong>Curved surfaces</strong> - Bottles, tubes, cylinders</li>
-</ul>
+## Use Cases
 
-<h2>Advantages</h2>
-<p>Aztec codes don't require a quiet zone around them and can be read even when partially damaged, making them ideal for mobile ticketing.</p>
+- **Transportation** - Train and airline tickets
+
+- **Event tickets** - Mobile ticketing apps
+
+- **Patient wristbands** - Healthcare identification
+
+- **Curved surfaces** - Bottles, tubes, cylinders
+
+## Advantages
+
+Aztec codes don't require a quiet zone around them and can be read even when partially damaged, making them ideal for mobile ticketing.

--- a/Website/content/docs/aztec.md
+++ b/Website/content/docs/aztec.md
@@ -27,11 +27,8 @@ AztecCode.Save("Ticket data", "aztec.png", errorCorrectionPercent: 33);
 ## Use Cases
 
 - **Transportation** - Train and airline tickets
-
 - **Event tickets** - Mobile ticketing apps
-
 - **Patient wristbands** - Healthcare identification
-
 - **Curved surfaces** - Bottles, tubes, cylinders
 
 ## Advantages

--- a/Website/content/docs/code128.md
+++ b/Website/content/docs/code128.md
@@ -4,47 +4,30 @@ description: Code 128 / GS1-128 usage and character sets.
 slug: code128
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Code 128 / GS1-128</h1>
-<p>Code 128 is a high-density linear barcode supporting the full ASCII character set. GS1-128 is an application standard that uses Code 128.</p>
+# Code 128 / GS1-128
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+Code 128 is a high-density linear barcode supporting the full ASCII character set. GS1-128 is an application standard that uses Code 128.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Code 128
 Barcode.Save(BarcodeType.Code128, "PRODUCT-12345", "code128.png");
 
 // GS1-128 with Application Identifiers
-Barcode.Save(BarcodeType.Gs1128, "(01)09501101530003(17)250101", "gs1.png");</pre>
+Barcode.Save(BarcodeType.Gs1128, "(01)09501101530003(17)250101", "gs1.png");
+```
 
-<h2>Character Sets</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Set</th>
-<th style="text-align: left; padding: 0.75rem;">Characters</th>
-<th style="text-align: left; padding: 0.75rem;">Best For</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><code>A</code></td>
-<td style="padding: 0.75rem;">A-Z, 0-9, control chars</td>
-<td style="padding: 0.75rem;">Alphanumeric with controls</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><code>B</code></td>
-<td style="padding: 0.75rem;">A-Z, a-z, 0-9, symbols</td>
-<td style="padding: 0.75rem;">General text (most common)</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;"><code>C</code></td>
-<td style="padding: 0.75rem;">00-99 (digit pairs)</td>
-<td style="padding: 0.75rem;">Numeric data (most compact)</td>
-</tr>
-</tbody>
-</table>
+## Character Sets
+
+| Set | Characters | Best For |
+| --- | --- | --- |
+| `A` | A-Z, 0-9, control chars | Alphanumeric with controls |
+| `B` | A-Z, a-z, 0-9, symbols | General text (most common) |
+| `C` | 00-99 (digit pairs) | Numeric data (most compact) |

--- a/Website/content/docs/code39.md
+++ b/Website/content/docs/code39.md
@@ -4,51 +4,36 @@ description: Code 39 / 93 usage and comparisons.
 slug: code39
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Code 39 / Code 93</h1>
-<p>Code 39 and Code 93 are widely used linear barcodes, particularly in automotive and defense industries.</p>
+# Code 39 / Code 93
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+Code 39 and Code 93 are widely used linear barcodes, particularly in automotive and defense industries.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Code 39
 Barcode.Save(BarcodeType.Code39, "HELLO-123", "code39.png");
 
 // Code 93 (more compact)
-Barcode.Save(BarcodeType.Code93, "HELLO-123", "code93.png");</pre>
+Barcode.Save(BarcodeType.Code93, "HELLO-123", "code93.png");
+```
 
-<h2>Valid Characters</h2>
-<p>Code 39 supports: <code>A-Z</code>, <code>0-9</code>, <code>-</code>, <code>.</code>, <code>$</code>, <code>/</code>, <code>+</code>, <code>%</code>, <code>SPACE</code></p>
-<p style="margin-top: 0.5rem;"><strong>Note:</strong> Lowercase letters are automatically converted to uppercase.</p>
+## Valid Characters
 
-<h2>Comparison</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Feature</th>
-<th style="text-align: left; padding: 0.75rem;">Code 39</th>
-<th style="text-align: left; padding: 0.75rem;">Code 93</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Density</td>
-<td style="padding: 0.75rem;">Lower</td>
-<td style="padding: 0.75rem;">~40% more compact</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Checksum</td>
-<td style="padding: 0.75rem;">Optional</td>
-<td style="padding: 0.75rem;">Mandatory (2 chars)</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;">Industry</td>
-<td style="padding: 0.75rem;">Automotive, Defense</td>
-<td style="padding: 0.75rem;">Logistics, Postal</td>
-</tr>
-</tbody>
-</table>
+Code 39 supports: `A-Z`, `0-9`, `-`, `.`, `$`, `/`, `+`, `%`, `SPACE`
+
+**Note:** Lowercase letters are automatically converted to uppercase.
+
+## Comparison
+
+| Feature | Code 39 | Code 93 |
+| --- | --- | --- |
+| Density | Lower | ~40% more compact |
+| Checksum | Optional | Mandatory (2 chars) |
+| Industry | Automotive, Defense | Logistics, Postal |

--- a/Website/content/docs/datamatrix.md
+++ b/Website/content/docs/datamatrix.md
@@ -4,30 +4,36 @@ description: Data Matrix encoding basics and use cases.
 slug: datamatrix
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Data Matrix</h1>
-<p>Data Matrix is a 2D barcode widely used in industrial and commercial applications for marking small items.</p>
+# Data Matrix
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+Data Matrix is a 2D barcode widely used in industrial and commercial applications for marking small items.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Simple Data Matrix
 DataMatrixCode.Save("SERIAL-12345", "datamatrix.png");
 
 // With specific size
-DataMatrixCode.Save("SERIAL-12345", "datamatrix.svg", size: DataMatrixSize.Square24);</pre>
+DataMatrixCode.Save("SERIAL-12345", "datamatrix.svg", size: DataMatrixSize.Square24);
+```
 
-<h2>Use Cases</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>Electronics manufacturing</strong> - Component marking and tracking</li>
-<li><strong>Healthcare</strong> - Medical device identification (UDI)</li>
-<li><strong>Aerospace</strong> - Part serialization</li>
-<li><strong>Postal services</strong> - High-density mail sorting</li>
-</ul>
+## Use Cases
 
-<h2>Features</h2>
-<p>CodeGlyphX supports all standard Data Matrix sizes from 10x10 to 144x144 modules, including rectangular variants.</p>
+- **Electronics manufacturing** - Component marking and tracking
+
+- **Healthcare** - Medical device identification (UDI)
+
+- **Aerospace** - Part serialization
+
+- **Postal services** - High-density mail sorting
+
+## Features
+
+CodeGlyphX supports all standard Data Matrix sizes from 10x10 to 144x144 modules, including rectangular variants.

--- a/Website/content/docs/datamatrix.md
+++ b/Website/content/docs/datamatrix.md
@@ -27,11 +27,8 @@ DataMatrixCode.Save("SERIAL-12345", "datamatrix.svg", size: DataMatrixSize.Squar
 ## Use Cases
 
 - **Electronics manufacturing** - Component marking and tracking
-
 - **Healthcare** - Medical device identification (UDI)
-
 - **Aerospace** - Part serialization
-
 - **Postal services** - High-density mail sorting
 
 ## Features

--- a/Website/content/docs/decoding.md
+++ b/Website/content/docs/decoding.md
@@ -34,28 +34,22 @@ var decodeResult = QrImageDecoder.DecodeImage(stream);
 ## Supported Formats for Decoding
 
 - **Images:** PNG, JPEG, WebP, BMP, GIF, TIFF, PPM/PGM/PBM/PAM, TGA, ICO/CUR, XBM, XPM
-
 - **QR Codes:** Standard QR, Micro QR
-
 - **1D Barcodes:** Code 128, Code 39/93, EAN/UPC, ITF, Codabar, MSI, Telepen, Plessey, more
-
 - **2D Matrix:** Data Matrix, PDF417, Aztec
 
 ## Known Gaps (Decoding)
 
 - AVIF, HEIC, JPEG2000
-
 - ImageReader.DecodeRgba32 returns the first GIF/WebP frame; use ImageReader.DecodeGifAnimationFrames / DecodeWebpAnimationFrames (or GifReader/WebpReader) for animation frames
-
 - ImageReader.DecodeRgba32 returns the first TIFF page; use ImageReader.TryDecodeTiffPagesRgba32 (or TiffReader.DecodePagesRgba32) for multi-page
-
 - PDF decode supports image-only PDFs with embedded JPEG/Flate; PS decode still needs rasterization
 
 ## Format Corpus (Optional)
 
 We maintain external image samples to validate edge cases (PNG/TIFF suites, packed bit-depths, interlace, etc.). These are not stored in the repo.
 
-```
+```powershell
 // Download the image format corpus
 pwsh Build/Download-ImageSamples.ps1
 

--- a/Website/content/docs/decoding.md
+++ b/Website/content/docs/decoding.md
@@ -4,16 +4,18 @@ description: Decode barcodes and QR codes from images.
 slug: decoding
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Image Decoding</h1>
-<p>CodeGlyphX includes a built-in decoder for reading QR codes and barcodes from images.</p>
+# Image Decoding
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+CodeGlyphX includes a built-in decoder for reading QR codes and barcodes from images.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Decode from file
 byte[] imageBytes = File.ReadAllBytes("qrcode.png");
@@ -26,46 +28,61 @@ if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
 
 // Decode from stream
 using var stream = File.OpenRead("barcode.png");
-var decodeResult = QrImageDecoder.DecodeImage(stream);</pre>
+var decodeResult = QrImageDecoder.DecodeImage(stream);
+```
 
-<h2>Supported Formats for Decoding</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>Images:</strong> PNG, JPEG, WebP, BMP, GIF, TIFF, PPM/PGM/PBM/PAM, TGA, ICO/CUR, XBM, XPM</li>
-<li><strong>QR Codes:</strong> Standard QR, Micro QR</li>
-<li><strong>1D Barcodes:</strong> Code 128, Code 39/93, EAN/UPC, ITF, Codabar, MSI, Telepen, Plessey, more</li>
-<li><strong>2D Matrix:</strong> Data Matrix, PDF417, Aztec</li>
-</ul>
+## Supported Formats for Decoding
 
-<h2>Known Gaps (Decoding)</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li>AVIF, HEIC, JPEG2000</li>
-<li>ImageReader.DecodeRgba32 returns the first GIF/WebP frame; use ImageReader.DecodeGifAnimationFrames / DecodeWebpAnimationFrames (or GifReader/WebpReader) for animation frames</li>
-<li>ImageReader.DecodeRgba32 returns the first TIFF page; use ImageReader.TryDecodeTiffPagesRgba32 (or TiffReader.DecodePagesRgba32) for multi-page</li>
-<li>PDF decode supports image-only PDFs with embedded JPEG/Flate; PS decode still needs rasterization</li>
-</ul>
+- **Images:** PNG, JPEG, WebP, BMP, GIF, TIFF, PPM/PGM/PBM/PAM, TGA, ICO/CUR, XBM, XPM
 
-<h2>Format Corpus (Optional)</h2>
-<p class="text-muted">We maintain external image samples to validate edge cases (PNG/TIFF suites, packed bit-depths, interlace, etc.). These are not stored in the repo.</p>
-<pre class="code-block">// Download the image format corpus
+- **QR Codes:** Standard QR, Micro QR
+
+- **1D Barcodes:** Code 128, Code 39/93, EAN/UPC, ITF, Codabar, MSI, Telepen, Plessey, more
+
+- **2D Matrix:** Data Matrix, PDF417, Aztec
+
+## Known Gaps (Decoding)
+
+- AVIF, HEIC, JPEG2000
+
+- ImageReader.DecodeRgba32 returns the first GIF/WebP frame; use ImageReader.DecodeGifAnimationFrames / DecodeWebpAnimationFrames (or GifReader/WebpReader) for animation frames
+
+- ImageReader.DecodeRgba32 returns the first TIFF page; use ImageReader.TryDecodeTiffPagesRgba32 (or TiffReader.DecodePagesRgba32) for multi-page
+
+- PDF decode supports image-only PDFs with embedded JPEG/Flate; PS decode still needs rasterization
+
+## Format Corpus (Optional)
+
+We maintain external image samples to validate edge cases (PNG/TIFF suites, packed bit-depths, interlace, etc.). These are not stored in the repo.
+
+```
+// Download the image format corpus
 pwsh Build/Download-ImageSamples.ps1
 
 // Download external barcode/QR samples
-pwsh Build/Download-ExternalSamples.ps1</pre>
+pwsh Build/Download-ExternalSamples.ps1
+```
 
-<h2>Handling Multiple Results</h2>
-<pre class="code-block">// Decode all barcodes in an image
+## Handling Multiple Results
+
+```csharp
+// Decode all barcodes in an image
 var results = QrImageDecoder.DecodeAllImages(imageBytes);
 
 foreach (var barcode in results)
 {
     Console.WriteLine($"{barcode.BarcodeFormat}: {barcode.Text}");
-}</pre>
+}
+```
 
-<h2>Diagnostics</h2>
-<pre class="code-block">using CodeGlyphX;
+## Diagnostics
+
+```csharp
+using CodeGlyphX;
 
 if (!CodeGlyph.TryDecodeImage(imageBytes, out var decoded, out var diagnostics, options: null))
 {
     Console.WriteLine(diagnostics.FailureReason);
     Console.WriteLine(diagnostics.Failure);
-}</pre>
+}
+```

--- a/Website/content/docs/ean-upc.md
+++ b/Website/content/docs/ean-upc.md
@@ -4,16 +4,18 @@ description: EAN and UPC formats overview.
 slug: ean-upc
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>EAN / UPC Barcodes</h1>
-<p>EAN (European Article Number) and UPC (Universal Product Code) are the standard retail barcodes found on consumer products worldwide.</p>
+# EAN / UPC Barcodes
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+EAN (European Article Number) and UPC (Universal Product Code) are the standard retail barcodes found on consumer products worldwide.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // EAN-13 (International)
 Barcode.Save(BarcodeType.EAN, "5901234123457", "ean13.png");
@@ -25,42 +27,14 @@ Barcode.Save(BarcodeType.EAN, "96385074", "ean8.png");
 Barcode.Save(BarcodeType.UPCA, "012345678905", "upca.png");
 
 // UPC-E (Compact)
-Barcode.Save(BarcodeType.UPCE, "01234565", "upce.png");</pre>
+Barcode.Save(BarcodeType.UPCE, "01234565", "upce.png");
+```
 
-<h2>Format Guide</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Type</th>
-<th style="text-align: left; padding: 0.75rem;">Digits</th>
-<th style="text-align: left; padding: 0.75rem;">Region</th>
-<th style="text-align: left; padding: 0.75rem;">Use Case</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">EAN-13</td>
-<td style="padding: 0.75rem;">13</td>
-<td style="padding: 0.75rem;">International</td>
-<td style="padding: 0.75rem;">Standard retail products</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">EAN-8</td>
-<td style="padding: 0.75rem;">8</td>
-<td style="padding: 0.75rem;">International</td>
-<td style="padding: 0.75rem;">Small packages</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">UPC-A</td>
-<td style="padding: 0.75rem;">12</td>
-<td style="padding: 0.75rem;">North America</td>
-<td style="padding: 0.75rem;">Retail products</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;">UPC-E</td>
-<td style="padding: 0.75rem;">8</td>
-<td style="padding: 0.75rem;">North America</td>
-<td style="padding: 0.75rem;">Small items</td>
-</tr>
-</tbody>
-</table>
+## Format Guide
+
+| Type | Digits | Region | Use Case |
+| --- | --- | --- | --- |
+| EAN-13 | 13 | International | Standard retail products |
+| EAN-8 | 8 | International | Small packages |
+| UPC-A | 12 | North America | Retail products |
+| UPC-E | 8 | North America | Small items |

--- a/Website/content/docs/index.md
+++ b/Website/content/docs/index.md
@@ -18,13 +18,9 @@ for generating and decoding QR codes, barcodes, and other 2D matrix codes.
 ## Key Features
 
 - **Zero external dependencies** - No System.Drawing, SkiaSharp, or ImageSharp required
-
 - **Full encode & decode** - Round-trip support for all symbologies
-
 - **Multiple output formats** - PNG, SVG, PDF, EPS, HTML, and many more
-
 - **Cross-platform** - Windows, Linux, macOS
-
 - **AOT compatible** - Works with Native AOT and trimming
 
 ## Supported Symbologies
@@ -40,17 +36,11 @@ Code 128, GS1-128, Code 39/93/11, Codabar, MSI, Plessey, Telepen, Pharmacode, Co
 ## Documentation Map
 
 - **QR & Micro QR** - Core encoding, error correction, and QR specifics. [QR docs](/docs/qr/)
-
 - **Styling & presets** - Module shapes, palettes, logos, and the style board gallery. [Styling options](/docs/qr/#styling-options)
-
 - **Payload helpers** - WiFi, vCards, OTP, SEPA, and more. [Payload helpers](/docs/payloads/)
-
 - **Image decoding** - Decode from images and screenshots. [Image decoding](/docs/decoding/)
-
 - **Output formats** - PNG, SVG, PDF, EPS, HTML, and more. [Output formats](/docs/renderers/)
-
 - **API Reference** - Full type and method documentation. [API reference](/api/)
-
 - **FAQ** - Common questions and troubleshooting. [FAQ](/faq/)
 
 ## Quick Example

--- a/Website/content/docs/index.md
+++ b/Website/content/docs/index.md
@@ -4,47 +4,59 @@ description: CodeGlyphX documentation - learn how to generate and decode QR code
 slug: index
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>CodeGlyphX Documentation</h1>
-<p>
-                Welcome to the CodeGlyphX documentation. CodeGlyphX is a zero-dependency .NET library
-                for generating and decoding QR codes, barcodes, and other 2D matrix codes.
-</p>
-<div class="docs-status">Actively developed - Stable core - Expanding format support</div>
+# CodeGlyphX Documentation
 
-<h2>Key Features</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>Zero external dependencies</strong> - No System.Drawing, SkiaSharp, or ImageSharp required</li>
-<li><strong>Full encode &amp; decode</strong> - Round-trip support for all symbologies</li>
-<li><strong>Multiple output formats</strong> - PNG, SVG, PDF, EPS, HTML, and many more</li>
-<li><strong>Cross-platform</strong> - Windows, Linux, macOS</li>
-<li><strong>AOT compatible</strong> - Works with Native AOT and trimming</li>
-</ul>
+Welcome to the CodeGlyphX documentation. CodeGlyphX is a zero-dependency .NET library
+for generating and decoding QR codes, barcodes, and other 2D matrix codes.
 
-<h2>Supported Symbologies</h2>
-<h3>2D Matrix Codes</h3>
-<p>QR Code, Micro QR, Data Matrix, PDF417 / MicroPDF417, Aztec, GS1 DataBar (Omni/Stacked), and postal 4-state (IMB/RM4SCC/AusPost)</p>
+> **Status:** Actively developed - Stable core - Expanding format support
 
-<h3>1D Linear Barcodes</h3>
-<p>Code 128, GS1-128, Code 39/93/11, Codabar, MSI, Plessey, Telepen, Pharmacode, Code 32, EAN/UPC, ITF and 2-of-5 variants, GS1 DataBar (Truncated/Expanded)</p>
+## Key Features
 
-<h2>Documentation Map</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>QR &amp; Micro QR</strong> - Core encoding, error correction, and QR specifics. <a href="/docs/qr/">QR docs</a></li>
-<li><strong>Styling &amp; presets</strong> - Module shapes, palettes, logos, and the style board gallery. <a href="/docs/qr/#styling-options">Styling options</a></li>
-<li><strong>Payload helpers</strong> - WiFi, vCards, OTP, SEPA, and more. <a href="/docs/payloads/">Payload helpers</a></li>
-<li><strong>Image decoding</strong> - Decode from images and screenshots. <a href="/docs/decoding/">Image decoding</a></li>
-<li><strong>Output formats</strong> - PNG, SVG, PDF, EPS, HTML, and more. <a href="/docs/renderers/">Output formats</a></li>
-<li><strong>API Reference</strong> - Full type and method documentation. <a href="/api/">API reference</a></li>
-<li><strong>FAQ</strong> - Common questions and troubleshooting. <a href="/faq/">FAQ</a></li>
-</ul>
+- **Zero external dependencies** - No System.Drawing, SkiaSharp, or ImageSharp required
 
-<h2>Quick Example</h2>
-<pre class="code-block">using CodeGlyphX;
+- **Full encode & decode** - Round-trip support for all symbologies
+
+- **Multiple output formats** - PNG, SVG, PDF, EPS, HTML, and many more
+
+- **Cross-platform** - Windows, Linux, macOS
+
+- **AOT compatible** - Works with Native AOT and trimming
+
+## Supported Symbologies
+
+### 2D Matrix Codes
+
+QR Code, Micro QR, Data Matrix, PDF417 / MicroPDF417, Aztec, GS1 DataBar (Omni/Stacked), and postal 4-state (IMB/RM4SCC/AusPost)
+
+### 1D Linear Barcodes
+
+Code 128, GS1-128, Code 39/93/11, Codabar, MSI, Plessey, Telepen, Pharmacode, Code 32, EAN/UPC, ITF and 2-of-5 variants, GS1 DataBar (Truncated/Expanded)
+
+## Documentation Map
+
+- **QR & Micro QR** - Core encoding, error correction, and QR specifics. [QR docs](/docs/qr/)
+
+- **Styling & presets** - Module shapes, palettes, logos, and the style board gallery. [Styling options](/docs/qr/#styling-options)
+
+- **Payload helpers** - WiFi, vCards, OTP, SEPA, and more. [Payload helpers](/docs/payloads/)
+
+- **Image decoding** - Decode from images and screenshots. [Image decoding](/docs/decoding/)
+
+- **Output formats** - PNG, SVG, PDF, EPS, HTML, and more. [Output formats](/docs/renderers/)
+
+- **API Reference** - Full type and method documentation. [API reference](/api/)
+
+- **FAQ** - Common questions and troubleshooting. [FAQ](/faq/)
+
+## Quick Example
+
+```csharp
+using CodeGlyphX;
 
 // Generate a QR code
 QR.Save("https://evotec.xyz", "website.png");
@@ -56,16 +68,13 @@ Barcode.Save(BarcodeType.Code128, "PRODUCT-123", "barcode.png");
 if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
 {
     Console.WriteLine(result.Text);
-}</pre>
+}
+```
 
-<h2>Getting Help</h2>
-<p>
-                If you encounter issues or have questions, please visit the
-<a href="https://github.com/EvotecIT/CodeGlyphX/issues" target="_blank">GitHub Issues</a> page.
-</p>
-<p>
-                For planned work and known gaps, see the
-<a href="https://github.com/EvotecIT/CodeGlyphX/blob/master/ROADMAP.md" target="_blank">ROADMAP</a>.
-</p>
+## Getting Help
 
+If you encounter issues or have questions, please visit the
+[GitHub Issues](https://github.com/EvotecIT/CodeGlyphX/issues) page.
 
+For planned work and known gaps, see the
+[ROADMAP](https://github.com/EvotecIT/CodeGlyphX/blob/master/ROADMAP.md).

--- a/Website/content/docs/installation.md
+++ b/Website/content/docs/installation.md
@@ -4,79 +4,58 @@ description: Install CodeGlyphX via NuGet and configure targets.
 slug: installation
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Installation</h1>
-<p>CodeGlyphX is available as a NuGet package and can be installed in several ways.</p>
+# Installation
 
-<h2>.NET CLI</h2>
-<pre class="code-block">dotnet add package CodeGlyphX</pre>
+CodeGlyphX is available as a NuGet package and can be installed in several ways.
 
-<h2>Package Manager Console</h2>
-<pre class="code-block">Install-Package CodeGlyphX</pre>
+## .NET CLI
 
-<h2>PackageReference</h2>
-<p>Add the following to your <code>.csproj</code> file:</p>
-<pre class="code-block">&lt;PackageReference Include="CodeGlyphX" Version="*" /&gt;</pre>
+```csharp
+dotnet add package CodeGlyphX
+```
 
-<h2>Supported Frameworks</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>.NET 8.0+</strong> - Full support, no additional dependencies</li>
-<li><strong>.NET Standard 2.0</strong> - Requires System.Memory 4.5.5</li>
-<li><strong>.NET Framework 4.7.2+</strong> - Requires System.Memory 4.5.5</li>
-</ul>
+## Package Manager Console
 
-<h2>Feature Availability</h2>
-<p>Most features are available across all targets, but the QR pixel pipeline and Span-based APIs are net8+ only.</p>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Feature</th>
-<th style="text-align: left; padding: 0.75rem;">net8.0+</th>
-<th style="text-align: left; padding: 0.75rem;">net472 / netstandard2.0</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Encode (QR/Micro QR + 1D/2D)</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Decode from module grids (BitMatrix)</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Renderers + image file codecs</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">1D/2D pixel decode (Barcode/DataMatrix/PDF417/Aztec)</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">QR pixel decode from raw pixels / screenshots</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No (returns false)</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">QR pixel debug rendering</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;">Span-based overloads</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No (byte[] only)</td>
-</tr>
-</tbody>
-</table>
-<p class="text-muted">QR pixel decode APIs are net8+ only (e.g., <code>QrImageDecoder.TryDecodeImage(...)</code> and <code>QrDecoder.TryDecode(...)</code> from pixels).</p>
-<p class="text-muted">You can check capabilities at runtime via <code>CodeGlyphXFeatures</code> (for example, <code>SupportsQrPixelDecode</code> and <code>SupportsQrPixelDebug</code>).</p>
-<p class="text-muted"><strong>Choosing a target:</strong> pick <code>net8.0+</code> for QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick <code>net472</code>/<code>netstandard2.0</code> for legacy apps that only need encoding, rendering, and module-grid decode.</p>
+```csharp
+Install-Package CodeGlyphX
+```
+
+## PackageReference
+
+Add the following to your `.csproj` file:
+
+```xml
+<PackageReference Include="CodeGlyphX" Version="*" />
+```
+
+## Supported Frameworks
+
+- **.NET 8.0+** - Full support, no additional dependencies
+
+- **.NET Standard 2.0** - Requires System.Memory 4.5.5
+
+- **.NET Framework 4.7.2+** - Requires System.Memory 4.5.5
+
+## Feature Availability
+
+Most features are available across all targets, but the QR pixel pipeline and Span-based APIs are net8+ only.
+
+| Feature | net8.0+ | net472 / netstandard2.0 |
+| --- | --- | --- |
+| Encode (QR/Micro QR + 1D/2D) | Yes | Yes |
+| Decode from module grids (BitMatrix) | Yes | Yes |
+| Renderers + image file codecs | Yes | Yes |
+| 1D/2D pixel decode (Barcode/DataMatrix/PDF417/Aztec) | Yes | Yes |
+| QR pixel decode from raw pixels / screenshots | Yes | No (returns false) |
+| QR pixel debug rendering | Yes | No |
+| Span-based overloads | Yes | No (byte[] only) |
+
+QR pixel decode APIs are net8+ only (e.g., `QrImageDecoder.TryDecodeImage(...)` and `QrDecoder.TryDecode(...)` from pixels).
+
+You can check capabilities at runtime via `CodeGlyphXFeatures` (for example, `SupportsQrPixelDecode` and `SupportsQrPixelDebug`).
+
+**Choosing a target:** pick `net8.0+` for QR image decoding, pixel debug tools, Span APIs, and maximum throughput. Pick `net472`/`netstandard2.0` for legacy apps that only need encoding, rendering, and module-grid decode.

--- a/Website/content/docs/installation.md
+++ b/Website/content/docs/installation.md
@@ -14,13 +14,13 @@ CodeGlyphX is available as a NuGet package and can be installed in several ways.
 
 ## .NET CLI
 
-```csharp
+```bash
 dotnet add package CodeGlyphX
 ```
 
 ## Package Manager Console
 
-```csharp
+```powershell
 Install-Package CodeGlyphX
 ```
 
@@ -35,9 +35,7 @@ Add the following to your `.csproj` file:
 ## Supported Frameworks
 
 - **.NET 8.0+** - Full support, no additional dependencies
-
 - **.NET Standard 2.0** - Requires System.Memory 4.5.5
-
 - **.NET Framework 4.7.2+** - Requires System.Memory 4.5.5
 
 ## Feature Availability

--- a/Website/content/docs/microqr.md
+++ b/Website/content/docs/microqr.md
@@ -4,44 +4,27 @@ description: Micro QR generation and constraints.
 slug: microqr
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Micro QR Code</h1>
-<p>Micro QR is a smaller version of the standard QR code, designed for applications where space is limited.</p>
+# Micro QR Code
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+Micro QR is a smaller version of the standard QR code, designed for applications where space is limited.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Generate Micro QR
-QR.Save("ABC123", "microqr.png", microQr: true);</pre>
+QR.Save("ABC123", "microqr.png", microQr: true);
+```
 
-<h2>Comparison with Standard QR</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Feature</th>
-<th style="text-align: left; padding: 0.75rem;">Standard QR</th>
-<th style="text-align: left; padding: 0.75rem;">Micro QR</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Finder patterns</td>
-<td style="padding: 0.75rem;">3 corners</td>
-<td style="padding: 0.75rem;">1 corner</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Max capacity</td>
-<td style="padding: 0.75rem;">~3KB</td>
-<td style="padding: 0.75rem;">~35 characters</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;">Best for</td>
-<td style="padding: 0.75rem;">General use</td>
-<td style="padding: 0.75rem;">Small labels, PCBs</td>
-</tr>
-</tbody>
-</table>
+## Comparison with Standard QR
+
+| Feature | Standard QR | Micro QR |
+| --- | --- | --- |
+| Finder patterns | 3 corners | 1 corner |
+| Max capacity | ~3KB | ~35 characters |
+| Best for | General use | Small labels, PCBs |

--- a/Website/content/docs/other-1d.md
+++ b/Website/content/docs/other-1d.md
@@ -4,55 +4,30 @@ description: Additional 1D and postal barcode formats.
 slug: other-1d
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Other 1D &amp; Postal Barcodes</h1>
-<p>CodeGlyphX supports a wide range of additional 1D symbologies beyond the most common retail formats.</p>
-<p><strong>Note:</strong> Some postal and stacked formats use the matrix pipeline and must be rendered with <code>MatrixBarcodeEncoder</code> + matrix renderers.</p>
+# Other 1D &amp; Postal Barcodes
 
-<h2>Supported Types</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Category</th>
-<th style="text-align: left; padding: 0.75rem;">Symbologies</th>
-<th style="text-align: left; padding: 0.75rem;">Notes</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Interleaved / 2-of-5</td>
-<td style="padding: 0.75rem;">ITF, ITF-14, Industrial 2-of-5, Matrix 2-of-5, IATA 2-of-5</td>
-<td style="padding: 0.75rem;">Logistics, cartons, older systems</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Specialty / Legacy</td>
-<td style="padding: 0.75rem;">Codabar, MSI, Code 11, Plessey, Telepen, Code 32</td>
-<td style="padding: 0.75rem;">Warehousing, libraries, healthcare</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Pharma</td>
-<td style="padding: 0.75rem;">Pharmacode (one-track), Pharmacode (two-track)</td>
-<td style="padding: 0.75rem;">Packaging and pharmaceuticals</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">Postal</td>
-<td style="padding: 0.75rem;">POSTNET, PLANET, Royal Mail 4-State, Australia Post, Japan Post, USPS IMB</td>
-<td style="padding: 0.75rem;">Matrix encoder required</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;">GS1 DataBar</td>
-<td style="padding: 0.75rem;">DataBar Truncated, Omni, Stacked, Expanded, Expanded Stacked</td>
-<td style="padding: 0.75rem;">Omni/Stacked/Expanded Stacked use matrix encoder</td>
-</tr>
-</tbody>
-</table>
+CodeGlyphX supports a wide range of additional 1D symbologies beyond the most common retail formats.
 
-<h2>Examples</h2>
-<pre class="code-block">using CodeGlyphX;
+**Note:** Some postal and stacked formats use the matrix pipeline and must be rendered with `MatrixBarcodeEncoder` + matrix renderers.
+
+## Supported Types
+
+| Category | Symbologies | Notes |
+| --- | --- | --- |
+| Interleaved / 2-of-5 | ITF, ITF-14, Industrial 2-of-5, Matrix 2-of-5, IATA 2-of-5 | Logistics, cartons, older systems |
+| Specialty / Legacy | Codabar, MSI, Code 11, Plessey, Telepen, Code 32 | Warehousing, libraries, healthcare |
+| Pharma | Pharmacode (one-track), Pharmacode (two-track) | Packaging and pharmaceuticals |
+| Postal | POSTNET, PLANET, Royal Mail 4-State, Australia Post, Japan Post, USPS IMB | Matrix encoder required |
+| GS1 DataBar | DataBar Truncated, Omni, Stacked, Expanded, Expanded Stacked | Omni/Stacked/Expanded Stacked use matrix encoder |
+
+## Examples
+
+```csharp
+using CodeGlyphX;
 using CodeGlyphX.Rendering.Png;
 
 Barcode.Save(BarcodeType.ITF14, "12345678901231", "itf14.png");
@@ -64,4 +39,5 @@ var imb = MatrixBarcodeEncoder.EncodeUspsImb("0123456709498765432101234567891");
 MatrixPngRenderer.RenderToFile(
     imb,
     new MatrixPngRenderOptions { ModuleSize = 2, QuietZone = 2 },
-    "usps-imb.png");</pre>
+    "usps-imb.png");
+```

--- a/Website/content/docs/payloads.md
+++ b/Website/content/docs/payloads.md
@@ -4,26 +4,31 @@ description: Payload helpers for WiFi, vCards, OTP, and more.
 slug: payloads
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Payload Helpers</h1>
-<p>CodeGlyphX includes built-in helpers for generating QR codes with structured payloads that mobile devices can interpret.</p>
+# Payload Helpers
 
-<h2>WiFi Configuration</h2>
-<pre class="code-block">using CodeGlyphX;
+CodeGlyphX includes built-in helpers for generating QR codes with structured payloads that mobile devices can interpret.
+
+## WiFi Configuration
+
+```csharp
+using CodeGlyphX;
 using CodeGlyphX.Payloads;
 
 // WPA/WPA2 network
 QR.Save(QrPayloads.Wifi("NetworkName", "Password123"), "wifi.png");
 
 // Open network (no password)
-QR.Save(QrPayloads.Wifi("PublicNetwork", "", "nopass"), "wifi-open.png");</pre>
+QR.Save(QrPayloads.Wifi("PublicNetwork", "", "nopass"), "wifi-open.png");
+```
 
-<h2>Contact Cards</h2>
-<pre class="code-block">// vCard format (widely supported)
+## Contact Cards
+
+```csharp
+// vCard format (widely supported)
 QR.Save(QrPayloads.Contact(
     QrContactOutputType.VCard3,
     firstname: "Przemyslaw",
@@ -32,25 +37,33 @@ QR.Save(QrPayloads.Contact(
     phone: "+48123456789",
     website: "https://evotec.xyz",
     org: "Evotec Services"
-), "contact.png");</pre>
+), "contact.png");
+```
 
-<h2>OTP / 2FA</h2>
-<pre class="code-block">// TOTP (Time-based One-Time Password)
+## OTP / 2FA
+
+```csharp
+// TOTP (Time-based One-Time Password)
 QR.Save(QrPayloads.OneTimePassword(
     OtpAuthType.Totp,
     secretBase32: "JBSWY3DPEHPK3PXP",
     label: "user@example.com",
     issuer: "MyApp"
-), "totp.png");</pre>
+), "totp.png");
+```
 
-<h2>SEPA Girocode</h2>
-<pre class="code-block">QR.Save(QrPayloads.Girocode(
+## SEPA Girocode
+
+```csharp
+QR.Save(QrPayloads.Girocode(
     iban: "DE89370400440532013000",
     bic: "COBADEFFXXX",
     name: "Evotec Services",
     amount: 99.99m,
     remittanceInformation: "Invoice-2024-001"
-), "sepa.png");</pre>
+), "sepa.png");
+```
 
-<p>Additional helpers include PayPal.Me, UPI, BezahlCode variants, Swiss QR Bill, Slovenian UPN, Russia payment order, crypto URIs, and social/app store links. See the API reference for the full list.</p>
-<p>Auto-detect helper: <code>QrPayloads.Detect("...")</code> builds the best-known payload for mixed inputs.</p>
+Additional helpers include PayPal.Me, UPI, BezahlCode variants, Swiss QR Bill, Slovenian UPN, Russia payment order, crypto URIs, and social/app store links. See the API reference for the full list.
+
+Auto-detect helper: `QrPayloads.Detect("...")` builds the best-known payload for mixed inputs.

--- a/Website/content/docs/pdf417.md
+++ b/Website/content/docs/pdf417.md
@@ -4,30 +4,36 @@ description: PDF417 encoding basics and use cases.
 slug: pdf417
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>PDF417</h1>
-<p>PDF417 is a stacked linear barcode capable of encoding large amounts of data, commonly used in ID cards and transport tickets.</p>
+# PDF417
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+PDF417 is a stacked linear barcode capable of encoding large amounts of data, commonly used in ID cards and transport tickets.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Simple PDF417
 Pdf417Code.Save("Document content here", "pdf417.png");
 
 // With error correction level
-Pdf417Code.Save("Document content", "pdf417.png", errorCorrectionLevel: 5);</pre>
+Pdf417Code.Save("Document content", "pdf417.png", errorCorrectionLevel: 5);
+```
 
-<h2>Use Cases</h2>
-<ul style="color: var(--text-muted); margin-left: 1.5rem;">
-<li><strong>Government IDs</strong> - Driver's licenses, ID cards</li>
-<li><strong>Travel documents</strong> - Boarding passes, tickets</li>
-<li><strong>Shipping</strong> - Package labels with detailed info</li>
-<li><strong>Inventory</strong> - Large data capacity for detailed records</li>
-</ul>
+## Use Cases
 
-<h2>Data Capacity</h2>
-<p>PDF417 can encode up to 1,850 alphanumeric characters or 2,710 numeric digits.</p>
+- **Government IDs** - Driver's licenses, ID cards
+
+- **Travel documents** - Boarding passes, tickets
+
+- **Shipping** - Package labels with detailed info
+
+- **Inventory** - Large data capacity for detailed records
+
+## Data Capacity
+
+PDF417 can encode up to 1,850 alphanumeric characters or 2,710 numeric digits.

--- a/Website/content/docs/pdf417.md
+++ b/Website/content/docs/pdf417.md
@@ -27,11 +27,8 @@ Pdf417Code.Save("Document content", "pdf417.png", errorCorrectionLevel: 5);
 ## Use Cases
 
 - **Government IDs** - Driver's licenses, ID cards
-
 - **Travel documents** - Boarding passes, tickets
-
 - **Shipping** - Package labels with detailed info
-
 - **Inventory** - Large data capacity for detailed records
 
 ## Data Capacity

--- a/Website/content/docs/qr.md
+++ b/Website/content/docs/qr.md
@@ -88,22 +88,22 @@ Full source code for these presets lives in
 
 | Style | Recipe | Extras |
 | --- | --- | --- |
-| **Neon Dot** | Shape: Dot   <br>Eyes: Target   <br>Palette: Random (cyan/magenta/yellow)   <br>Canvas: Dark gradient | — |
-| **Candy Checker** | Shape: Rounded   <br>Eyes: Badge   <br>Palette: Checker (pink/yellow)   <br>Canvas: Dots pattern | — |
-| **Pastel Rings** | Shape: Squircle   <br>Eyes: DoubleRing   <br>Palette: Rings (pastels)   <br>Canvas: Checker pattern | Scale map: Radial |
-| **Ocean Grid** | Shape: DotGrid   <br>Eyes: Single   <br>Palette: Cycle (ocean blues)   <br>Canvas: Grid pattern | — |
-| **Mono Badge** | Shape: Square   <br>Eyes: Badge   <br>Palette: None (mono)   <br>Canvas: White with black border | — |
-| **Bracket Tech** | Shape: Diamond   <br>Eyes: Bracket   <br>Palette: Random (teal/blue/white)   <br>Canvas: Dark gradient | Scale map: Rings |
-| **Sunset Sticker** | Shape: Rounded   <br>Eyes: Target   <br>Palette: Cycle (sunset warm)   <br>Canvas: Warm gradient | Logo: Warm circle |
-| **Aurora** | Shape: Circle   <br>Eyes: DoubleRing   <br>Palette: Random (aurora hues)   <br>Canvas: Dots pattern | Scale map: Random |
-| **Mint Board** | Shape: Squircle   <br>Eyes: Single   <br>Palette: Checker (mint)   <br>Canvas: Mint border | — |
-| **Deep Space** | Shape: Dot   <br>Eyes: Target   <br>Palette: Rings (purple/teal)   <br>Canvas: Night gradient | Logo: Cool circle |
-| **Leaf Bloom** | Shape: Leaf   <br>Eyes: DoubleRing   <br>Palette: Cycle (greens)   <br>Canvas: Forest gradient | — |
-| **Wave Pulse** | Shape: Wave   <br>Eyes: Target   <br>Palette: Random (electric blue)   <br>Canvas: Dots pattern | — |
-| **Ink Blob** | Shape: Blob   <br>Eyes: Badge   <br>Palette: Random (grayscale)   <br>Canvas: Light border | — |
-| **Soft Diamond** | Shape: SoftDiamond   <br>Eyes: DoubleRing   <br>Palette: Rings (peach/pink)   <br>Canvas: Warm gradient | — |
-| **Sticker Grid** | Shape: Square   <br>Eyes: Badge   <br>Palette: Cycle (mono)   <br>Canvas: Grid pattern | — |
-| **Center Pop** | Shape: Rounded   <br>Eyes: Single   <br>Palette: Cycle (navy) + Zones   <br>Canvas: Clean border | Logo: Warm circle   <br>Zones: Center + corners |
+| **Neon Dot** | Shape: Dot; Eyes: Target; Palette: Random (cyan/magenta/yellow); Canvas: Dark gradient | — |
+| **Candy Checker** | Shape: Rounded; Eyes: Badge; Palette: Checker (pink/yellow); Canvas: Dots pattern | — |
+| **Pastel Rings** | Shape: Squircle; Eyes: DoubleRing; Palette: Rings (pastels); Canvas: Checker pattern | Scale map: Radial |
+| **Ocean Grid** | Shape: DotGrid; Eyes: Single; Palette: Cycle (ocean blues); Canvas: Grid pattern | — |
+| **Mono Badge** | Shape: Square; Eyes: Badge; Palette: None (mono); Canvas: White with black border | — |
+| **Bracket Tech** | Shape: Diamond; Eyes: Bracket; Palette: Random (teal/blue/white); Canvas: Dark gradient | Scale map: Rings |
+| **Sunset Sticker** | Shape: Rounded; Eyes: Target; Palette: Cycle (sunset warm); Canvas: Warm gradient | Logo: Warm circle |
+| **Aurora** | Shape: Circle; Eyes: DoubleRing; Palette: Random (aurora hues); Canvas: Dots pattern | Scale map: Random |
+| **Mint Board** | Shape: Squircle; Eyes: Single; Palette: Checker (mint); Canvas: Mint border | — |
+| **Deep Space** | Shape: Dot; Eyes: Target; Palette: Rings (purple/teal); Canvas: Night gradient | Logo: Cool circle |
+| **Leaf Bloom** | Shape: Leaf; Eyes: DoubleRing; Palette: Cycle (greens); Canvas: Forest gradient | — |
+| **Wave Pulse** | Shape: Wave; Eyes: Target; Palette: Random (electric blue); Canvas: Dots pattern | — |
+| **Ink Blob** | Shape: Blob; Eyes: Badge; Palette: Random (grayscale); Canvas: Light border | — |
+| **Soft Diamond** | Shape: SoftDiamond; Eyes: DoubleRing; Palette: Rings (peach/pink); Canvas: Warm gradient | — |
+| **Sticker Grid** | Shape: Square; Eyes: Badge; Palette: Cycle (mono); Canvas: Grid pattern | — |
+| **Center Pop** | Shape: Rounded; Eyes: Single; Palette: Cycle (navy) + Zones; Canvas: Clean border | Logo: Warm circle; Zones: Center + corners |
 
 #### Preset Starting Point (Neon Dot)
 

--- a/Website/content/docs/qr.md
+++ b/Website/content/docs/qr.md
@@ -4,58 +4,39 @@ description: QR code generation, styling, and presets.
 slug: qr
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>QR Code Generation</h1>
-<p>CodeGlyphX provides comprehensive QR code support including standard QR and Micro QR formats.</p>
+# QR Code Generation
 
-<h2>Basic Usage</h2>
-<pre class="code-block">using CodeGlyphX;
+CodeGlyphX provides comprehensive QR code support including standard QR and Micro QR formats.
+
+## Basic Usage
+
+```csharp
+using CodeGlyphX;
 
 // Simple one-liner
 QR.Save("https://example.com", "qr.png");
 
 // With error correction level
-QR.Save("https://example.com", "qr.png", QrErrorCorrection.H);</pre>
+QR.Save("https://example.com", "qr.png", QrErrorCorrection.H);
+```
 
-<h2>Error Correction Levels</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Level</th>
-<th style="text-align: left; padding: 0.75rem;">Recovery</th>
-<th style="text-align: left; padding: 0.75rem;">Use Case</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><code>L</code></td>
-<td style="padding: 0.75rem;">~7%</td>
-<td style="padding: 0.75rem;">Maximum data capacity</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><code>M</code></td>
-<td style="padding: 0.75rem;">~15%</td>
-<td style="padding: 0.75rem;">Default, balanced</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><code>Q</code></td>
-<td style="padding: 0.75rem;">~25%</td>
-<td style="padding: 0.75rem;">Higher reliability</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;"><code>H</code></td>
-<td style="padding: 0.75rem;">~30%</td>
-<td style="padding: 0.75rem;">Maximum error correction</td>
-</tr>
-</tbody>
-</table>
+## Error Correction Levels
 
-<h2 id="styling-options">Styling Options</h2>
-<pre class="code-block">using CodeGlyphX;
+| Level | Recovery | Use Case |
+| --- | --- | --- |
+| `L` | ~7% | Maximum data capacity |
+| `M` | ~15% | Default, balanced |
+| `Q` | ~25% | Higher reliability |
+| `H` | ~30% | Maximum error correction |
+
+## Styling Options
+
+```csharp
+using CodeGlyphX;
 
 var options = new QrEasyOptions
 {
@@ -71,10 +52,13 @@ var options = new QrEasyOptions
     }
 };
 
-QR.Save("https://example.com", "styled-qr.png", options);</pre>
+QR.Save("https://example.com", "styled-qr.png", options);
+```
 
-<h3>Fluent Builder (logo + styling)</h3>
-<pre class="code-block">using CodeGlyphX;
+### Fluent Builder (logo + styling)
+
+```csharp
+using CodeGlyphX;
 using CodeGlyphX.Rendering;
 
 var logo = LogoBuilder.CreateCirclePng(
@@ -89,114 +73,42 @@ var png = QR.Create("https://example.com")
     .WithLogoScale(0.22)
     .WithLogoPaddingPx(6)
     .WithStyle(QrRenderStyle.Fancy)
-    .Png();</pre>
+    .Png();
+```
 
-<h3>Style Board Presets (Homepage Gallery)</h3>
-<p>
-                The homepage style board is generated from a curated set of presets. Each QR payload
-                points back to this section and includes a <code>?style=slug</code> hint for tracking or
-                future deep-linking. All presets use error correction <code>H</code>, a 384px target size,
-                and a quiet zone of 4 modules to keep them crisp while remaining web-friendly.
-</p>
-<p>
-                Full source code for these presets lives in
-<a href="https://github.com/EvotecIT/CodeGlyphX/blob/master/CodeGlyphX.Examples/QrStyleBoardExample.cs" target="_blank" rel="noopener">QrStyleBoardExample.cs</a>.
-</p>
+### Style Board Presets (Homepage Gallery)
 
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Style</th>
-<th style="text-align: left; padding: 0.75rem;">Recipe</th>
-<th style="text-align: left; padding: 0.75rem;">Extras</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Neon Dot</strong><br /><span style="color: var(--text-dim);">Slug: <code>neon-dot</code></span></td>
-<td style="padding: 0.75rem;">Shape: Dot<br />Eyes: Target<br />Palette: Random (cyan/magenta/yellow)<br />Canvas: Dark gradient</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Candy Checker</strong><br /><span style="color: var(--text-dim);">Slug: <code>candy-checker</code></span></td>
-<td style="padding: 0.75rem;">Shape: Rounded<br />Eyes: Badge<br />Palette: Checker (pink/yellow)<br />Canvas: Dots pattern</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Pastel Rings</strong><br /><span style="color: var(--text-dim);">Slug: <code>pastel-rings</code></span></td>
-<td style="padding: 0.75rem;">Shape: Squircle<br />Eyes: DoubleRing<br />Palette: Rings (pastels)<br />Canvas: Checker pattern</td>
-<td style="padding: 0.75rem;">Scale map: Radial</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Ocean Grid</strong><br /><span style="color: var(--text-dim);">Slug: <code>ocean-grid</code></span></td>
-<td style="padding: 0.75rem;">Shape: DotGrid<br />Eyes: Single<br />Palette: Cycle (ocean blues)<br />Canvas: Grid pattern</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Mono Badge</strong><br /><span style="color: var(--text-dim);">Slug: <code>mono-badge</code></span></td>
-<td style="padding: 0.75rem;">Shape: Square<br />Eyes: Badge<br />Palette: None (mono)<br />Canvas: White with black border</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Bracket Tech</strong><br /><span style="color: var(--text-dim);">Slug: <code>bracket-tech</code></span></td>
-<td style="padding: 0.75rem;">Shape: Diamond<br />Eyes: Bracket<br />Palette: Random (teal/blue/white)<br />Canvas: Dark gradient</td>
-<td style="padding: 0.75rem;">Scale map: Rings</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Sunset Sticker</strong><br /><span style="color: var(--text-dim);">Slug: <code>sunset-sticker</code></span></td>
-<td style="padding: 0.75rem;">Shape: Rounded<br />Eyes: Target<br />Palette: Cycle (sunset warm)<br />Canvas: Warm gradient</td>
-<td style="padding: 0.75rem;">Logo: Warm circle</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Aurora</strong><br /><span style="color: var(--text-dim);">Slug: <code>aurora</code></span></td>
-<td style="padding: 0.75rem;">Shape: Circle<br />Eyes: DoubleRing<br />Palette: Random (aurora hues)<br />Canvas: Dots pattern</td>
-<td style="padding: 0.75rem;">Scale map: Random</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Mint Board</strong><br /><span style="color: var(--text-dim);">Slug: <code>mint-board</code></span></td>
-<td style="padding: 0.75rem;">Shape: Squircle<br />Eyes: Single<br />Palette: Checker (mint)<br />Canvas: Mint border</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Deep Space</strong><br /><span style="color: var(--text-dim);">Slug: <code>deep-space</code></span></td>
-<td style="padding: 0.75rem;">Shape: Dot<br />Eyes: Target<br />Palette: Rings (purple/teal)<br />Canvas: Night gradient</td>
-<td style="padding: 0.75rem;">Logo: Cool circle</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Leaf Bloom</strong><br /><span style="color: var(--text-dim);">Slug: <code>leaf-bloom</code></span></td>
-<td style="padding: 0.75rem;">Shape: Leaf<br />Eyes: DoubleRing<br />Palette: Cycle (greens)<br />Canvas: Forest gradient</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Wave Pulse</strong><br /><span style="color: var(--text-dim);">Slug: <code>wave-pulse</code></span></td>
-<td style="padding: 0.75rem;">Shape: Wave<br />Eyes: Target<br />Palette: Random (electric blue)<br />Canvas: Dots pattern</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Ink Blob</strong><br /><span style="color: var(--text-dim);">Slug: <code>ink-blob</code></span></td>
-<td style="padding: 0.75rem;">Shape: Blob<br />Eyes: Badge<br />Palette: Random (grayscale)<br />Canvas: Light border</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Soft Diamond</strong><br /><span style="color: var(--text-dim);">Slug: <code>soft-diamond</code></span></td>
-<td style="padding: 0.75rem;">Shape: SoftDiamond<br />Eyes: DoubleRing<br />Palette: Rings (peach/pink)<br />Canvas: Warm gradient</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;"><strong>Sticker Grid</strong><br /><span style="color: var(--text-dim);">Slug: <code>sticker-grid</code></span></td>
-<td style="padding: 0.75rem;">Shape: Square<br />Eyes: Badge<br />Palette: Cycle (mono)<br />Canvas: Grid pattern</td>
-<td style="padding: 0.75rem;">—</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;"><strong>Center Pop</strong><br /><span style="color: var(--text-dim);">Slug: <code>center-pop</code></span></td>
-<td style="padding: 0.75rem;">Shape: Rounded<br />Eyes: Single<br />Palette: Cycle (navy) + Zones<br />Canvas: Clean border</td>
-<td style="padding: 0.75rem;">Logo: Warm circle<br />Zones: Center + corners</td>
-</tr>
-</tbody>
-</table>
+The homepage style board is generated from a curated set of presets. Each QR payload
+points back to this section and includes a `?style=slug` hint for tracking or
+future deep-linking. All presets use error correction `H`, a 384px target size,
+and a quiet zone of 4 modules to keep them crisp while remaining web-friendly.
 
-<h4>Preset Starting Point (Neon Dot)</h4>
-<pre class="code-block">using CodeGlyphX;
+Full source code for these presets lives in
+[QrStyleBoardExample.cs](https://github.com/EvotecIT/CodeGlyphX/blob/master/CodeGlyphX.Examples/QrStyleBoardExample.cs).
+
+| Style | Recipe | Extras |
+| --- | --- | --- |
+| **Neon Dot** | Shape: Dot   <br>Eyes: Target   <br>Palette: Random (cyan/magenta/yellow)   <br>Canvas: Dark gradient | — |
+| **Candy Checker** | Shape: Rounded   <br>Eyes: Badge   <br>Palette: Checker (pink/yellow)   <br>Canvas: Dots pattern | — |
+| **Pastel Rings** | Shape: Squircle   <br>Eyes: DoubleRing   <br>Palette: Rings (pastels)   <br>Canvas: Checker pattern | Scale map: Radial |
+| **Ocean Grid** | Shape: DotGrid   <br>Eyes: Single   <br>Palette: Cycle (ocean blues)   <br>Canvas: Grid pattern | — |
+| **Mono Badge** | Shape: Square   <br>Eyes: Badge   <br>Palette: None (mono)   <br>Canvas: White with black border | — |
+| **Bracket Tech** | Shape: Diamond   <br>Eyes: Bracket   <br>Palette: Random (teal/blue/white)   <br>Canvas: Dark gradient | Scale map: Rings |
+| **Sunset Sticker** | Shape: Rounded   <br>Eyes: Target   <br>Palette: Cycle (sunset warm)   <br>Canvas: Warm gradient | Logo: Warm circle |
+| **Aurora** | Shape: Circle   <br>Eyes: DoubleRing   <br>Palette: Random (aurora hues)   <br>Canvas: Dots pattern | Scale map: Random |
+| **Mint Board** | Shape: Squircle   <br>Eyes: Single   <br>Palette: Checker (mint)   <br>Canvas: Mint border | — |
+| **Deep Space** | Shape: Dot   <br>Eyes: Target   <br>Palette: Rings (purple/teal)   <br>Canvas: Night gradient | Logo: Cool circle |
+| **Leaf Bloom** | Shape: Leaf   <br>Eyes: DoubleRing   <br>Palette: Cycle (greens)   <br>Canvas: Forest gradient | — |
+| **Wave Pulse** | Shape: Wave   <br>Eyes: Target   <br>Palette: Random (electric blue)   <br>Canvas: Dots pattern | — |
+| **Ink Blob** | Shape: Blob   <br>Eyes: Badge   <br>Palette: Random (grayscale)   <br>Canvas: Light border | — |
+| **Soft Diamond** | Shape: SoftDiamond   <br>Eyes: DoubleRing   <br>Palette: Rings (peach/pink)   <br>Canvas: Warm gradient | — |
+| **Sticker Grid** | Shape: Square   <br>Eyes: Badge   <br>Palette: Cycle (mono)   <br>Canvas: Grid pattern | — |
+| **Center Pop** | Shape: Rounded   <br>Eyes: Single   <br>Palette: Cycle (navy) + Zones   <br>Canvas: Clean border | Logo: Warm circle   <br>Zones: Center + corners |
+
+#### Preset Starting Point (Neon Dot)
+
+```csharp
+using CodeGlyphX;
 using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 
@@ -248,4 +160,5 @@ var options = new QrEasyOptions
     }
 };
 
-QR.Save("https://codeglyphx.com/docs/qr?style=neon-dot#styling-options", "neon-dot.png", options);</pre>
+QR.Save("https://codeglyphx.com/docs/qr?style=neon-dot#styling-options", "neon-dot.png", options);
+```

--- a/Website/content/docs/quickstart.md
+++ b/Website/content/docs/quickstart.md
@@ -4,29 +4,37 @@ description: Get started with CodeGlyphX in minutes.
 slug: quickstart
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Quick Start</h1>
-<p>Get up and running with CodeGlyphX in under a minute.</p>
+# Quick Start
 
-<h2>1. Install the Package</h2>
-<pre class="code-block">dotnet add package CodeGlyphX</pre>
+Get up and running with CodeGlyphX in under a minute.
 
-<h2>2. Generate Your First QR Code</h2>
-<pre class="code-block">using CodeGlyphX;
+## 1. Install the Package
+
+```csharp
+dotnet add package CodeGlyphX
+```
+
+## 2. Generate Your First QR Code
+
+```csharp
+using CodeGlyphX;
 
 // Create a QR code and save to file
 QR.Save("Hello, World!", "hello.png");
 
 // The output format is determined by the file extension
 QR.Save("Hello, World!", "hello.svg");  // Vector SVG
-QR.Save("Hello, World!", "hello.pdf");  // PDF document</pre>
+QR.Save("Hello, World!", "hello.pdf");  // PDF document
+```
 
-<h3>Render In-Memory</h3>
-<pre class="code-block">using CodeGlyphX;
+### Render In-Memory
+
+```csharp
+using CodeGlyphX;
 using CodeGlyphX.Rendering;
 
 var svg = Barcode.Render(BarcodeType.Code128, "PRODUCT-12345", OutputFormat.Svg).GetText();
@@ -34,23 +42,30 @@ var png = QrCode.Render("Hello, World!", OutputFormat.Png).Data;
 
 // HTML title + raster PDF/EPS
 var extras = new RenderExtras { HtmlTitle = "My Code", VectorMode = RenderMode.Raster };
-QR.Save("Hello, World!", "hello.html", extras: extras);</pre>
+QR.Save("Hello, World!", "hello.html", extras: extras);
+```
 
-<h2>3. Generate Barcodes</h2>
-<pre class="code-block">using CodeGlyphX;
+## 3. Generate Barcodes
+
+```csharp
+using CodeGlyphX;
 
 // Code 128 barcode
 Barcode.Save(BarcodeType.Code128, "PRODUCT-12345", "barcode.png");
 
 // EAN-13 (retail products)
-Barcode.Save(BarcodeType.EAN, "5901234123457", "ean.png");</pre>
+Barcode.Save(BarcodeType.EAN, "5901234123457", "ean.png");
+```
 
-<h2>4. Decode Images</h2>
-<pre class="code-block">using CodeGlyphX;
+## 4. Decode Images
+
+```csharp
+using CodeGlyphX;
 
 var imageBytes = File.ReadAllBytes("qrcode.png");
 
 if (QrImageDecoder.TryDecodeImage(imageBytes, out var result))
 {
     Console.WriteLine($"Decoded: {result.Text}");
-}</pre>
+}
+```

--- a/Website/content/docs/quickstart.md
+++ b/Website/content/docs/quickstart.md
@@ -14,7 +14,7 @@ Get up and running with CodeGlyphX in under a minute.
 
 ## 1. Install the Package
 
-```csharp
+```bash
 dotnet add package CodeGlyphX
 ```
 

--- a/Website/content/docs/renderers.md
+++ b/Website/content/docs/renderers.md
@@ -4,143 +4,39 @@ description: Supported rendering formats and output types.
 slug: renderers
 collection: docs
 layout: docs
-meta.raw_html: true
 ---
 
 {{< edit-link >}}
 
-<h1>Output Formats</h1>
-<p>CodeGlyphX supports a wide variety of output formats. The format is automatically determined by the file extension.</p>
+# Output Formats
 
-<h2>Format Matrix (Encode + Decode)</h2>
-<table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
-<thead>
-<tr style="border-bottom: 1px solid var(--border);">
-<th style="text-align: left; padding: 0.75rem;">Format</th>
-<th style="text-align: left; padding: 0.75rem;">Extensions</th>
-<th style="text-align: left; padding: 0.75rem;">Encode</th>
-<th style="text-align: left; padding: 0.75rem;">Decode</th>
-<th style="text-align: left; padding: 0.75rem;">Notes</th>
-</tr>
-</thead>
-<tbody style="color: var(--text-muted);">
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">PNG</td>
-<td style="padding: 0.75rem;"><code>.png</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">tRNS, Adam7, 1/2/4/8/16-bit</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">JPEG</td>
-<td style="padding: 0.75rem;"><code>.jpg</code>, <code>.jpeg</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Baseline + progressive, EXIF, CMYK/YCCK</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">WebP</td>
-<td style="padding: 0.75rem;"><code>.webp</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Managed VP8/VP8L; ImageReader returns first animation frame (use WebpReader/ImageReader multi-frame helpers); animation via WebpWriter or Webp renderers RenderAnimation</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">BMP</td>
-<td style="padding: 0.75rem;"><code>.bmp</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">1/4/8/16/24/32-bit, RLE, bitfields</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">GIF</td>
-<td style="padding: 0.75rem;"><code>.gif</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Single-frame encode (indexed, 256 colors max; quantizes + dithers if needed); animation via GifReader/GifWriter.WriteAnimation or GIF renderers RenderAnimation (diff-cropped)</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">TIFF</td>
-<td style="padding: 0.75rem;"><code>.tif</code>, <code>.tiff</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Baseline RGBA encode (multi-page via TiffWriter.WriteRgba32Pages; tiled multi-page via WriteRgba32PagesTiled; planar via WriteRgba32Planar; bilevel 1-bit via WriteBilevel/WriteBilevelFromRgba or RenderBilevel; direct matrix bilevel via RenderBilevelFromModules; direct barcode bilevel via RenderBilevelFromBars; tiled bilevel via WriteBilevelTiled/WriteBilevelTiledFromRgba or RenderBilevelTiled; tiled direct matrix bilevel via RenderBilevelTiledFromModules; tiled direct barcode bilevel via RenderBilevelTiledFromBars; strips via rowsPerStrip; tiles via WriteRgba32Tiled; PackBits/Deflate/LZW via TiffCompression; optional predictor via usePredictor); decode strips/tiles, planar config 1/2, PackBits/LZW/Deflate, 1/8/16-bit</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">PSD</td>
-<td style="padding: 0.75rem;"><code>.psd</code></td>
-<td style="padding: 0.75rem;">No</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Flattened 8-bit grayscale/RGB; raw or RLE image data</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">PPM/PGM/PAM/PBM</td>
-<td style="padding: 0.75rem;"><code>.ppm</code>, <code>.pgm</code>, <code>.pam</code>, <code>.pbm</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Portable pixmaps (8/16-bit maxval)</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">TGA</td>
-<td style="padding: 0.75rem;"><code>.tga</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Uncompressed + RLE, true-color/grayscale/color-mapped</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">ICO</td>
-<td style="padding: 0.75rem;"><code>.ico</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">PNG/BMP payloads (CUR decode supported)</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">XBM/XPM</td>
-<td style="padding: 0.75rem;"><code>.xbm</code>, <code>.xpm</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Text formats</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">SVG / SVGZ</td>
-<td style="padding: 0.75rem;"><code>.svg</code>, <code>.svgz</code>, <code>.svg.gz</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No</td>
-<td style="padding: 0.75rem;">Vector output only</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">PDF / EPS</td>
-<td style="padding: 0.75rem;"><code>.pdf</code>, <code>.eps</code>, <code>.ps</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">Limited</td>
-<td style="padding: 0.75rem;">Vector by default, raster via RenderMode (PDF decode: image-only JPEG/Flate)</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">HTML</td>
-<td style="padding: 0.75rem;"><code>.html</code>, <code>.htm</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No</td>
-<td style="padding: 0.75rem;">Table-based output</td>
-</tr>
-<tr style="border-bottom: 1px solid var(--border);">
-<td style="padding: 0.75rem;">ASCII</td>
-<td style="padding: 0.75rem;"><code>.txt</code></td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No</td>
-<td style="padding: 0.75rem;">Text art</td>
-</tr>
-<tr>
-<td style="padding: 0.75rem;">Raw RGBA</td>
-<td style="padding: 0.75rem;">API only</td>
-<td style="padding: 0.75rem;">Yes</td>
-<td style="padding: 0.75rem;">No</td>
-<td style="padding: 0.75rem;">Use <code>RenderPixels</code></td>
-</tr>
-</tbody>
-</table>
+CodeGlyphX supports a wide variety of output formats. The format is automatically determined by the file extension.
 
-<h2>Programmatic Rendering</h2>
-<pre class="code-block">using CodeGlyphX;
+## Format Matrix (Encode + Decode)
+
+| Format | Extensions | Encode | Decode | Notes |
+| --- | --- | --- | --- | --- |
+| PNG | `.png` | Yes | Yes | tRNS, Adam7, 1/2/4/8/16-bit |
+| JPEG | `.jpg`, `.jpeg` | Yes | Yes | Baseline + progressive, EXIF, CMYK/YCCK |
+| WebP | `.webp` | Yes | Yes | Managed VP8/VP8L; ImageReader returns first animation frame (use WebpReader/ImageReader multi-frame helpers); animation via WebpWriter or Webp renderers RenderAnimation |
+| BMP | `.bmp` | Yes | Yes | 1/4/8/16/24/32-bit, RLE, bitfields |
+| GIF | `.gif` | Yes | Yes | Single-frame encode (indexed, 256 colors max; quantizes + dithers if needed); animation via GifReader/GifWriter.WriteAnimation or GIF renderers RenderAnimation (diff-cropped) |
+| TIFF | `.tif`, `.tiff` | Yes | Yes | Baseline RGBA encode (multi-page via TiffWriter.WriteRgba32Pages; tiled multi-page via WriteRgba32PagesTiled; planar via WriteRgba32Planar; bilevel 1-bit via WriteBilevel/WriteBilevelFromRgba or RenderBilevel; direct matrix bilevel via RenderBilevelFromModules; direct barcode bilevel via RenderBilevelFromBars; tiled bilevel via WriteBilevelTiled/WriteBilevelTiledFromRgba or RenderBilevelTiled; tiled direct matrix bilevel via RenderBilevelTiledFromModules; tiled direct barcode bilevel via RenderBilevelTiledFromBars; strips via rowsPerStrip; tiles via WriteRgba32Tiled; PackBits/Deflate/LZW via TiffCompression; optional predictor via usePredictor); decode strips/tiles, planar config 1/2, PackBits/LZW/Deflate, 1/8/16-bit |
+| PSD | `.psd` | No | Yes | Flattened 8-bit grayscale/RGB; raw or RLE image data |
+| PPM/PGM/PAM/PBM | `.ppm`, `.pgm`, `.pam`, `.pbm` | Yes | Yes | Portable pixmaps (8/16-bit maxval) |
+| TGA | `.tga` | Yes | Yes | Uncompressed + RLE, true-color/grayscale/color-mapped |
+| ICO | `.ico` | Yes | Yes | PNG/BMP payloads (CUR decode supported) |
+| XBM/XPM | `.xbm`, `.xpm` | Yes | Yes | Text formats |
+| SVG / SVGZ | `.svg`, `.svgz`, `.svg.gz` | Yes | No | Vector output only |
+| PDF / EPS | `.pdf`, `.eps`, `.ps` | Yes | Limited | Vector by default, raster via RenderMode (PDF decode: image-only JPEG/Flate) |
+| HTML | `.html`, `.htm` | Yes | No | Table-based output |
+| ASCII | `.txt` | Yes | No | Text art |
+| Raw RGBA | API only | Yes | No | Use `RenderPixels` |
+
+## Programmatic Rendering
+
+```csharp
+using CodeGlyphX;
 
 // Get raw PNG bytes
 byte[] pngBytes = QrEasy.RenderPng("Hello", QrErrorCorrection.M, moduleSize: 10);
@@ -149,4 +45,5 @@ byte[] pngBytes = QrEasy.RenderPng("Hello", QrErrorCorrection.M, moduleSize: 10)
 string svg = QrEasy.RenderSvg("Hello", QrErrorCorrection.M);
 
 // Get Base64 data URI
-string dataUri = QrEasy.RenderPngBase64DataUri("Hello");</pre>
+string dataUri = QrEasy.RenderPngBase64DataUri("Hello");
+```


### PR DESCRIPTION
## Summary\n- convert docs content pages from inline HTML to Markdown-native headings, lists, tables, and code fences\n- remove meta.raw_html: true usage from migrated docs pages\n- keep existing shortcode usage and docs structure intact\n\n## Validation\n- Website/build.ps1\n  - build + verify + optimize + audit all passed\n