### PR TITLE
Linkify plain URLs in release note cards

### DIFF
--- a/Website/content/pages/changelog.md
+++ b/Website/content/pages/changelog.md
@@ -29,11 +29,5 @@ canonical: https://codeglyphx.com/changelog/
 {{< release-button placement="changelog.primary" product="codeglyphx" >}}
   </div>
 
-  <section class="pf-release-downloads-panel cgx-release-panel">
-    <h2>Download Matrix</h2>
-    <p>All stable downloadable assets grouped by release.</p>
-{{< release-buttons placement="changelog.downloads_matrix" >}}
-  </section>
-
 {{< release-changelog placement="changelog.timeline" >}}
 </section>

--- a/Website/content/pages/changelog.md
+++ b/Website/content/pages/changelog.md
@@ -11,17 +11,25 @@ meta.structured_data: true
 canonical: https://codeglyphx.com/changelog/
 ---
 
-<section class="faq-page">
+<section class="faq-page cgx-release-page">
   <div class="faq-hero">
     <h1>Changelog</h1>
     <p>Releases and assets pulled from GitHub so this page stays current automatically.</p>
+  </div>
+
+  <p class="cgx-release-intro">Use this page for release notes and migration context. For direct binaries, go to <a href="/downloads/">Downloads</a>.</p>
+
+  <div class="cgx-release-quicklinks" aria-label="Release resources">
+    <a href="/downloads/">Downloads</a>
+    <a href="/docs/">Documentation</a>
+    <a href="/docs/quickstart/">Quick Start</a>
   </div>
 
   <div class="cgx-release-cta">
 {{< release-button placement="changelog.primary" product="codeglyphx" >}}
   </div>
 
-  <section class="pf-release-downloads-panel">
+  <section class="pf-release-downloads-panel cgx-release-panel">
     <h2>Download Matrix</h2>
     <p>All stable downloadable assets grouped by release.</p>
 {{< release-buttons placement="changelog.downloads_matrix" >}}

--- a/Website/content/pages/downloads.md
+++ b/Website/content/pages/downloads.md
@@ -40,6 +40,4 @@ canonical: https://codeglyphx.com/downloads/
     <p>Alternative view grouped by package type.</p>
 {{< release-buttons placement="downloads.stable_by_kind" >}}
   </section>
-
-{{< release-changelog placement="downloads.timeline" >}}
 </section>

--- a/Website/content/pages/downloads.md
+++ b/Website/content/pages/downloads.md
@@ -11,25 +11,31 @@ meta.structured_data: true
 canonical: https://codeglyphx.com/downloads/
 ---
 
-<section class="faq-page">
+<section class="faq-page cgx-release-page">
   <div class="faq-hero">
     <h1>Downloads</h1>
     <p>Get current and historical CodeGlyphX assets directly from release metadata.</p>
   </div>
 
-  <p>All assets and release notes are sourced from <a href="https://github.com/EvotecIT/CodeGlyphX/releases">GitHub Releases</a>.</p>
+  <p class="cgx-release-intro">All assets and release notes are sourced from <a href="https://github.com/EvotecIT/CodeGlyphX/releases">GitHub Releases</a>.</p>
+
+  <div class="cgx-release-quicklinks" aria-label="Release resources">
+    <a href="/docs/installation/">Install Guide</a>
+    <a href="/docs/">Documentation</a>
+    <a href="/changelog/">Changelog</a>
+  </div>
 
   <div class="cgx-release-cta">
 {{< release-button placement="downloads.primary" >}}
   </div>
 
-  <section class="pf-release-downloads-panel">
+  <section class="pf-release-downloads-panel cgx-release-panel">
     <h2>Stable Downloads By Release</h2>
     <p>Browse stable assets grouped by release tag.</p>
 {{< release-buttons placement="downloads.stable_by_release" >}}
   </section>
 
-  <section class="pf-release-downloads-panel">
+  <section class="pf-release-downloads-panel cgx-release-panel">
     <h2>Stable Downloads By Package Type</h2>
     <p>Alternative view grouped by package type.</p>
 {{< release-buttons placement="downloads.stable_by_kind" >}}

--- a/Website/site.json
+++ b/Website/site.json
@@ -127,8 +127,6 @@
           { "Title": "Docs", "Url": "/docs/" },
           { "Title": "Benchmarks", "Url": "/benchmarks/" },
           { "Title": "Showcase", "Url": "/showcase/" },
-          { "Title": "Downloads", "Url": "/downloads/" },
-          { "Title": "Changelog", "Url": "/changelog/" },
           { "Title": "Pricing", "Url": "/pricing/" }
         ]
       },

--- a/Website/static/css/app.css
+++ b/Website/static/css/app.css
@@ -4293,6 +4293,40 @@ section {
     margin: 1rem 0 1.5rem;
 }
 
