### PR TITLE
ci(website): roll forward default PowerForge pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'a9b7144f30da9edd6e06e644c3fc05535baec26a' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '83bb21dba0f8a102851c08cb7ed615d1cf061aa1' }}
 
 jobs:
   build-test:
@@ -178,4 +178,5 @@ jobs:
           files: ./CodeGlyphX.Tests/TestResults/**/coverage.cobertura.xml
           fail_ci_if_error: false
           verbose: true
+
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ concurrency:
 env:
   # Optional repo/org variable: POWERFORGE_REF (branch/tag/SHA) for controlled engine rollouts.
   POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || 'a9b7144f30da9edd6e06e644c3fc05535baec26a' }}
+  POWERFORGE_REF: ${{ vars.POWERFORGE_REF != '' && vars.POWERFORGE_REF || '83bb21dba0f8a102851c08cb7ed615d1cf061aa1' }}
 
 jobs:
   build:
@@ -135,4 +135,5 @@ jobs:
             cloudflare verify \
             --site-config "Website/site.json" \
             --warmup 1
+
 


### PR DESCRIPTION
## Summary
- update website workflow fallback POWERFORGE_REF to \\83bb21dba0f8a102851c08cb7ed615d1cf061aa1\\ in CI/pages workflows

## Why
Prevents fallback to outdated PSPublishModule pin when repo variable is missing/reset, reducing website-build advisory churn.