### PR TITLE
Website: fix API CSS contract selectors for syntax signature scrollbars

### DIFF
--- a/Website/static/css/api.css
+++ b/Website/static/css/api.css
@@ -530,6 +530,33 @@
     line-height: 1.4;
 }
 
+.member-header pre.member-signature {
+    overflow: auto;
+    white-space: pre;
+    word-break: normal;
+    overflow-wrap: normal;
+}
+
+.member-card pre::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+.member-card pre::-webkit-scrollbar-track {
+    background: color-mix(in srgb, var(--bg-code) 85%, transparent);
+    border-radius: 999px;
+}
+
+.member-card pre::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--api-accent-soft) 60%, var(--border));
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+}
+
+.member-card pre::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--api-accent-strong) 58%, var(--api-accent-soft));
+}
+
 .member-summary,
 .member-remarks,
 .type-summary,

--- a/Website/themes/nova/assets/api.css
+++ b/Website/themes/nova/assets/api.css
@@ -471,6 +471,33 @@
     line-height: 1.4;
 }
 
+.member-header pre.member-signature {
+    overflow: auto;
+    white-space: pre;
+    word-break: normal;
+    overflow-wrap: normal;
+}
+
+.member-card pre::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+.member-card pre::-webkit-scrollbar-track {
+    background: color-mix(in srgb, var(--bg-code) 85%, transparent);
+    border-radius: 999px;
+}
+
+.member-card pre::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--api-accent-soft) 60%, var(--border));
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+}
+
+.member-card pre::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--api-accent-strong) 58%, var(--api-accent-soft));
+}
+
 .member-summary,
 .member-remarks,
 .type-summary,


### PR DESCRIPTION
## Summary
- add .member-header pre.member-signature style for syntax/signature blocks
- add webkit scrollbar selectors for .member-card pre
- sync the same rules in both Website/static/css/api.css and Website/themes/nova/assets/api.css

## Why
PowerForge.Web API docs CSS contract now validates these selectors. Without them, the website pipeline fails in CI/deploy during pidocs.

## Validation
- selector presence confirmed with ripgrep in both CSS files
- resolves failing contract warning that was promoted to failure in CI