### PR TITLE
Refine footer information architecture and link rendering

### DIFF
--- a/Website/site.json
+++ b/Website/site.json
@@ -133,13 +133,11 @@
       {
         "Name": "footer-product",
         "Items": [
-          { "Title": "Home", "Url": "/" },
           { "Title": "Playground", "Url": "/playground/" },
           { "Title": "Docs", "Url": "/docs/" },
+          { "Title": "API Reference", "Url": "/api/" },
           { "Title": "Benchmarks", "Url": "/benchmarks/" },
           { "Title": "Showcase", "Url": "/showcase/" },
-          { "Title": "Downloads", "Url": "/downloads/" },
-          { "Title": "Changelog", "Url": "/changelog/" },
           { "Title": "Pricing", "Url": "/pricing/" }
         ]
       },

--- a/Website/themes/codeglyphx/partials/footer.html
+++ b/Website/themes/codeglyphx/partials/footer.html
@@ -25,10 +25,18 @@
       {{ if footer_product && footer_product.items && footer_product.items.size > 0 }}
       <section class="footer-section">
         <h3>Product</h3>
+        {{ product_visible_count = 0 }}
         <ul class="footer-list{{ if footer_product.items.size > 8 }} is-dense{{ end }}{{ if footer_product.items.size > 14 }} is-mega{{ end }}{{ if footer_product.items.size > 20 }} is-scroll{{ end }}">
         {{~ for item in footer_product.items ~}}
-        {{~ if item.url ~}}
-        <li><a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}{{ if item.external }} target="_blank" rel="noopener"{{ end }}>{{ item.title }}</a></li>
+        {{~ if item.url && product_visible_count < 6 ~}}
+        {{ link_target = item.target }}
+        {{ link_rel = item.rel }}
+        {{ if item.external }}
+        {{ if link_target == null || link_target == "" }}{{ link_target = "_blank" }}{{ end }}
+        {{ if link_rel == null || link_rel == "" }}{{ link_rel = "noopener" }}{{ end }}
+        {{ end }}
+        <li><a href="{{ item.url }}"{{ if link_target }} target="{{ link_target }}"{{ end }}{{ if link_rel }} rel="{{ link_rel }}"{{ end }}>{{ item.title }}</a></li>
+        {{ product_visible_count = product_visible_count + 1 }}
         {{~ end ~}}
         {{~ end ~}}
         </ul>
@@ -37,10 +45,18 @@
       {{ if footer_resources && footer_resources.items && footer_resources.items.size > 0 }}
       <section class="footer-section">
         <h3>Resources</h3>
+        {{ resources_visible_count = 0 }}
         <ul class="footer-list{{ if footer_resources.items.size > 8 }} is-dense{{ end }}{{ if footer_resources.items.size > 14 }} is-mega{{ end }}{{ if footer_resources.items.size > 20 }} is-scroll{{ end }}">
         {{~ for item in footer_resources.items ~}}
-        {{~ if item.url ~}}
-        <li><a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}{{ if item.external }} target="_blank" rel="noopener"{{ end }}>{{ item.title }}</a></li>
+        {{~ if item.url && resources_visible_count < 8 ~}}
+        {{ link_target = item.target }}
+        {{ link_rel = item.rel }}
+        {{ if item.external }}
+        {{ if link_target == null || link_target == "" }}{{ link_target = "_blank" }}{{ end }}
+        {{ if link_rel == null || link_rel == "" }}{{ link_rel = "noopener" }}{{ end }}
+        {{ end }}
+        <li><a href="{{ item.url }}"{{ if link_target }} target="{{ link_target }}"{{ end }}{{ if link_rel }} rel="{{ link_rel }}"{{ end }}>{{ item.title }}</a></li>
+        {{ resources_visible_count = resources_visible_count + 1 }}
         {{~ end ~}}
         {{~ end ~}}
         </ul>
@@ -49,10 +65,18 @@
       {{ if footer_company && footer_company.items && footer_company.items.size > 0 }}
       <section class="footer-section">
         <h3>Company</h3>
+        {{ company_visible_count = 0 }}
         <ul class="footer-list{{ if footer_company.items.size > 8 }} is-dense{{ end }}{{ if footer_company.items.size > 14 }} is-mega{{ end }}{{ if footer_company.items.size > 20 }} is-scroll{{ end }}">
         {{~ for item in footer_company.items ~}}
-        {{~ if item.url ~}}
-        <li><a href="{{ item.url }}"{{ if item.target }} target="{{ item.target }}"{{ end }}{{ if item.rel }} rel="{{ item.rel }}"{{ end }}{{ if item.external }} target="_blank" rel="noopener"{{ end }}>{{ item.title }}</a></li>
+        {{~ if item.url && company_visible_count < 6 ~}}
+        {{ link_target = item.target }}
+        {{ link_rel = item.rel }}
+        {{ if item.external }}
+        {{ if link_target == null || link_target == "" }}{{ link_target = "_blank" }}{{ end }}
+        {{ if link_rel == null || link_rel == "" }}{{ link_rel = "noopener" }}{{ end }}
+        {{ end }}
+        <li><a href="{{ item.url }}"{{ if link_target }} target="{{ link_target }}"{{ end }}{{ if link_rel }} rel="{{ link_rel }}"{{ end }}>{{ item.title }}</a></li>
+        {{ company_visible_count = company_visible_count + 1 }}
         {{~ end ~}}
         {{~ end ~}}
         </ul>


### PR DESCRIPTION
## Summary
- reduce footer product menu noise (remove duplicated links like Downloads/Changelog from product group)
- add API Reference into product group and keep Downloads/Changelog under Resources
- cap rendered footer links per section (Product 6, Resources 8, Company 6) so future menu growth does not bloat layout
- normalize external link attribute rendering to avoid duplicate 	arget/el in generated HTML

## Validation
- ./build.ps1 -Dev passed in website worktree
- verified generated footer HTML no longer contains duplicate external-link attributes
