### PR TITLE
[codex] Fix transparent QR alpha compositing

### DIFF
--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -98,6 +98,72 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_SimpleRgba_Preserves_Straight_Alpha_Over_Transparent_Background() {
+        var matrix = new BitMatrix(1, 1);
+        matrix[0, 0] = true;
+
+        var png = QrPngRenderer.Render(matrix, new QrPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            Foreground = new Rgba32(0, 0, 0, 128),
+            Background = new Rgba32(255, 255, 255, 0),
+        });
+
+        var (rgba, _, _, _) = PngTestDecoder.DecodeRgba32(png);
+        Assert.Equal(0, rgba[0]);
+        Assert.Equal(0, rgba[1]);
+        Assert.Equal(0, rgba[2]);
+        Assert.Equal(128, rgba[3]);
+    }
+
+    [Fact]
+    public void Render_GeneralPath_Preserves_Straight_Alpha_Over_Transparent_Background() {
+        var matrix = new BitMatrix(1, 1);
+        matrix[0, 0] = true;
+
+        var png = QrPngRenderer.Render(matrix, new QrPngRenderOptions {
+            ModuleSize = 5,
+            QuietZone = 0,
+            Foreground = new Rgba32(0, 0, 0, 128),
+            Background = new Rgba32(255, 255, 255, 0),
+            ModuleShape = QrPngModuleShape.Circle,
+            ModuleScale = 0.8,
+        });
+
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+        var center = (height / 2) * stride + (width / 2) * 4;
+        Assert.Equal(0, rgba[center + 0]);
+        Assert.Equal(0, rgba[center + 1]);
+        Assert.Equal(0, rgba[center + 2]);
+        Assert.Equal(128, rgba[center + 3]);
+    }
+
+    [Fact]
+    public void Render_LogoOverlay_Preserves_Straight_Alpha_Over_Transparent_Background() {
+        var matrix = new BitMatrix(1, 1);
+        var logoRgba = new byte[] { 255, 0, 0, 128 };
+
+        var png = QrPngRenderer.Render(matrix, new QrPngRenderOptions {
+            ModuleSize = 12,
+            QuietZone = 0,
+            Foreground = Rgba32.Black,
+            Background = new Rgba32(255, 255, 255, 0),
+            Logo = new QrPngLogoOptions(logoRgba, 1, 1) {
+                Scale = 1.0,
+                PaddingPx = 0,
+                DrawBackground = false,
+            },
+        });
+
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+        var center = (height / 2) * stride + (width / 2) * 4;
+        Assert.Equal(255, rgba[center + 0]);
+        Assert.Equal(0, rgba[center + 1]);
+        Assert.Equal(0, rgba[center + 2]);
+        Assert.Equal(128, rgba[center + 3]);
+    }
+
+    [Fact]
     public void Render_With_SpecklePattern_Changes_With_Seed() {
         var matrix = new BitMatrix(1, 1);
         matrix[0, 0] = true;

--- a/CodeGlyphX.Tests/QrPngRendererTests.cs
+++ b/CodeGlyphX.Tests/QrPngRendererTests.cs
@@ -117,6 +117,25 @@ public sealed class QrPngRendererTests {
     }
 
     [Fact]
+    public void Render_SimpleRgba_TransparentForeground_LeavesBackgroundUnchanged() {
+        var matrix = new BitMatrix(1, 1);
+        matrix[0, 0] = true;
+
+        var png = QrPngRenderer.Render(matrix, new QrPngRenderOptions {
+            ModuleSize = 1,
+            QuietZone = 0,
+            Foreground = new Rgba32(0, 0, 0, 0),
+            Background = new Rgba32(12, 34, 56, 78),
+        });
+
+        var (rgba, _, _, _) = PngTestDecoder.DecodeRgba32(png);
+        Assert.Equal(12, rgba[0]);
+        Assert.Equal(34, rgba[1]);
+        Assert.Equal(56, rgba[2]);
+        Assert.Equal(78, rgba[3]);
+    }
+
+    [Fact]
     public void Render_GeneralPath_Preserves_Straight_Alpha_Over_Transparent_Background() {
         var matrix = new BitMatrix(1, 1);
         matrix[0, 0] = true;
@@ -136,6 +155,28 @@ public sealed class QrPngRendererTests {
         Assert.Equal(0, rgba[center + 1]);
         Assert.Equal(0, rgba[center + 2]);
         Assert.Equal(128, rgba[center + 3]);
+    }
+
+    [Fact]
+    public void Render_GeneralPath_TransparentForeground_LeavesBackgroundUnchanged() {
+        var matrix = new BitMatrix(1, 1);
+        matrix[0, 0] = true;
+
+        var png = QrPngRenderer.Render(matrix, new QrPngRenderOptions {
+            ModuleSize = 5,
+            QuietZone = 0,
+            Foreground = new Rgba32(0, 0, 0, 0),
+            Background = new Rgba32(12, 34, 56, 78),
+            ModuleShape = QrPngModuleShape.Circle,
+            ModuleScale = 0.8,
+        });
+
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+        var center = (height / 2) * stride + (width / 2) * 4;
+        Assert.Equal(12, rgba[center + 0]);
+        Assert.Equal(34, rgba[center + 1]);
+        Assert.Equal(56, rgba[center + 2]);
+        Assert.Equal(78, rgba[center + 3]);
     }
 
     [Fact]

--- a/CodeGlyphX.Tests/RoundTripTests.cs
+++ b/CodeGlyphX.Tests/RoundTripTests.cs
@@ -57,6 +57,23 @@ public sealed class RoundTripTests {
     }
 
     [Fact]
+    public void Encode_RenderTransparentPng_DecodePixels_RoundTrip() {
+        var text = "Transparent round-trip";
+        var qr = QrCodeEncoder.EncodeText(text, QrErrorCorrectionLevel.M, 1, 10, null);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 8,
+            QuietZone = 4,
+            Foreground = Rgba32.Black,
+            Background = new Rgba32(255, 255, 255, 0)
+        });
+
+        var (rgba, width, height, stride) = PngTestDecoder.DecodeRgba32(png);
+        Assert.Equal(0, rgba[3]);
+        Assert.True(QrDecoder.TryDecode(rgba, width, height, stride, PixelFormat.Rgba32, out var decoded));
+        Assert.Equal(text, decoded.Text);
+    }
+
+    [Fact]
     public void DecodePixels_FinderBased_CanIgnoreNoiseOutsideQr() {
         var text = "Noise outside QR";
         var qr = QrCodeEncoder.EncodeText(text, QrErrorCorrectionLevel.M, 1, 10, null);

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Eyes.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Eyes.cs
@@ -1113,16 +1113,7 @@ public static partial class QrPngRenderer {
                     continue;
                 }
 
-                var dr = scanlines[dst + 0];
-                var dg = scanlines[dst + 1];
-                var db = scanlines[dst + 2];
-                var da = scanlines[dst + 3];
-
-                var inv = 255 - sa;
-                scanlines[dst + 0] = (byte)((sr * sa + dr * inv + 127) / 255);
-                scanlines[dst + 1] = (byte)((sg * sa + dg * inv + 127) / 255);
-                scanlines[dst + 2] = (byte)((sb * sa + db * inv + 127) / 255);
-                scanlines[dst + 3] = (byte)((sa + da * inv + 127) / 255);
+                BlendPixelAt(scanlines, dst, new Rgba32(sr, sg, sb, sa));
             }
         }
     }

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Render.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Render.cs
@@ -443,23 +443,7 @@ public static partial class QrPngRenderer {
                     }
                 }
 