+.cgx-release-page {
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.cgx-release-intro {
+    margin: 0.25rem 0 0.9rem;
+    color: var(--text-dim);
+}
+
+.cgx-release-quicklinks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin: 0 0 1.1rem;
+}
+
+.cgx-release-quicklinks a {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--border);
+    background: rgba(59, 130, 246, 0.08);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.32rem 0.8rem;
+    font-size: 0.8rem;
+    text-decoration: none;
+}
+
+.cgx-release-quicklinks a:hover {
+    border-color: var(--primary);
+    color: var(--primary-light);
+}
+
 .pf-release-button {
     display: inline-flex;
     align-items: center;
@@ -4319,6 +4353,7 @@ section {
 }
 
 .pf-release-button--item {
+    display: flex;
     width: 100%;
     justify-content: space-between;
     align-items: flex-start;
@@ -4416,7 +4451,7 @@ section {
 
 .pf-release-buttons-list {
     display: grid;
-    gap: 0.55rem;
+    gap: 0.65rem;
 }
 
 .pf-release-group {
@@ -4440,6 +4475,10 @@ section {
     border: 1px solid var(--border);
     border-radius: var(--radius);
     background: linear-gradient(135deg, rgba(139, 92, 246, 0.12), rgba(6, 182, 212, 0.06));
+}
+
+.cgx-release-panel {
+    box-shadow: 0 18px 38px rgba(4, 12, 28, 0.28);
 }
 
 .pf-release-downloads-panel h2 {
@@ -4472,6 +4511,7 @@ section {
     border-radius: var(--radius);
     padding: 1rem 1.1rem;
     background: linear-gradient(135deg, rgba(139, 92, 246, 0.12), rgba(6, 182, 212, 0.08));
+    box-shadow: 0 16px 34px rgba(4, 12, 28, 0.22);
 }
 
 .pf-release-entry-header h3 {
@@ -4528,6 +4568,31 @@ section {
 
 .pf-release-body {
     margin-bottom: 0.75rem;
+    color: var(--text);
+    line-height: 1.62;
+}
+
+.pf-release-body p {
+    margin: 0.45rem 0;
+}
+
+.pf-release-body ul,
+.pf-release-body ol {
+    margin: 0.55rem 0 0.7rem 1.1rem;
+    padding: 0;
+}
+
+.pf-release-body li {
+    margin: 0 0 0.32rem;
+}
+
+.pf-release-body a {
+    color: var(--primary-light);
+    overflow-wrap: anywhere;
+}
+
+.pf-release-body a:hover {
+    color: var(--primary);
 }
 
 .pf-release-body > :first-child {

--- a/Website/static/js/site.js
+++ b/Website/static/js/site.js
@@ -600,6 +600,90 @@ globalThis.setTheme = setTheme;
         });
     }
 
+    function linkifyReleaseBodyUrls() {
+        const containers = Array.from(document.querySelectorAll('.pf-release-body'))
+            .filter((container) => container.dataset.linkified !== 'true');
+
+        containers.forEach((container) => {
+            const walker = document.createTreeWalker(
+                container,
+                NodeFilter.SHOW_TEXT,
+                {
+                    acceptNode(node) {
+                        if (!node?.nodeValue || !/https?:\/\//i.test(node.nodeValue)) {
+                            return NodeFilter.FILTER_REJECT;
+                        }
+                        const parent = node.parentElement;
+                        if (!parent) {
+                            return NodeFilter.FILTER_ACCEPT;
+                        }
+                        const tag = parent.tagName;
+                        if (tag === 'A' || tag === 'CODE' || tag === 'PRE' || tag === 'SCRIPT' || tag === 'STYLE') {
+                            return NodeFilter.FILTER_REJECT;
+                        }
+                        return NodeFilter.FILTER_ACCEPT;
+                    }
+                }
+            );
+
+            const textNodes = [];
+            let current = walker.nextNode();
+            while (current) {
+                textNodes.push(current);
+                current = walker.nextNode();
+            }
+
+            textNodes.forEach((node) => {
+                const source = node.nodeValue || '';
+                const urlPattern = /https?:\/\/[^\s<>()]+/gi;
+                let lastIndex = 0;
+                let match = urlPattern.exec(source);
+                if (!match) return;
+
+                const fragment = document.createDocumentFragment();
+                while (match) {
+                    const raw = match[0];
+                    let url = raw;
+                    let suffix = '';
+                    while (/[.,;:!?)]$/.test(url)) {
+                        suffix = url.slice(-1) + suffix;
+                        url = url.slice(0, -1);
+                    }
+
+                    if (match.index > lastIndex) {
+                        fragment.appendChild(document.createTextNode(source.slice(lastIndex, match.index)));
+                    }
+
+                    if (url) {
+                        const anchor = document.createElement('a');
+                        anchor.href = url;
+                        anchor.textContent = url;
+                        anchor.target = '_blank';
+                        anchor.rel = 'noopener';
+                        fragment.appendChild(anchor);
+                    } else {
+                        fragment.appendChild(document.createTextNode(raw));
+                    }
+
+                    if (suffix) {
+                        fragment.appendChild(document.createTextNode(suffix));
+                    }
+
+                    lastIndex = match.index + raw.length;
+                    match = urlPattern.exec(source);
+                }
+
+                if (lastIndex < source.length) {
+                    fragment.appendChild(document.createTextNode(source.slice(lastIndex)));
+                }
+
+                node.parentNode?.replaceChild(fragment, node);
+            });
+
+            container.dataset.linkified = 'true';
+        });
+    }
+
     document.addEventListener('click', (event) => {
         const target = event.target;
         if (!(target instanceof Element)) return;
@@ -620,6 +704,7 @@ globalThis.setTheme = setTheme;
             initDocsNav();
             initShowcaseCarousel();
             renderBenchmarkSummary();
+            linkifyReleaseBodyUrls();
         }, 100);
     }
 

--- a/Website/themes/codeglyphx/partials/docs-sidebar.html
+++ b/Website/themes/codeglyphx/partials/docs-sidebar.html
@@ -35,6 +35,8 @@
     <div class="docs-nav-section">
         <div class="docs-nav-title">Reference</div>
         <a href="/api/">API Reference →</a>
+        <a href="/downloads/">Downloads →</a>
+        <a href="/changelog/">Changelog →</a>
         <a href="/faq/">FAQ →</a>
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- add client-side URL linkification for release notes rendered inside `.pf-release-body`
- convert plain `http(s)` text in changelog bullets into clickable anchors
- skip existing links/code/pre/script/style nodes to avoid double-linking

## Validation
- `node --check Website/static/js/site.js`
- local full pipeline build depends on live GitHub release-hub step/token; this PR changes only static JS behavior