### PR TITLE
[codex] Adopt website engine lock workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@96756d66fe78931dcfdb3d95a30de0d3b0590e93
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@91a34dd50854f44d20f896ac6f4b449293fd851a
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@ba663dbeaaca2be3d8ad176c6e14075cb8222187
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@96756d66fe78931dcfdb3d95a30de0d3b0590e93
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
       powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
       powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
       report_artifact_name: powerforge-website-reports
-    secrets: inherit
 
   coverage:
     name: Coverage (linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,6 @@ jobs:
       pipeline_config: Website/pipeline.website-ci.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_lock_path: Website/.powerforge/engine-lock.json
-      powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
-      powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,6 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Pinned to a PowerForge commit that keeps release-hub support and clears current NuGet vulnerability gates.
-  POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: 4751f06a2a52d926fc222a709ea6f0fff3d022c7
-
 jobs:
   build-test:
     name: Build & Test (${{ matrix.os }})
@@ -113,45 +108,19 @@ jobs:
 
   website-build:
     name: Website Build (PR)
-    # Prefer private/self-hosted runners for private repos to reduce hosted spend.
-    runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
-    timeout-minutes: 10
     if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Checkout PSPublishModule
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.POWERFORGE_REPOSITORY }}
-          ref: ${{ env.POWERFORGE_REF }}
-          path: PSPublishModule
-
-      - name: Restore and build PowerForge.Web.Cli
-        run: |
-          dotnet restore PSPublishModule/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj --force-evaluate
-          dotnet build PSPublishModule/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Release --no-restore
-
-      - name: Build website (static + playground)
-        working-directory: Website
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: dotnet ../PSPublishModule/PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll pipeline --config pipeline.json --mode ci --skip doctor
-
-      - name: Verify website output
-        run: |
-          test -f Website/_site/.nojekyll
-          test -f Website/_site/index.html
-          test -f Website/_site/docs/index.html
-          test -f Website/_site/playground/index.html
-
-      # Playwright smoke coverage is handled by the PowerForge.Web audit step
+    permissions:
+      contents: read
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@ba663dbeaaca2be3d8ad176c6e14075cb8222187
+    with:
+      website_root: Website
+      pipeline_config: Website/pipeline.website-ci.json
+      runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_lock_path: Website/.powerforge/engine-lock.json
+      powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
+      powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
+      report_artifact_name: powerforge-website-reports
+    secrets: inherit
 
   coverage:
     name: Coverage (linux)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,9 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Pinned to a PowerForge commit that keeps release-hub support and clears current NuGet vulnerability gates.
-  POWERFORGE_REPOSITORY: EvotecIT/PSPublishModule
-  POWERFORGE_REF: 4751f06a2a52d926fc222a709ea6f0fff3d022c7
+  POWERFORGE_LOCK_PATH: Website/.powerforge/engine-lock.json
 
 jobs:
   build:
@@ -23,6 +21,9 @@ jobs:
     runs-on: ${{ fromJSON(github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]') }}
     permissions:
       contents: read
+    outputs:
+      powerforge_repository: ${{ steps.powerforge.outputs.repository }}
+      powerforge_ref: ${{ steps.powerforge.outputs.ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,11 +33,45 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Resolve PowerForge engine source
+        id: powerforge
+        shell: pwsh
+        run: |
+          $lockPath = [string]'${{ env.POWERFORGE_LOCK_PATH }}'
+          $resolvedRepository = [string]'${{ vars.POWERFORGE_REPOSITORY }}'
+          $resolvedRef = [string]'${{ vars.POWERFORGE_REF }}'
+
+          if (([string]::IsNullOrWhiteSpace($resolvedRepository) -or [string]::IsNullOrWhiteSpace($resolvedRef)) -and (Test-Path -LiteralPath $lockPath)) {
+            $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json
+            if ($null -eq $lock) {
+              throw "Invalid engine lock JSON: $lockPath"
+            }
+
+            if ([string]::IsNullOrWhiteSpace($resolvedRepository)) {
+              $resolvedRepository = [string]$lock.repository
+            }
+
+            if ([string]::IsNullOrWhiteSpace($resolvedRef)) {
+              $resolvedRef = [string]$lock.ref
+            }
+          }
+
+          if ([string]::IsNullOrWhiteSpace($resolvedRepository) -or [string]::IsNullOrWhiteSpace($resolvedRef)) {
+            throw "Provide POWERFORGE_REPOSITORY + POWERFORGE_REF overrides or commit a valid engine lock file at '$lockPath'."
+          }
+
+          if ($resolvedRef -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+            throw "PowerForge ref must be an immutable commit SHA (40/64 hex): '$resolvedRef'."
+          }
+
+          "repository=$resolvedRepository" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "ref=$resolvedRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       - name: Checkout PSPublishModule
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.POWERFORGE_REPOSITORY }}
-          ref: ${{ env.POWERFORGE_REF }}
+          repository: ${{ steps.powerforge.outputs.repository }}
+          ref: ${{ steps.powerforge.outputs.ref }}
           path: PSPublishModule
 
       - name: Restore and build PowerForge.Web.Cli
@@ -115,8 +150,8 @@ jobs:
         if: steps.cloudflare.outputs.enabled == 'true'
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.POWERFORGE_REPOSITORY }}
-          ref: ${{ env.POWERFORGE_REF }}
+          repository: ${{ needs.build.outputs.powerforge_repository }}
+          ref: ${{ needs.build.outputs.powerforge_ref }}
           path: PSPublishModule
 
       - name: Restore and build PowerForge.Web.Cli

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,8 +38,8 @@ jobs:
         shell: pwsh
         run: |
           $lockPath = [string]'${{ env.POWERFORGE_LOCK_PATH }}'
