### PR TITLE
Improve website caching and limit deploy triggers

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,9 @@ name: Deploy Website
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'Website/**'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 concurrency:

--- a/Website/site.json
+++ b/Website/site.json
@@ -94,7 +94,16 @@
     },
     "CacheHeaders": {
       "Enabled": true,
-      "OutputPath": "_headers"
+      "OutputPath": "_headers",
+      "HtmlCacheControl": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=604800",
+      "ImmutableCacheControl": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      "ImmutablePaths": [
+        "/assets/*",
+        "/css/*",
+        "/js/*",
+        "/fonts/*",
+        "/playground/_framework/*"
+      ]
     }
   },
   "Prism": {


### PR DESCRIPTION
## Summary\n- limit website deploy workflow triggers to website-related changes only\n- keep release-safe asset hashing behavior and tune generated _headers cache policy\n- add explicit asset path cache rules for static assets and Blazor framework files\n\n## Why\n- improves Cloudflare cache hit ratio by avoiding max-age=0 on all assets\n- avoids rebuilding/redeploying website for unrelated repository pushes\n- keeps behavior safe for non-hashed playground/static assets\n\n## Validation\n- pwsh -NoProfile -File ./build.ps1 -CI (passes)