### PR TITLE
Redesign footer navigation to scale for long menus

### DIFF
--- a/Website/static/css/app.css
+++ b/Website/static/css/app.css
@@ -1964,11 +1964,20 @@ code.signature:focus-within .copy-btn {
 
 .footer-links {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
     padding: 2rem 0;
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
+}
+
+.footer-section {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0.9rem 1rem 1rem;
+    background:
+        linear-gradient(165deg, rgba(124, 58, 237, 0.08), rgba(124, 58, 237, 0) 52%),
+        rgba(255, 255, 255, 0.01);
 }
 
 .footer-section h3 {
@@ -1977,34 +1986,58 @@ code.signature:focus-within .copy-btn {
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--text);
-    margin-bottom: 1rem;
+    margin-bottom: 0.85rem;
 }
 
-.footer-section a {
+.footer-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.35rem 1rem;
+}
+
+.footer-list.is-dense {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.footer-list.is-mega {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.footer-list.is-scroll {
+    max-height: 12rem;
+    overflow: auto;
+    padding-right: 0.3rem;
+    scrollbar-width: thin;
+}
+
+.footer-list a {
     display: flex;
     align-items: center;
     gap: 0.35rem;
     color: var(--text-muted);
-    font-size: 0.9rem;
-    padding: 0.375rem 0;
+    font-size: 0.85rem;
+    padding: 0.28rem 0;
     transition: color 0.2s;
     text-decoration: none;
 }
 
-.footer-section a::after {
+.footer-list a[target="_blank"]::after {
     content: "↗";
     font-size: 0.75em;
     opacity: 0.6;
 }
 
-.footer-section a:hover {
+.footer-list a:hover {
     color: var(--primary-light);
     text-decoration: underline;
     text-decoration-color: currentColor;
     text-underline-offset: 3px;
 }
 
-.footer-section a:focus-visible {
+.footer-list a:focus-visible {
     color: var(--primary-light);
     text-decoration: underline;
     text-decoration-color: currentColor;
@@ -2069,6 +2102,10 @@ code.signature:focus-within .copy-btn {
     .footer-links {
         grid-template-columns: 1fr;
         gap: 1.5rem;
+    }
+    .footer-list.is-dense,
+    .footer-list.is-mega {
+        grid-template-columns: 1fr;
     }
 
     .footer-bottom {

--- a/Website/themes/codeglyphx/partials/footer.html
+++ b/Website/themes/codeglyphx/partials/footer.html
@@ -1,5 +1,19 @@
 <footer class="footer">
     <div class="footer-content">
+        {{ footer_product = null }}
+        {{ footer_resources = null }}
+        {{ footer_company = null }}
+        {{ if navigation.menus }}
+        {{ for menu in navigation.menus }}
+        {{ if menu.name == "footer-product" }}
+        {{ footer_product = menu }}
+        {{ else if menu.name == "footer-resources" }}
+        {{ footer_resources = menu }}
+        {{ else if menu.name == "footer-company" }}
+        {{ footer_company = menu }}
+        {{ end }}
+        {{ end }}
+        {{ end }}
         <div class="footer-brand">
             <div class="footer-logo">
                 <img src="/codeglyphx-qr-icon.png" alt="{{ site.name }} logo" width="28" height="28" loading="lazy" decoding="async" />
@@ -8,42 +22,42 @@
             <p>Zero-dependency QR &amp; barcode toolkit for .NET</p>
         </div>
         <div class="footer-links">
-      <div class="footer-section">
+      {{ if footer_product && footer_product.items && footer_product.items.size > 0 }}
+      <section class="footer-section">
         <h3>Product</h3>
-        {{~ for menu in navigation.menus ~}}
-        {{~ if menu.name == "footer-product" ~}}
-        {{~ for item in menu.items ~}}
+        <ul class="footer-list{{ if footer_product.items.size > 8 }} is-dense{{ end }}{{ if footer_product.items.size > 14 }} is-mega{{ end }}{{ if footer_product.items.size > 20 }} is-scroll{{ end }}">
+        {{~ for item in footer_product.items ~}}
         {{~ if item.url ~}}
-        <a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}>{{ item.title }}</a>
+        <li><a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}{{ if item.external }} target="_blank" rel="noopener"{{ end }}>{{ item.title }}</a></li>
         {{~ end ~}}
         {{~ end ~}}
-        {{~ end ~}}
-        {{~ end ~}}
-      </div>
-      <div class="footer-section">
+        </ul>
+      </section>
+      {{ end }}
+      {{ if footer_resources && footer_resources.items && footer_resources.items.size > 0 }}
+      <section class="footer-section">
         <h3>Resources</h3>
-        {{~ for menu in navigation.menus ~}}
-        {{~ if menu.name == "footer-resources" ~}}
-        {{~ for item in menu.items ~}}
+        <ul class="footer-list{{ if footer_resources.items.size > 8 }} is-dense{{ end }}{{ if footer_resources.items.size > 14 }} is-mega{{ end }}{{ if footer_resources.items.size > 20 }} is-scroll{{ end }}">
+        {{~ for item in footer_resources.items ~}}
         {{~ if item.url ~}}
-        <a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}>{{ item.title }}</a>
+        <li><a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}{{ if item.external }} target="_blank" rel="noopener"{{ end }}>{{ item.title }}</a></li>
         {{~ end ~}}
         {{~ end ~}}
-        {{~ end ~}}
-        {{~ end ~}}
-      </div>
-      <div class="footer-section">
+        </ul>
+      </section>
+      {{ end }}
+      {{ if footer_company && footer_company.items && footer_company.items.size > 0 }}
+      <section class="footer-section">
         <h3>Company</h3>
-        {{~ for menu in navigation.menus ~}}
-        {{~ if menu.name == "footer-company" ~}}
-        {{~ for item in menu.items ~}}
+        <ul class="footer-list{{ if footer_company.items.size > 8 }} is-dense{{ end }}{{ if footer_company.items.size > 14 }} is-mega{{ end }}{{ if footer_company.items.size > 20 }} is-scroll{{ end }}">
+        {{~ for item in footer_company.items ~}}
         {{~ if item.url ~}}
-        <a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}>{{ item.title }}</a>
+        <li><a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}{{ if item.external }} target="_blank" rel="noopener"{{ end }}>{{ item.title }}</a></li>
         {{~ end ~}}
         {{~ end ~}}
-        {{~ end ~}}
-        {{~ end ~}}
-      </div>
+        </ul>
+      </section>
+      {{ end }}
         </div>
         <div class="footer-bottom">
             <div class="footer-badges">


### PR DESCRIPTION
## Summary
- refactor footer rendering to resolve ooter-product, ooter-resources, and ooter-company menus by name
- replace raw footer link columns with card sections and list grids for better readability
- add adaptive list density classes (is-dense, is-mega, is-scroll) to handle future large menu growth
- keep mobile footer clean by collapsing dense grid variants to a single column

## Validation
- ./build.ps1 -Dev completed successfully in the Website worktree
