### PR TITLE
Workflow: checkout repo before Cloudflare purge/verify

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -101,6 +101,10 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Checkout
+        if: steps.cloudflare.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
       - name: Checkout PSPublishModule
         if: steps.cloudflare.outputs.enabled == 'true'
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary\n- add ctions/checkout step in purge-cloudflare job before purge/verify commands\n\n## Why\n- purge job runs in a fresh workspace and currently only checks out PSPublishModule\n- without repo checkout, Website/site.json is missing and purge step fails