### PR TITLE
fix(website pipeline): prevent playground overlay from being overwritten

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -53,24 +53,6 @@
       "defineConstants": "TRACE;PLAYGROUND_BUILD"
     },
     {
-      "task": "overlay",
-      "id": "overlay-playground",
-      "dependsOn": "publish-playground",
-      "source": "./_temp/playground/wwwroot",
-      "destination": "./_site/playground",
-      "clean": true,
-      "include": "**/*, *"
-    },
-    {
-      "task": "overlay",
-      "id": "overlay-playground-api",
-      "dependsOn": "overlay-playground",
-      "source": "./static/api",
-      "destination": "./_site/playground/api",
-      "clean": true,
-      "include": "**/*, *"
-    },
-    {
       "task": "apidocs",
       "id": "build-apidocs",
       "dependsOn": "build-library",
@@ -123,9 +105,27 @@
       "clean": false
     },
     {
+      "task": "overlay",
+      "id": "overlay-playground",
+      "dependsOn": "publish-playground",
+      "source": "./_temp/playground/wwwroot",
+      "destination": "./_site/playground",
+      "clean": true,
+      "include": "**/*, *"
+    },
+    {
+      "task": "overlay",
+      "id": "overlay-playground-api",
+      "dependsOn": "overlay-playground",
+      "source": "./static/api",
+      "destination": "./_site/playground/api",
+      "clean": true,
+      "include": "**/*, *"
+    },
+    {
       "task": "verify",
       "id": "verify-ci-final",
-      "dependsOn": "build-site-xref-refresh",
+      "dependsOn": "overlay-playground-api",
       "modes": ["ci"],
       "config": "./site.json",
       "baseline": "./.powerforge/verify-baseline.json",


### PR DESCRIPTION
Summary:
- move playground overlay steps to run after xref refresh build
- make final CI verify depend on final playground overlay output
- keep dotnet-publish before apidocs to avoid assembly lock conflicts

Why:
A late site rebuild was overwriting /playground with placeholder content after Blazor publish/overlay.

Validation:
- targeted pipeline run via PowerForge.Web.Cli with build, dotnet-build, dotnet-publish, apidocs, xref-merge, overlay steps
- confirmed _site/playground/index.html contains Blazor boot script and no placeholder page