### PR TITLE
Use doctor stage for final website validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/PSPublishModule
-          ref: v2-speedgonzales
+          ref: main
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/PSPublishModule
-          ref: v2-speedgonzales
+          ref: main
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli

--- a/WEBSITE.md
+++ b/WEBSITE.md
@@ -38,7 +38,7 @@ pwsh Website/build.ps1
 3) Publish Blazor playground into `/playground`
 4) Generate API reference into `/api` (docs template + JSON)
 5) Generate `llms.txt` and `sitemap.xml`
-6) Optimize + audit
+6) Optimize + doctor (final validation; skips duplicate build/verify)
 
 ## API Reference
 The API reference is generated under `/api`. `/docs/api` is a redirect for legacy links.

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -154,7 +154,7 @@
       "renderedInclude": "index.html,docs/**,benchmarks/**,faq/**,pricing/**,showcase/**,playground/**",
       "renderedExclude": "api/**,docs/api/**,api-docs/**",
       "summary": true,
-      "summaryPath": "./_reports/audit-summary.json",
+      "summaryPath": "./_reports/doctor-summary.json",
       "summaryMaxIssues": 50,
       "checkUtf8": true,
       "checkMetaCharset": true,

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -134,6 +134,7 @@
       "task": "doctor",
       "id": "doctor-site",
       "dependsOn": "optimize-site",
+      "config": "./site.json",
       "siteRoot": "./_site",
       "noBuild": true,
       "noVerify": true,

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -131,10 +131,12 @@
       "reportPath": "./_reports/optimize-report.json"
     },
     {
-      "task": "audit",
-      "id": "audit-site",
+      "task": "doctor",
+      "id": "doctor-site",
       "dependsOn": "optimize-site",
       "siteRoot": "./_site",
+      "noBuild": true,
+      "noVerify": true,
       "exclude": "**/*.scripts.html,**/*.head.html,**/api-fragments/**,api-fragments/**",
       "ignoreNav": "sitemap/**,playground/index.html,playground/404.html",
       "noDefaultIgnoreNav": true,


### PR DESCRIPTION
## Summary
- switch final website validation step from `audit` to `doctor`
- keep existing nav/link/asset/rendered gating settings
- avoid duplicate work by setting `noBuild: true` and `noVerify: true`
- rename report artifact to `./_reports/doctor-summary.json`
- update `WEBSITE.md` pipeline docs to reference the new doctor stage

## Why
This uses the unified `doctor` stage while preserving existing gating strictness and improving pipeline clarity.