### PR TITLE
Polish home/download/changelog release UX

### DIFF
--- a/Website/content/pages/index.md
+++ b/Website/content/pages/index.md
@@ -40,6 +40,12 @@ meta.extra_scripts_file: index.scripts.html
             {{< release-button placement="home.hero_download" product="codeglyphx" >}}
         </div>
 
+        <div class="hero-secondary-links" aria-label="Release resources">
+            <a href="/downloads/">Downloads</a>
+            <a href="/changelog/">Changelog</a>
+            <a href="/docs/installation/">Install Guide</a>
+        </div>
+
         <div class="install-command">
             <code>dotnet add package CodeGlyphX</code>
             <button class="copy-btn" type="button" data-copy="dotnet add package CodeGlyphX" title="Copy install command">
@@ -49,12 +55,6 @@ meta.extra_scripts_file: index.scripts.html
                 </svg>
             </button>
         </div>
-
-        <section class="pf-release-downloads-panel">
-            <h2>Latest Stable Downloads</h2>
-            <p>Quick download matrix grouped by release so users can choose the exact package build they need.</p>
-            {{< release-buttons placement="home.downloads_matrix" >}}
-        </section>
 
         <div class="hero-badges">
             <a href="https://github.com/EvotecIT/CodeGlyphX" target="_blank" rel="noopener" class="hero-badge-link">

--- a/Website/data/release_placements.json
+++ b/Website/data/release_placements.json
@@ -6,13 +6,6 @@
       "kind": "zip",
       "label": "Download Latest ZIP",
       "class": "btn btn-secondary"
-    },
-    "downloads_matrix": {
-      "product": "codeglyphx",
-      "channel": "stable",
-      "groupBy": "release",
-      "limit": 12,
-      "class": "pf-release-buttons--matrix"
     }
   },
   "changelog": {

--- a/Website/static/css/app.css
+++ b/Website/static/css/app.css
@@ -489,7 +489,33 @@ body:has(.page-playground) {
     gap: 1rem;
     justify-content: center;
     flex-wrap: wrap;
-    margin-bottom: 3rem;
+    margin-bottom: 1rem;
+}
+
+.hero-secondary-links {
+    display: flex;
+    gap: 0.65rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 1.25rem;
+}
+
+.hero-secondary-links a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.42rem 0.95rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    background: linear-gradient(135deg, rgba(139, 92, 246, 0.08), rgba(6, 182, 212, 0.04));
+    font-size: 0.93rem;
+}
+
+.hero-secondary-links a:hover {
+    color: var(--text);
+    border-color: rgba(139, 92, 246, 0.55);
+    background: linear-gradient(135deg, rgba(139, 92, 246, 0.16), rgba(6, 182, 212, 0.08));
 }
 
 /* Buttons */
@@ -4632,6 +4658,40 @@ section {
     color: var(--primary);
 }
 
+.pf-release-body a.pf-release-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    border-radius: 999px;
+    padding: 0.08rem 0.46rem;
+    text-decoration: none;
+    line-height: 1.35;
+    font-size: 0.84em;
+    background: rgba(15, 23, 42, 0.36);
+}
+
+.pf-release-body a.pf-release-link:hover {
+    border-color: rgba(139, 92, 246, 0.5);
+    background: rgba(139, 92, 246, 0.12);
+}
+
+.pf-release-link--mention {
+    color: #A5B4FC;
+    border-color: rgba(99, 102, 241, 0.45);
+}
+
+.pf-release-link--pr,
+.pf-release-link--issue {
+    color: #67E8F9;
+    border-color: rgba(6, 182, 212, 0.5);
+}
+
+.pf-release-link--compare {
+    color: #C4B5FD;
+    border-color: rgba(139, 92, 246, 0.5);
+}
+
 .pf-release-body > :first-child {
     margin-top: 0;
 }
@@ -4649,6 +4709,10 @@ section {
     flex-wrap: wrap;
     gap: 0.45rem 0.7rem;
     align-items: center;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.48rem 0.58rem;
+    background: rgba(15, 23, 42, 0.24);
 }
 
 .pf-release-asset-thumb {
@@ -4664,6 +4728,9 @@ section {
 .pf-release-asset-link {
     font-weight: 600;
     color: var(--primary-light);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
 }
 
 .pf-release-asset-link:hover {

--- a/Website/static/js/site.js
+++ b/Website/static/js/site.js
@@ -600,6 +600,25 @@ globalThis.setTheme = setTheme;
         });
     }
 