-          $resolvedRepository = [string]'${{ vars.POWERFORGE_REPOSITORY }}'
-          $resolvedRef = [string]'${{ vars.POWERFORGE_REF }}'
+          $resolvedRepository = ''
+          $resolvedRef = ''
 
           if (([string]::IsNullOrWhiteSpace($resolvedRepository) -or [string]::IsNullOrWhiteSpace($resolvedRef)) -and (Test-Path -LiteralPath $lockPath)) {
             $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json
@@ -57,7 +57,7 @@ jobs:
           }
 
           if ([string]::IsNullOrWhiteSpace($resolvedRepository) -or [string]::IsNullOrWhiteSpace($resolvedRef)) {
-            throw "Provide POWERFORGE_REPOSITORY + POWERFORGE_REF overrides or commit a valid engine lock file at '$lockPath'."
+            throw "Commit a valid engine lock file at '$lockPath'."
           }
 
           if ($resolvedRef -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@96756d66fe78931dcfdb3d95a30de0d3b0590e93
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@91a34dd50854f44d20f896ac6f4b449293fd851a
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@ba663dbeaaca2be3d8ad176c6e14075cb8222187
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@96756d66fe78931dcfdb3d95a30de0d3b0590e93
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -21,6 +21,4 @@ jobs:
       pipeline_config: Website/pipeline.maintenance.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_lock_path: Website/.powerforge/engine-lock.json
-      powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
-      powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -24,4 +24,3 @@ jobs:
       powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
       powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
       report_artifact_name: powerforge-website-maintenance-reports
-    secrets: inherit

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -1,0 +1,27 @@
+name: Website Maintenance
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: website-maintenance-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  website-maintenance:
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@ba663dbeaaca2be3d8ad176c6e14075cb8222187
+    with:
+      website_root: Website
+      pipeline_config: Website/pipeline.maintenance.json
+      runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_lock_path: Website/.powerforge/engine-lock.json
+      powerforge_repository_override: ${{ vars.POWERFORGE_REPOSITORY }}
+      powerforge_ref_override: ${{ vars.POWERFORGE_REF }}
+      report_artifact_name: powerforge-website-maintenance-reports
+    secrets: inherit

--- a/Website/.powerforge/engine-lock.json
+++ b/Website/.powerforge/engine-lock.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.enginelock.schema.json",
+  "repository": "EvotecIT/PSPublishModule",
+  "ref": "5d4ebe404474f9c79963b9f9bb245dc2313b1eea",
+  "channel": "stable",
+  "updatedUtc": "2026-03-26T19:18:00.0000000+00:00"
+}

--- a/Website/.powerforge/engine-lock.json
+++ b/Website/.powerforge/engine-lock.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.enginelock.schema.json",
   "repository": "EvotecIT/PSPublishModule",
-  "ref": "5d4ebe404474f9c79963b9f9bb245dc2313b1eea",
-  "channel": "stable",
-  "updatedUtc": "2026-03-26T19:18:00.0000000+00:00"
+  "ref": "c2cbd086aa4b74660f77b786a1253a43bd36b3ae",
+  "channel": "preview",
+  "updatedUtc": "2026-03-28T09:30:00.0000000+00:00"
 }

--- a/Website/.powerforge/engine-lock.json
+++ b/Website/.powerforge/engine-lock.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.enginelock.schema.json",
   "repository": "EvotecIT/PSPublishModule",
-  "ref": "c2cbd086aa4b74660f77b786a1253a43bd36b3ae",
-  "channel": "preview",
-  "updatedUtc": "2026-03-28T09:30:00.0000000+00:00"
+  "ref": "91a34dd50854f44d20f896ac6f4b449293fd851a",
+  "channel": "stable",
+  "updatedUtc": "2026-03-28T10:53:00.0000000+00:00"
 }

