### PR TITLE
ci(website): purge + verify Cloudflare cache after deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -103,33 +103,10 @@ jobs:
             --base-url "https://codeglyphx.com" \
             --path "/,/docs/,/api/,/blog/,/showcase/,/pricing/,/benchmarks/,/faq/,/search/,/sitemap/,/playground/,/404.html,/sitemap.xml,/llms.txt,/llms-full.txt,/llms.json"
 
-  verify-cache:
-    # Prefer private/self-hosted runners for private repos to reduce hosted spend.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
-    needs: purge-cloudflare
-    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID_CODEGLYPHX != '' }}
-    steps:
-      - name: Verify Cloudflare caching on key pages
+      - name: Verify Cloudflare cache status (key routes)
         run: |
-          set -euo pipefail
-          urls=(
-            "https://codeglyphx.com/"
-            "https://codeglyphx.com/docs/"
-            "https://codeglyphx.com/api/"
-            "https://codeglyphx.com/showcase/"
-            "https://codeglyphx.com/search/"
-            "https://codeglyphx.com/sitemap/"
-            "https://codeglyphx.com/playground/"
-          )
-          for url in "${urls[@]}"; do
-            curl -s -o /dev/null "$url"
-            status=$(curl -s -D - "$url" -o /dev/null | awk 'BEGIN{IGNORECASE=1}/^cf-cache-status:/{print toupper($2)}' | tr -d '\r')
-            echo "$url -> cf-cache-status=$status"
-            case "$status" in
-              HIT|REVALIDATED|EXPIRED|STALE) ;;
-              *)
-                echo "Unexpected cache status for $url: $status"
-                exit 1
-                ;;
-            esac
-          done
+          dotnet PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll \
+            cloudflare verify \
+            --base-url "https://codeglyphx.com" \
+            --path "/,/docs/,/api/,/showcase/,/search/,/sitemap/,/playground/" \
+            --warmup 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -68,3 +68,68 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  purge-cloudflare:
+    # Prefer private/self-hosted runners for private repos to reduce hosted spend.
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
+    needs: deploy
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID_CODEGLYPHX != '' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Checkout PSPublishModule
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/PSPublishModule
+          ref: main
+          path: PSPublishModule
+
+      - name: Build PowerForge.Web.Cli
+        run: dotnet build PSPublishModule/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Release
+
+      - name: Purge Cloudflare cache (key routes)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          dotnet PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll \
+            cloudflare purge \
+            --zone-id "${{ secrets.CLOUDFLARE_ZONE_ID_CODEGLYPHX }}" \
+            --token-env CLOUDFLARE_API_TOKEN \
+            --base-url "https://codeglyphx.com" \
+            --path "/,/docs/,/api/,/blog/,/showcase/,/pricing/,/benchmarks/,/faq/,/search/,/sitemap/,/playground/,/404.html,/sitemap.xml,/llms.txt,/llms-full.txt,/llms.json"
+
+  verify-cache:
+    # Prefer private/self-hosted runners for private repos to reduce hosted spend.
+    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
+    needs: purge-cloudflare
+    if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID_CODEGLYPHX != '' }}
+    steps:
+      - name: Verify Cloudflare caching on key pages
+        run: |
+          set -euo pipefail
+          urls=(
+            "https://codeglyphx.com/"
+            "https://codeglyphx.com/docs/"
+            "https://codeglyphx.com/api/"
+            "https://codeglyphx.com/showcase/"
+            "https://codeglyphx.com/search/"
+            "https://codeglyphx.com/sitemap/"
+            "https://codeglyphx.com/playground/"
+          )
+          for url in "${urls[@]}"; do
+            curl -s -o /dev/null "$url"
+            status=$(curl -s -D - "$url" -o /dev/null | awk 'BEGIN{IGNORECASE=1}/^cf-cache-status:/{print toupper($2)}' | tr -d '\r')
+            echo "$url -> cf-cache-status=$status"
+            case "$status" in
+              HIT|REVALIDATED|EXPIRED|STALE) ;;
+              *)
+                echo "Unexpected cache status for $url: $status"
+                exit 1
+                ;;
+            esac
+          done


### PR DESCRIPTION
## Summary
- add post-deploy Cloudflare purge job using org secrets
- use native powerforge-web cloudflare verify command (no inline bash loop)
- verifies key routes after purge to catch cache rule regressions

## Required secrets
- CLOUDFLARE_API_TOKEN
- CLOUDFLARE_ZONE_ID_CODEGLYPHX

## Dependency
Requires PSPublishModule PR #139 to be merged first (adds cloudflare verify command).