+    function getFriendlyReleaseUrlInfo(url) {
+        const prMatch = url.match(/^https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:[/?#].*)?$/i);
+        if (prMatch) {
+            return { label: `PR #${prMatch[1]}`, className: 'pf-release-link--pr' };
+        }
+
+        const issueMatch = url.match(/^https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)(?:[/?#].*)?$/i);
+        if (issueMatch) {
+            return { label: `Issue #${issueMatch[1]}`, className: 'pf-release-link--issue' };
+        }
+
+        const compareMatch = url.match(/^https?:\/\/github\.com\/[^/]+\/[^/]+\/compare\/[^?#]+$/i);
+        if (compareMatch) {
+            return { label: 'Full Changelog', className: 'pf-release-link--compare' };
+        }
+
+        return { label: url.replace(/^https?:\/\//i, ''), className: '' };
+    }
+
     function linkifyReleaseBodyUrls() {
         const containers = Array.from(document.querySelectorAll('.pf-release-body'))
             .filter((container) => container.dataset.linkified !== 'true');
@@ -610,7 +629,7 @@ globalThis.setTheme = setTheme;
                 NodeFilter.SHOW_TEXT,
                 {
                     acceptNode(node) {
-                        if (!node?.nodeValue || !/https?:\/\//i.test(node.nodeValue)) {
+                        if (!node?.nodeValue || !/(https?:\/\/|@[A-Za-z0-9-]{1,39})/i.test(node.nodeValue)) {
                             return NodeFilter.FILTER_REJECT;
                         }
                         const parent = node.parentElement;
@@ -635,42 +654,69 @@ globalThis.setTheme = setTheme;
 
             textNodes.forEach((node) => {
                 const source = node.nodeValue || '';
-                const urlPattern = /https?:\/\/[^\s<>()]+/gi;
+                const tokenPattern = /(https?:\/\/[^\s<>()]+)|@([A-Za-z0-9-]{1,39})/gi;
                 let lastIndex = 0;
-                let match = urlPattern.exec(source);
+                let match = tokenPattern.exec(source);
                 if (!match) return;
 
                 const fragment = document.createDocumentFragment();
                 while (match) {
-                    const raw = match[0];
-                    let url = raw;
-                    let suffix = '';
-                    while (/[.,;:!?)]$/.test(url)) {
-                        suffix = url.slice(-1) + suffix;
-                        url = url.slice(0, -1);
-                    }
+                    const rawUrl = match[1];
+                    const mentionUser = match[2];
+                    const token = match[0];
 
                     if (match.index > lastIndex) {
                         fragment.appendChild(document.createTextNode(source.slice(lastIndex, match.index)));
                     }
 
-                    if (url) {
-                        const anchor = document.createElement('a');
-                        anchor.href = url;
-                        anchor.textContent = url;
-                        anchor.target = '_blank';
-                        anchor.rel = 'noopener';
-                        fragment.appendChild(anchor);
+                    if (rawUrl) {
+                        let url = rawUrl;
+                        let suffix = '';
+                        while (/[.,;:!?)]$/.test(url)) {
+                            suffix = url.slice(-1) + suffix;
+                            url = url.slice(0, -1);
+                        }
+
+                        if (url) {
+                            const linkInfo = getFriendlyReleaseUrlInfo(url);
+                            const anchor = document.createElement('a');
+                            anchor.href = url;
+                            anchor.textContent = linkInfo.label;
+                            anchor.target = '_blank';
+                            anchor.rel = 'noopener';
+                            anchor.className = `pf-release-link ${linkInfo.className}`.trim();
+                            if (linkInfo.label !== url) {
+                                anchor.title = url;
+                            }
+                            fragment.appendChild(anchor);
+                        } else {
+                            fragment.appendChild(document.createTextNode(token));
+                        }
+
+                        if (suffix) {
+                            fragment.appendChild(document.createTextNode(suffix));
+                        }
                     } else {
-                        fragment.appendChild(document.createTextNode(raw));
+                        const mentionToken = `@${mentionUser}`;
+                        const previousChar = match.index > 0 ? source.charAt(match.index - 1) : '';
+                        const isLikelyEmail = previousChar && /[A-Za-z0-9._-]/.test(previousChar);
+
+                        if (isLikelyEmail) {
+                            fragment.appendChild(document.createTextNode(mentionToken));
+                        } else {
+                            const anchor = document.createElement('a');
+                            anchor.href = `https://github.com/${mentionUser}`;
+                            anchor.textContent = mentionToken;
+                            anchor.target = '_blank';
+                            anchor.rel = 'noopener';
+                            anchor.className = 'pf-release-link pf-release-link--mention';
+                            anchor.title = `GitHub profile: ${mentionUser}`;
+                            fragment.appendChild(anchor);
+                        }
                     }
 
-                    if (suffix) {
-                        fragment.appendChild(document.createTextNode(suffix));
-                    }
-
-                    lastIndex = match.index + raw.length;
-                    match = urlPattern.exec(source);
+                    lastIndex = match.index + token.length;
+                    match = tokenPattern.exec(source);
                 }
 
                 if (lastIndex < source.length) {


### PR DESCRIPTION
Home page now keeps CTA + simple release links (Downloads/Changelog/Install) instead of showing the full downloads matrix. Changelog release notes now render friendlier links (PR, Issue, Full Changelog) and auto-link GitHub @mentions. Release asset rows were restyled for better readability. Verified with node check and local website builds.