--- a/Website/pipeline.maintenance.json
+++ b/Website/pipeline.maintenance.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.pipelinespec.schema.json",
+  "steps": [
+    {
+      "task": "github-artifacts-prune",
+      "id": "github-artifacts-maintenance",
+      "tokenEnv": "GITHUB_TOKEN",
+      "optional": true,
+      "apply": true,
+      "continueOnError": true,
+      "keep": 7,
+      "maxAgeDays": 14,
+      "maxDelete": 100,
+      "reportPath": "./_reports/github-artifacts-maintenance.json",
+      "summaryPath": "./_reports/github-artifacts-maintenance.md"
+    }
+  ]
+}

--- a/Website/pipeline.website-ci.json
+++ b/Website/pipeline.website-ci.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/schemas/powerforge.web.pipelinespec.schema.json",
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.pipelinespec.schema.json",
   "cache": true,
   "cachePath": "./_temp/pipeline-cache.json",
   "profile": true,
@@ -49,29 +49,9 @@
       "clean": true
     },
     {
-      "task": "verify",
-      "id": "verify-site",
-      "dependsOn": "build-site",
-      "skipModes": ["ci"],
-      "config": "./site.json"
-    },
-    {
-      "task": "verify",
-      "id": "verify-ci",
-      "dependsOn": "build-site",
-      "modes": ["ci"],
-      "config": "./site.json",
-      "baseline": "./.powerforge/verify-baseline.json",
-      "failOnNewWarnings": true,
-      "failOnNavLint": true,
-      "failOnThemeContract": true,
-      "warningPreviewCount": 10,
-      "errorPreviewCount": 10
-    },
-    {
       "task": "dotnet-build",
       "id": "build-library",
-      "dependsOn": "verify-site",
+      "dependsOn": "build-site",
       "project": "../CodeGlyphX/CodeGlyphX.csproj",
       "configuration": "Release",
       "skipIfProjectMissing": true
@@ -241,42 +221,6 @@
       "cacheHeaders": true,
       "cacheHeadersOut": "_headers",
       "reportPath": "./_reports/optimize-report.json"
-    },
-    {
-      "task": "doctor",
-      "id": "doctor-site",
-      "dependsOn": "optimize-site",
-      "skipModes": ["dev"],
-      "config": "./site.json",
-      "siteRoot": "./_site",
-      "noBuild": true,
-      "noVerify": true,
-      "baseline": "./.powerforge/audit-baseline.json",
-      "failOnNewIssues": false,
-      "maxTotalFiles": 4000,
-      "exclude": "**/*.scripts.html,**/*.head.html,**/api-fragments/**,api-fragments/**",
-      "ignoreNav": "sitemap/**,search/**,playground/index.html,playground/404.html",
-      "noDefaultIgnoreNav": true,
-      "navSelector": "header nav.nav",
-      "navCanonicalPath": "index.html",
-      "navCanonicalSelector": "header nav.nav",
-      "navCanonicalRequired": true,
-      "navRequiredLinks": "/,/docs/",
-      "minNavCoveragePercent": 95,
-      "requiredRoutes": "/,/docs/,/404.html,/api/,/search/,/sitemap/",
-      "failOnCategories": "budget,nav,link,asset,rendered-console-error,rendered-request-failure",
-      "rendered": true,
-      "renderedEnsureInstalled": false,
-      "renderedMaxPages": 10,
-      "renderedInclude": "index.html,docs/**,benchmarks/**,faq/**,pricing/**,showcase/**,playground/**",
-      "renderedExclude": "api/**,docs/api/**,api-docs/**",
-      "summary": true,
-      "summaryPath": "./_reports/doctor-summary.json",
-      "summaryMaxIssues": 50,
-      "checkUtf8": true,
-      "checkMetaCharset": true,
-      "checkUnicodeReplacementChars": true
     }
   ]
 }
-


### PR DESCRIPTION
## Summary
- switch CodeGlyphX website PR CI to the central reusable PowerForge website workflow
- add `Website/.powerforge/engine-lock.json` so the website engine pin is committed once and reused everywhere
- add `Website/pipeline.website-ci.json` for the website-only CI path and `Website/pipeline.maintenance.json` for scheduled maintenance
- add a thin maintenance workflow wrapper and make `pages.yml` plus Cloudflare follow-up steps resolve the same engine lock

## Why
CodeGlyphX had the same duplicated website workflow/pin shape as the other sites.
This change aligns it with the reusable workflow model so future website engine updates are shared and deterministic instead of repeated across YAML files.

## Validation
- `git diff --check`
- parsed `Website/pipeline.json`, `Website/pipeline.website-ci.json`, `Website/pipeline.maintenance.json`, and `Website/.powerforge/engine-lock.json`
