### PR TITLE
harden(website): make API CSS contracts explicit (app.css + api.css)

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -63,7 +63,7 @@
       "title": "CodeGlyphX API Reference",
       "baseUrl": "/api",
       "format": "both",
-      "css": "/css/api.css",
+      "css": "/css/app.css,/css/api.css",
       "template": "docs",
       "injectCriticalCss": true,
       "nav": "./site.json",

--- a/Website/site.json
+++ b/Website/site.json
@@ -61,7 +61,7 @@
     "CssStrategy": "blocking",
     "Bundles": [
       { "Name": "global", "Css": ["/css/app.css"], "Js": ["/js/site.js"] },
-      { "Name": "docs", "Css": ["/css/api.css"], "Js": ["/js/site.js"] }
+      { "Name": "docs", "Css": ["/css/app.css", "/css/api.css"], "Js": ["/js/site.js"] }
     ],
     "RouteBundles": [
       { "Match": "/api/**", "Bundles": ["docs"] },

--- a/Website/themes/codeglyphx/theme.manifest.json
+++ b/Website/themes/codeglyphx/theme.manifest.json
@@ -18,7 +18,7 @@
   "featureContracts": {
     "apiDocs": {
       "requiredPartials": ["api-header", "api-footer"],
-      "cssHrefs": ["/css/api.css"],
+      "cssHrefs": ["/css/app.css", "/css/api.css"],
       "requiredCssSelectors": [
         ".api-layout",
         ".api-sidebar",


### PR DESCRIPTION
Use explicit multi-CSS wiring for API docs instead of implicit import behavior. Updated pipeline apidocs css, site docs bundle css, and theme apiDocs cssHrefs to include both app.css and api.css. Validated with targeted pipeline run and generated API index/type pages containing both stylesheet links.