### PR TITLE
Refresh PowerForge workflow pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-20260328151156
       report_artifact_name: powerforge-website-reports
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@30f4082c1a7d79bc8419d12ac87b43f88919eea2
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       pipeline_config: Website/pipeline.website-ci.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-20260328151156
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@30f4082c1a7d79bc8419d12ac87b43f88919eea2
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,7 @@ jobs:
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-20260328151156
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-20260328151156
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@30f4082c1a7d79bc8419d12ac87b43f88919eea2
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -20,5 +20,6 @@ jobs:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-20260328151156
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -21,5 +21,5 @@ jobs:
       pipeline_config: Website/pipeline.maintenance.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-20260328151156
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
Refresh PowerForge reusable workflow pins to the merged PSPublishModule main SHA so CI, deploy, and maintenance workflows resolve valid shared workflow refs.