-                if (outColor.A == 255) {
-                    scanlines[rowStart + 0] = outColor.R;
-                    scanlines[rowStart + 1] = outColor.G;
-                    scanlines[rowStart + 2] = outColor.B;
-                    scanlines[rowStart + 3] = 255;
-                } else {
-                    var dr = scanlines[rowStart + 0];
-                    var dg = scanlines[rowStart + 1];
-                    var db = scanlines[rowStart + 2];
-                    var da = scanlines[rowStart + 3];
-                    var sa = outColor.A;
-                    var inv = 255 - sa;
-                    scanlines[rowStart + 0] = (byte)((outColor.R * sa + dr * inv + 127) / 255);
-                    scanlines[rowStart + 1] = (byte)((outColor.G * sa + dg * inv + 127) / 255);
-                    scanlines[rowStart + 2] = (byte)((outColor.B * sa + db * inv + 127) / 255);
-                    scanlines[rowStart + 3] = (byte)((sa + da * inv + 127) / 255);
-                }
+                BlendPixelAt(scanlines, rowStart, outColor);
                 rowStart += 4;
             }
         }
@@ -522,23 +506,7 @@ public static partial class QrPngRenderer {
                     }
                 }
 
-                if (outColor.A == 255) {
-                    scanlines[rowStart + 0] = outColor.R;
-                    scanlines[rowStart + 1] = outColor.G;
-                    scanlines[rowStart + 2] = outColor.B;
-                    scanlines[rowStart + 3] = 255;
-                } else {
-                    var dr = scanlines[rowStart + 0];
-                    var dg = scanlines[rowStart + 1];
-                    var db = scanlines[rowStart + 2];
-                    var da = scanlines[rowStart + 3];
-                    var sa = outColor.A;
-                    var inv = 255 - sa;
-                    scanlines[rowStart + 0] = (byte)((outColor.R * sa + dr * inv + 127) / 255);
-                    scanlines[rowStart + 1] = (byte)((outColor.G * sa + dg * inv + 127) / 255);
-                    scanlines[rowStart + 2] = (byte)((outColor.B * sa + db * inv + 127) / 255);
-                    scanlines[rowStart + 3] = (byte)((sa + da * inv + 127) / 255);
-                }
+                BlendPixelAt(scanlines, rowStart, outColor);
                 rowStart += 4;
             }
         }
