### PR TITLE
chore(ci): centralize PowerForge ref pin in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '77253ad381bcc5f70db62f10ef513913f7c37b49' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'ab58992450def6b736a2ea87e6a492400250959f' }}
 
 jobs:
   build-test:
@@ -178,3 +178,4 @@ jobs:
           files: ./CodeGlyphX.Tests/TestResults/**/coverage.cobertura.xml
           fail_ci_if_error: false
           verbose: true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
+  POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '77253ad381bcc5f70db62f10ef513913f7c37b49' }}
+
 jobs:
   build-test:
     name: Build & Test (${{ matrix.os }})
@@ -124,8 +129,8 @@ jobs:
       - name: Checkout PSPublishModule
         uses: actions/checkout@v4
         with:
-          repository: EvotecIT/PSPublishModule
-          ref: main
+          repository: ${{ env.POWERFORGE_REPOSITORY }}
+          ref: ${{ env.POWERFORGE_REF }}
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '77253ad381bcc5f70db62f10ef513913f7c37b49' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'ab58992450def6b736a2ea87e6a492400250959f' }}
 
 jobs:
   build:
@@ -129,3 +129,4 @@ jobs:
             cloudflare verify \
             --site-config "Website/site.json" \
             --warmup 1
+

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,11 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
+  POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '77253ad381bcc5f70db62f10ef513913f7c37b49' }}
+
 jobs:
   build:
     # Prefer private/self-hosted runners for private repos to reduce hosted spend.
@@ -27,8 +32,8 @@ jobs:
       - name: Checkout PSPublishModule
         uses: actions/checkout@v4
         with:
-          repository: EvotecIT/PSPublishModule
-          ref: main
+          repository: ${{ env.POWERFORGE_REPOSITORY }}
+          ref: ${{ env.POWERFORGE_REF }}
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli
@@ -98,8 +103,8 @@ jobs:
         if: steps.cloudflare.outputs.enabled == 'true'
         uses: actions/checkout@v4
         with:
-          repository: EvotecIT/PSPublishModule
-          ref: main
+          repository: ${{ env.POWERFORGE_REPOSITORY }}
+          ref: ${{ env.POWERFORGE_REF }}
           path: PSPublishModule
 
       - name: Build PowerForge.Web.Cli


### PR DESCRIPTION
## Summary
- centralize PowerForge engine checkout settings in workflow-level env vars
- use POWERFORGE_REPOSITORY and POWERFORGE_REF across website build/deploy jobs
- default POWERFORGE_REF to commit b58992450def6b736a2ea87e6a492400250959f (stable baseline)

## Why
This avoids unrelated PR breakage when PSPublishModule/main changes defaults. We can now roll engine upgrades forward in a controlled way by setting repo/org variable POWERFORGE_REF.

## How to roll forward
- Set repository (or organization) Actions variable: POWERFORGE_REF
- Value can be a branch, tag, or commit SHA
- Remove/reset variable to fall back to the pinned default in this workflow