### PR TITLE
Website: add optional IndexNow step + pin PowerForge SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'ab58992450def6b736a2ea87e6a492400250959f' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'a9b7144f30da9edd6e06e644c3fc05535baec26a' }}
 
 jobs:
   build-test:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'ab58992450def6b736a2ea87e6a492400250959f' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'a9b7144f30da9edd6e06e644c3fc05535baec26a' }}
 
 jobs:
   build:
@@ -41,6 +41,8 @@ jobs:
 
       - name: Build website (static + playground)
         working-directory: Website
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
         run: dotnet ../PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll pipeline --config pipeline.json --mode ci
 
       - name: Verify website output

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -166,9 +166,23 @@
       "htmlTitle": "CodeGlyphX Sitemap"
     },
     {
+      "task": "indexnow",
+      "id": "submit-indexnow",
+      "dependsOn": "build-sitemap",
+      "modes": ["ci"],
+      "baseUrl": "https://codeglyphx.com",
+      "siteRoot": "./_site",
+      "scopeFromBuildUpdated": true,
+      "keyEnv": "INDEXNOW_KEY",
+      "optionalKey": true,
+      "continueOnError": true,
+      "reportPath": "./_reports/indexnow.json",
+      "summaryPath": "./_reports/indexnow.md"
+    },
+    {
       "task": "optimize",
       "id": "optimize-site",
-      "dependsOn": "build-sitemap",
+      "dependsOn": "submit-indexnow",
       "skipModes": ["dev"],
       "siteRoot": "./_site",
       "config": "./site.json",


### PR DESCRIPTION
## Summary\n- add CI-only indexnow pipeline step after sitemap (optionalKey: true, continueOnError: true)\n- chain optimize after IndexNow\n- bump workflow fallback pin to merged PSPublishModule SHA (9b7144f30da9edd6e06e644c3fc05535baec26a)\n- pass INDEXNOW_KEY to deploy pipeline build step when secret is available\n\n## Why\n- keeps sitemap/index submission automatic and safe\n- keeps deploys deterministic while allowing controlled rollouts via POWERFORGE_REF variable