### PR TITLE
Website: omit legacy API doc alias pages

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -63,6 +63,7 @@
       "title": "CodeGlyphX API Reference",
       "baseUrl": "/api",
       "format": "both",
+      "legacyAliasMode": "omit",
       "css": "/css/app.css,/css/api.css",
       "template": "docs",
       "injectCriticalCss": true,


### PR DESCRIPTION
## Summary\n- set legacyAliasMode to omit for all API docs generation steps\n- prevents publishing duplicate .html alias pages that can inflate crawl/discovered URLs\n\n## Why\n- aligns site pipeline with new PowerForge API docs alias control\n- reduces index noise and focuses crawlers on canonical routes