@@ -552,14 +520,7 @@ public static partial class QrPngRenderer {
     }
 
     private static Rgba32 CompositeColor(Rgba32 foreground, Rgba32 background) {
-        if (foreground.A == 255) return foreground;
-        var sa = foreground.A;
-        var inv = 255 - sa;
-        var r = (byte)((foreground.R * sa + background.R * inv + 127) / 255);
-        var g = (byte)((foreground.G * sa + background.G * inv + 127) / 255);
-        var b = (byte)((foreground.B * sa + background.B * inv + 127) / 255);
-        var a = (byte)((sa + background.A * inv + 127) / 255);
-        return new Rgba32(r, g, b, a);
+        return ComposeOver(foreground, background);
     }
 
     private static void ComputeLayout(
@@ -3213,24 +3174,31 @@ public static partial class QrPngRenderer {
         }
 
         var rowStart = y * (stride + 1) + 1 + x * 4;
-        var dr = scanlines[rowStart + 0];
-        var dg = scanlines[rowStart + 1];
-        var db = scanlines[rowStart + 2];
-        var da = scanlines[rowStart + 3];
-        var sa = color.A;
-        var invSa = 255 - sa;
-        var outA = sa + (da * invSa + 127) / 255;
-        if (outA == 0) {
-            scanlines[rowStart + 0] = 0;
-            scanlines[rowStart + 1] = 0;
-            scanlines[rowStart + 2] = 0;
-            scanlines[rowStart + 3] = 0;
+        BlendPixelAt(scanlines, rowStart, color);
+    }
+
+    private static void BlendPixelAt(byte[] buffer, int offset, Rgba32 color) {
+        if (color.A == 0) return;
+        if (color.A == 255) {
+            buffer[offset + 0] = color.R;
+            buffer[offset + 1] = color.G;
+            buffer[offset + 2] = color.B;
+            buffer[offset + 3] = 255;
             return;
         }
-        scanlines[rowStart + 0] = (byte)((color.R * sa + dr * da * invSa / 255 + outA / 2) / outA);
-        scanlines[rowStart + 1] = (byte)((color.G * sa + dg * da * invSa / 255 + outA / 2) / outA);
-        scanlines[rowStart + 2] = (byte)((color.B * sa + db * da * invSa / 255 + outA / 2) / outA);
-        scanlines[rowStart + 3] = (byte)outA;
+
+        var composed = ComposeOver(
+            color,
+            new Rgba32(
+                buffer[offset + 0],
+                buffer[offset + 1],
+                buffer[offset + 2],
+                buffer[offset + 3]));
+
+        buffer[offset + 0] = composed.R;
+        buffer[offset + 1] = composed.G;
+        buffer[offset + 2] = composed.B;
+        buffer[offset + 3] = composed.A;
     }
 
     private static void FillBackgroundGradient(byte[] scanlines, int widthPx, int heightPx, int stride, QrPngGradientOptions gradient) {

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Render.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.Render.cs
@@ -520,6 +520,8 @@ public static partial class QrPngRenderer {
     }
 
     private static Rgba32 CompositeColor(Rgba32 foreground, Rgba32 background) {
+        // Keep solid-module precompositing aligned with the per-pixel renderer so
+        // transparent output stores straight-alpha colors consistently.
         return ComposeOver(foreground, background);
     }
 
@@ -3142,6 +3144,8 @@ public static partial class QrPngRenderer {
         return m < 0 ? m + modulus : m;
     }
 
+    // Compose straight-alpha colors using Porter-Duff "over" so transparent
+    // canvases preserve the source RGB instead of leaking hidden background RGB.
     private static Rgba32 ComposeOver(Rgba32 top, Rgba32 bottom) {
         var ta = top.A;
         if (ta == 0) return bottom;
@@ -3177,6 +3181,8 @@ public static partial class QrPngRenderer {
         BlendPixelAt(scanlines, rowStart, color);
     }
 
+    // Blend onto the stored RGBA pixel with the same straight-alpha math used by
+    // the simple and solid paths. This keeps modules, eyes, and logos consistent.
     private static void BlendPixelAt(byte[] buffer, int offset, Rgba32 color) {
         if (color.A == 0) return;
         if (color.A == 255) {

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
@@ -194,6 +194,8 @@ public static partial class QrPngRenderer {
     }
 
     private static Rgba32 CompositeForeground(Rgba32 foreground, Rgba32 background) {
+        // Reuse the shared compositor so the simple square path matches the
+        // general renderer when foreground alpha is less than fully opaque.
         return ComposeOver(foreground, background);
     }
 

--- a/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
+++ b/CodeGlyphX/Rendering/Png/QrPngRenderer.Internal.SimpleRgba.cs
@@ -194,14 +194,7 @@ public static partial class QrPngRenderer {
     }
 
     private static Rgba32 CompositeForeground(Rgba32 foreground, Rgba32 background) {
-        if (foreground.A == 255 && background.A == 255) return foreground;
-        var sa = foreground.A;
-        var inv = 255 - sa;
-        var r = (byte)((foreground.R * sa + background.R * inv + 127) / 255);
-        var g = (byte)((foreground.G * sa + background.G * inv + 127) / 255);
-        var b = (byte)((foreground.B * sa + background.B * inv + 127) / 255);
-        var a = (byte)((sa + background.A * inv + 127) / 255);
-        return new Rgba32(r, g, b, a);
+        return ComposeOver(foreground, background);
     }
 
 }


### PR DESCRIPTION
## Summary
- fix straight-alpha compositing for QR PNG rendering paths
- preserve correct RGBA values for transparent backgrounds, simple modules, and logo overlays
- add regression coverage for transparent render output and transparent QR round-trip decoding

## Root Cause
The QR PNG renderer used compositing math that mixed source RGB directly against destination RGB without weighting the destination by its alpha. That produced incorrect stored RGB values under transparency, especially when rendering onto fully transparent backgrounds.

## Validation
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0
- dotnet test CodeGlyphX.Tests/CodeGlyphX.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~QrPngRendererTests|FullyQualifiedName~RoundTripTests"
- dotnet run --project CodeGlyphX.Examples/CodeGlyphX.Examples.csproj -c Release
- live PowerShell generation check: transparent background stayed alpha 0, QR modules kept alpha 128, and QR.TryDecodePng decoded the generated PNG successfully

## Notes
- The examples run still reports the pre-existing `QR (print)` size-limit failure for a very large PNG; this change does not touch that path.
