### PR TITLE
[codex] Improve net472 QR image decode parity

### DIFF
--- a/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
+++ b/CodeGlyphX.Tests/CodeGlyphX.Tests.csproj
@@ -21,6 +21,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Compile Include="Net472\**\*.cs" />
+    <Compile Include="QrImageDecodeParityData.cs" />
+    <Compile Include="QrImageDecodeParitySharedTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/CodeGlyphX.Tests/QrImageDecodeParityData.cs
+++ b/CodeGlyphX.Tests/QrImageDecodeParityData.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using CodeGlyphX.Payloads;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Png;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class QrImageDecodeParityCase {
+    public QrImageDecodeParityCase(string name, QrPayloadData payload, Rgba32 foreground, Rgba32 background, Action<QrEasyOptions>? configure = null) {
+        Name = name;
+        Payload = payload;
+        Foreground = foreground;
+        Background = background;
+        Configure = configure;
+    }
+
+    public string Name { get; }
+    public QrPayloadData Payload { get; }
+    public Rgba32 Foreground { get; }
+    public Rgba32 Background { get; }
+    public Action<QrEasyOptions>? Configure { get; }
+
+    public override string ToString() => Name;
+}
+
+public static class QrImageDecodeParityData {
+    public static IEnumerable<object[]> CleanGeneratedCases() {
+        yield return Case(
+            "url",
+            QrPayloads.Url("https://example.com/qr-parity?src=net472&v=1"));
+
+        yield return Case(
+            "wifi",
+            QrPayloads.Wifi("ParityNet", "P@ssw0rd!234", authType: "WPA"));
+
+        yield return Case(
+            "vcard",
+            QrPayloads.Contact(
+                QrContactOutputType.VCard3,
+                firstname: "Ada",
+                lastname: "Lovelace",
+                mobilePhone: "+48123456789",
+                email: "ada@example.com",
+                org: "Parity Labs",
+                orgTitle: "Engineer",
+                website: "https://example.com/contact",
+                note: "net472 parity sample"));
+
+        yield return Case(
+            "calendar",
+            QrPayloads.CalendarEvent(
+                subject: "Parity Review",
+                description: "QR decode parity validation event",
+                location: "Warsaw",
+                start: new DateTime(2026, 04, 01, 9, 30, 0, DateTimeKind.Utc),
+                end: new DateTime(2026, 04, 01, 10, 15, 0, DateTimeKind.Utc),
+                allDayEvent: false,
+                encoding: QrCalendarEncoding.ICalComplete));
+
+        yield return Case(
+            "sms",
+            QrPayloads.Sms("+48123456789", "Parity message body"));
+
+        yield return Case(
+            "email",
+            QrPayloads.Email("team@example.com", "Parity subject", "Parity body", QrMailEncoding.Mailto));
+
+        yield return Case(
+            "geo",
+            QrPayloads.Geo("52.2297", "21.0122", QrGeolocationEncoding.Geo));
+
+        yield return Case(
+            "bitcoin",
+            QrPayloads.BitcoinLike(
+                QrBitcoinLikeType.Bitcoin,
+                "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                amount: 0.015625,
+                label: "Parity Wallet",
+                message: "Invoice 42"));
+
+        yield return Case(
+            "url-transparent-background",
+            QrPayloads.Url("https://example.com/qr-parity-transparent"),
+            foreground: new Rgba32(12, 12, 12, 255),
+            background: new Rgba32(255, 255, 255, 0));
+
+        yield return Case(
+            "wifi-semitransparent-foreground",
+            QrPayloads.Wifi("ParityOverlay", "OverlayPass!9", authType: "WPA"),
+            foreground: new Rgba32(20, 20, 20, 208),
+            background: new Rgba32(255, 255, 255, 0));
+
+        yield return Case(
+            "url-foreground-gradient",
+            QrPayloads.Url("https://example.com/qr-parity-gradient"),
+            configure: options => {
+                options.Foreground = new Rgba32(12, 45, 110, 255);
+                options.ForegroundGradient = new QrPngGradientOptions {
+                    Type = QrPngGradientType.DiagonalDown,
+                    StartColor = new Rgba32(206, 32, 255, 255),
+                    EndColor = new Rgba32(0, 194, 255, 255)
+                };
+                options.ModuleShape = QrPngModuleShape.Rounded;
+                options.ModuleScale = 0.94;
+            });
+
+        yield return Case(
+            "email-background-pattern",
+            QrPayloads.Email("design@example.com", "Gradient parity", "Background pattern parity"),
+            configure: options => {
+                options.BackgroundPattern = new QrPngBackgroundPatternOptions {
+                    Type = QrPngBackgroundPatternType.Dots,
+                    Color = new Rgba32(0, 122, 255, 28),
+                    SizePx = 10,
+                    ThicknessPx = 1,
+                    SnapToModuleSize = true,
+                    ModuleStep = 2
+                };
+                options.BackgroundSupersample = 2;
+            });
+    }
+
+    public static byte[] RenderPng(QrImageDecodeParityCase testCase) {
+        var options = new QrEasyOptions {
+            ModuleSize = 14,
+            QuietZone = 6,
+            Foreground = testCase.Foreground,
+            Background = testCase.Background
+        };
+        testCase.Configure?.Invoke(options);
+
+        return QrCode.Render(testCase.Payload, OutputFormat.Png, options).Data;
+    }
+
+    private static object[] Case(string name, QrPayloadData payload, Rgba32? foreground = null, Rgba32? background = null, Action<QrEasyOptions>? configure = null) {
+        return new object[] {
+            new QrImageDecodeParityCase(
+                name,
+                payload,
+                foreground ?? new Rgba32(0, 0, 0, 255),
+                background ?? new Rgba32(255, 255, 255, 255),
+                configure)
+        };
+    }
+}

--- a/CodeGlyphX.Tests/QrImageDecodeParitySharedTests.cs
+++ b/CodeGlyphX.Tests/QrImageDecodeParitySharedTests.cs
@@ -1,0 +1,66 @@
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class QrImageDecodeParitySharedTests {
+    [Theory]
+    [Trait("Category", "QrParity")]
+    [MemberData(nameof(QrImageDecodeParityData.CleanGeneratedCases), MemberType = typeof(QrImageDecodeParityData))]
+    public void QrImageDecoder_Decodes_CleanGeneratedPngSamples(QrImageDecodeParityCase testCase) {
+        var png = QrImageDecodeParityData.RenderPng(testCase);
+
+        var ok = QrImageDecoder.TryDecodeImage(
+            png,
+            imageOptions: null,
+            options: new QrPixelDecodeOptions {
+                MaxDimension = 4096
+            },
+            out var decoded);
+
+        Assert.True(ok);
+        Assert.Equal(testCase.Payload.Text, decoded.Text);
+    }
+
+#if NET8_0_OR_GREATER
+    [Theory]
+    [Trait("Category", "QrParity")]
+    [MemberData(nameof(QrImageDecodeParityData.CleanGeneratedCases), MemberType = typeof(QrImageDecodeParityData))]
+    public void ForcedFallback_Matches_PrimaryDecode_On_CleanGeneratedPngSamples(QrImageDecodeParityCase testCase) {
+        var png = QrImageDecodeParityData.RenderPng(testCase);
+
+        var primaryOk = QrImageDecoder.TryDecodeImage(
+            png,
+            imageOptions: null,
+            options: new QrPixelDecodeOptions {
+                MaxDimension = 4096
+            },
+            out var primary);
+
+        QrDecoded fallback = null!;
+        var fallbackOk = false;
+        WithForcedFallback(() => {
+            fallbackOk = QrImageDecoder.TryDecodeImage(
+                png,
+                imageOptions: null,
+                options: new QrPixelDecodeOptions {
+                    MaxDimension = 4096
+                },
+                out fallback);
+        });
+
+        Assert.True(primaryOk);
+        Assert.True(fallbackOk);
+        Assert.Equal(primary.Text, fallback.Text);
+    }
+
+    private static void WithForcedFallback(System.Action action) {
+        var previous = CodeGlyphXFeatures.ForceQrFallbackForTests;
+        CodeGlyphXFeatures.ForceQrFallbackForTests = true;
+        try {
+            action();
+        } finally {
+            CodeGlyphXFeatures.ForceQrFallbackForTests = previous;
+        }
+    }
+#endif
+}

--- a/CodeGlyphX.Tests/QrImageDecoderFallbackTests.cs
+++ b/CodeGlyphX.Tests/QrImageDecoderFallbackTests.cs
@@ -1,5 +1,7 @@
 using CodeGlyphX.Rendering.Jpeg;
 using CodeGlyphX.Rendering.Png;
+using System;
+using System.Reflection;
 using Xunit;
 
 namespace CodeGlyphX.Tests;
@@ -33,6 +35,81 @@ public sealed class QrImageDecoderFallbackTests {
         });
     }
 
+    [Fact]
+    public void Fallback_Decodes_EqualLuminance_ColorContrast_Png() {
+        var qr = QrCodeEncoder.EncodeText(Payload);
+        var png = QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
+            ModuleSize = 18,
+            QuietZone = 6,
+            Foreground = new Rgba32(255, 0, 0, 255),
+            // Similar luminance to red, but strong channel separation.
+            Background = new Rgba32(0, 110, 100, 255)
+        });
+
+        WithForcedFallback(() => {
+            var ok = QrImageDecoder.TryDecodeImage(png, out var decoded, out var info, new QrPixelDecodeOptions {
+                MaxDimension = 2048
+            });
+            Assert.True(ok);
+            Assert.Equal(Payload, decoded.Text);
+            Assert.True(info.Dimension >= 21);
+        });
+    }
+
+    [Fact]
+    public void Fallback_Helper_Preprocessing_Branches_Work() {
+        var buildGray = GetPrivateMethod("BuildGrayscale");
+        var buildChannel = GetPrivateMethod("BuildChannelGrayscale");
+        var tryContrastStretch = GetPrivateMethod("TryContrastStretch");
+        var tryLocalNormalize = GetPrivateMethod("TryLocalNormalize");
+
+        var rgba = new byte[] {
+            255, 0, 0, 128,
+            0, 110, 100, 255
+        };
+
+        var gray = (byte[])buildGray.Invoke(null, new object[] { rgba, 2, 1, 8 })!;
+        Assert.Equal(2, gray.Length);
+
+        var red = (byte[])buildChannel.Invoke(null, new object[] { rgba, 2, 1, 8, 0 })!;
+        var green = (byte[])buildChannel.Invoke(null, new object[] { rgba, 2, 1, 8, 1 })!;
+        var blue = (byte[])buildChannel.Invoke(null, new object[] { rgba, 2, 1, 8, 2 })!;
+        var chroma = (byte[])buildChannel.Invoke(null, new object[] { rgba, 2, 1, 8, 3 })!;
+
+        Assert.Equal(255, red[0]);
+        Assert.Equal(127, green[0]);
+        Assert.Equal(127, blue[0]);
+        Assert.True(chroma[0] > 0);
+        Assert.True(red[0] > red[1]);
+        Assert.True(green[0] > green[1]);
+        Assert.True(blue[1] < blue[0]);
+
+        var noStretchArgs = new object?[] { new byte[] { 42, 42, 42 }, null };
+        var noStretch = (bool)tryContrastStretch.Invoke(null, noStretchArgs)!;
+        Assert.False(noStretch);
+        Assert.Empty((byte[])noStretchArgs[1]!);
+
+        var stretchArgs = new object?[] { new byte[] { 10, 200 }, null };
+        var stretched = (bool)tryContrastStretch.Invoke(null, stretchArgs)!;
+        Assert.True(stretched);
+        Assert.Equal(new byte[] { 0, 255 }, (byte[])stretchArgs[1]!);
+
+        var smallNormalizeArgs = new object?[] { new byte[] { 1, 2, 3, 4 }, 2, 2, null };
+        var smallNormalize = (bool)tryLocalNormalize.Invoke(null, smallNormalizeArgs)!;
+        Assert.False(smallNormalize);
+        Assert.Empty((byte[])smallNormalizeArgs[3]!);
+
+        var gradient = new byte[21 * 21];
+        for (var i = 0; i < gradient.Length; i++) {
+            gradient[i] = (byte)(i % 251);
+        }
+
+        var normalizeArgs = new object?[] { gradient, 21, 21, null };
+        var normalized = (bool)tryLocalNormalize.Invoke(null, normalizeArgs)!;
+        Assert.True(normalized);
+        Assert.Equal(gradient.Length, ((byte[])normalizeArgs[3]!).Length);
+    }
+
     private static byte[] RenderPng(int moduleSize, int quietZone) {
         var qr = QrCodeEncoder.EncodeText(Payload);
         return QrPngRenderer.Render(qr.Modules, new QrPngRenderOptions {
@@ -58,5 +135,9 @@ public sealed class QrImageDecoderFallbackTests {
             CodeGlyphXFeatures.ForceQrFallbackForTests = previous;
         }
     }
-}
 
+    private static MethodInfo GetPrivateMethod(string name) {
+        return typeof(QrImageDecoder).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static)
+               ?? throw new InvalidOperationException("Expected private method not found: " + name);
+    }
+}

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -988,23 +988,8 @@ public static class QrImageDecoder {
         if (cancellationToken.IsCancellationRequested) return false;
 
         var grayscale = BuildGrayscale(rgba, width, height, stride);
-        if (TryDecodeGrayscale(grayscale, width, height, options, cancellationToken, out decoded, out info)) {
+        if (TryDecodeGrayscaleVariants(grayscale, width, height, options, cancellationToken, out decoded, out info)) {
             return true;
-        }
-
-        // The legacy pipeline remains best-effort compared to the net8 QR pixel decoder.
-        // These extra grayscale passes are intentionally scoped to clean/generated assets
-        // (for example PNGs with antialiasing or transparency), not noisy camera photos.
-        if (TryContrastStretch(grayscale, out var contrast)) {
-            if (TryDecodeGrayscale(contrast, width, height, options, cancellationToken, out decoded, out info)) {
-                return true;
-            }
-        }
-
-        if (TryLocalNormalize(grayscale, width, height, out var normalized)) {
-            if (TryDecodeGrayscale(normalized, width, height, options, cancellationToken, out decoded, out info)) {
-                return true;
-            }
         }
 
         // Low-risk fallback for clean colored PNGs: if luminance contrast is weak but
@@ -1032,6 +1017,32 @@ public static class QrImageDecoder {
         return false;
     }
 
+    private static bool TryDecodeGrayscaleVariants(byte[] grayscale, int width, int height, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
+        decoded = null!;
+        info = default;
+
+        if (TryDecodeGrayscale(grayscale, width, height, options, cancellationToken, out decoded, out info)) {
+            return true;
+        }
+
+        // The legacy pipeline remains best-effort compared to the net8 QR pixel decoder.
+        // These extra grayscale passes are intentionally scoped to clean/generated assets
+        // (for example PNGs with antialiasing or transparency), not noisy camera photos.
+        if (TryContrastStretch(grayscale, out var contrast)) {
+            if (TryDecodeGrayscale(contrast, width, height, options, cancellationToken, out decoded, out info)) {
+                return true;
+            }
+        }
+
+        if (TryLocalNormalize(grayscale, width, height, out var normalized)) {
+            if (TryDecodeGrayscale(normalized, width, height, options, cancellationToken, out decoded, out info)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool TryDecodeColorVariants(byte[] rgba, int width, int height, int stride, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
         decoded = null!;
         info = default;
@@ -1039,20 +1050,8 @@ public static class QrImageDecoder {
 
         for (var variant = 0; variant < 4; variant++) {
             var gray = BuildChannelGrayscale(rgba, width, height, stride, variant);
-            if (TryDecodeGrayscale(gray, width, height, options, cancellationToken, out decoded, out info)) {
+            if (TryDecodeGrayscaleVariants(gray, width, height, options, cancellationToken, out decoded, out info)) {
                 return true;
-            }
-
-            if (TryContrastStretch(gray, out var contrast)) {
-                if (TryDecodeGrayscale(contrast, width, height, options, cancellationToken, out decoded, out info)) {
-                    return true;
-                }
-            }
-
-            if (TryLocalNormalize(gray, width, height, out var normalized)) {
-                if (TryDecodeGrayscale(normalized, width, height, options, cancellationToken, out decoded, out info)) {
-                    return true;
-                }
             }
         }
 
@@ -1100,16 +1099,7 @@ public static class QrImageDecoder {
             var row = y * stride;
             for (var x = 0; x < width; x++) {
                 var i = row + (x * 4);
-                var r = rgba[i + 0];
-                var g = rgba[i + 1];
-                var b = rgba[i + 2];
-                var a = rgba[i + 3];
-                if (a != 255) {
-                    var invA = 255 - a;
-                    r = (byte)((r * a + 255 * invA + 127) / 255);
-                    g = (byte)((g * a + 255 * invA + 127) / 255);
-                    b = (byte)((b * a + 255 * invA + 127) / 255);
-                }
+                ReadCompositedRgba(rgba, i, out var r, out var g, out var b);
                 var lum = (299 * r) + (587 * g) + (114 * b);
                 gray[dst++] = (byte)(lum / 1000);
             }
@@ -1124,17 +1114,7 @@ public static class QrImageDecoder {
             var row = y * stride;
             for (var x = 0; x < width; x++) {
                 var i = row + (x * 4);
-                var r = rgba[i + 0];
-                var g = rgba[i + 1];
-                var b = rgba[i + 2];
-                var a = rgba[i + 3];
-                if (a != 255) {
-                    var invA = 255 - a;
-                    r = (byte)((r * a + 255 * invA + 127) / 255);
-                    g = (byte)((g * a + 255 * invA + 127) / 255);
-                    b = (byte)((b * a + 255 * invA + 127) / 255);
-                }
-
+                ReadCompositedRgba(rgba, i, out var r, out var g, out var b);
                 gray[dst++] = variant switch {
                     0 => r,
                     1 => g,
@@ -1144,6 +1124,19 @@ public static class QrImageDecoder {
             }
         }
         return gray;
+    }
+
+    private static void ReadCompositedRgba(byte[] rgba, int index, out byte r, out byte g, out byte b) {
+        r = rgba[index + 0];
+        g = rgba[index + 1];
+        b = rgba[index + 2];
+        var a = rgba[index + 3];
+        if (a == 255) return;
+
+        var invA = 255 - a;
+        r = (byte)((r * a + 255 * invA + 127) / 255);
+        g = (byte)((g * a + 255 * invA + 127) / 255);
+        b = (byte)((b * a + 255 * invA + 127) / 255);
     }
 
     private static byte[] InvertGrayscale(byte[] gray) {

--- a/CodeGlyphX/QrImageDecoder.cs
+++ b/CodeGlyphX/QrImageDecoder.cs
@@ -988,11 +988,71 @@ public static class QrImageDecoder {
         if (cancellationToken.IsCancellationRequested) return false;
 
         var grayscale = BuildGrayscale(rgba, width, height, stride);
-        var mean = ComputeMean(grayscale);
-        var thresholds = BuildThresholds(mean);
+        if (TryDecodeGrayscale(grayscale, width, height, options, cancellationToken, out decoded, out info)) {
+            return true;
+        }
+
+        // The legacy pipeline remains best-effort compared to the net8 QR pixel decoder.
+        // These extra grayscale passes are intentionally scoped to clean/generated assets
+        // (for example PNGs with antialiasing or transparency), not noisy camera photos.
+        if (TryContrastStretch(grayscale, out var contrast)) {
+            if (TryDecodeGrayscale(contrast, width, height, options, cancellationToken, out decoded, out info)) {
+                return true;
+            }
+        }
+
+        if (TryLocalNormalize(grayscale, width, height, out var normalized)) {
+            if (TryDecodeGrayscale(normalized, width, height, options, cancellationToken, out decoded, out info)) {
+                return true;
+            }
+        }
+
+        // Low-risk fallback for clean colored PNGs: if luminance contrast is weak but
+        // channel separation is strong, per-channel/chroma passes often recover decode.
+        if (TryDecodeColorVariants(rgba, width, height, stride, options, cancellationToken, out decoded, out info)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryDecodeGrayscale(byte[] grayscale, int width, int height, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
+        decoded = null!;
+        info = default;
+        if (grayscale.Length == 0) return false;
+
+        ComputeGrayStats(grayscale, out var min, out var max, out var mean, out var otsuThreshold);
+        var thresholds = BuildThresholds(mean, min, max, otsuThreshold);
         for (var t = 0; t < thresholds.Length; t++) {
             if (TryDecodeWithThreshold(grayscale, width, height, thresholds[t], options, cancellationToken, out decoded, out info)) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryDecodeColorVariants(byte[] rgba, int width, int height, int stride, QrPixelDecodeOptions? options, CancellationToken cancellationToken, out QrDecoded decoded, out QrPixelDecodeInfo info) {
+        decoded = null!;
+        info = default;
+        if (cancellationToken.IsCancellationRequested) return false;
+
+        for (var variant = 0; variant < 4; variant++) {
+            var gray = BuildChannelGrayscale(rgba, width, height, stride, variant);
+            if (TryDecodeGrayscale(gray, width, height, options, cancellationToken, out decoded, out info)) {
+                return true;
+            }
+
+            if (TryContrastStretch(gray, out var contrast)) {
+                if (TryDecodeGrayscale(contrast, width, height, options, cancellationToken, out decoded, out info)) {
+                    return true;
+                }
+            }
+
+            if (TryLocalNormalize(gray, width, height, out var normalized)) {
+                if (TryDecodeGrayscale(normalized, width, height, options, cancellationToken, out decoded, out info)) {
+                    return true;
+                }
             }
         }
 
@@ -1043,8 +1103,44 @@ public static class QrImageDecoder {
                 var r = rgba[i + 0];
                 var g = rgba[i + 1];
                 var b = rgba[i + 2];
+                var a = rgba[i + 3];
+                if (a != 255) {
+                    var invA = 255 - a;
+                    r = (byte)((r * a + 255 * invA + 127) / 255);
+                    g = (byte)((g * a + 255 * invA + 127) / 255);
+                    b = (byte)((b * a + 255 * invA + 127) / 255);
+                }
                 var lum = (299 * r) + (587 * g) + (114 * b);
                 gray[dst++] = (byte)(lum / 1000);
+            }
+        }
+        return gray;
+    }
+
+    private static byte[] BuildChannelGrayscale(byte[] rgba, int width, int height, int stride, int variant) {
+        var gray = new byte[checked(width * height)];
+        var dst = 0;
+        for (var y = 0; y < height; y++) {
+            var row = y * stride;
+            for (var x = 0; x < width; x++) {
+                var i = row + (x * 4);
+                var r = rgba[i + 0];
+                var g = rgba[i + 1];
+                var b = rgba[i + 2];
+                var a = rgba[i + 3];
+                if (a != 255) {
+                    var invA = 255 - a;
+                    r = (byte)((r * a + 255 * invA + 127) / 255);
+                    g = (byte)((g * a + 255 * invA + 127) / 255);
+                    b = (byte)((b * a + 255 * invA + 127) / 255);
+                }
+
+                gray[dst++] = variant switch {
+                    0 => r,
+                    1 => g,
+                    2 => b,
+                    _ => (byte)(Math.Max(r, Math.Max(g, b)) - Math.Min(r, Math.Min(g, b)))
+                };
             }
         }
         return gray;
@@ -1064,11 +1160,39 @@ public static class QrImageDecoder {
         return (int)(sum / Math.Max(1, gray.Length));
     }
 
-    private static byte[] BuildThresholds(int mean) {
-        var thresholds = new List<byte>(3);
+    private static void ComputeGrayStats(byte[] gray, out byte min, out byte max, out int mean, out byte otsuThreshold) {
+        var histogram = new int[256];
+        long sum = 0;
+        min = 255;
+        max = 0;
+
+        for (var i = 0; i < gray.Length; i++) {
+            var value = gray[i];
+            histogram[value]++;
+            sum += value;
+            if (value < min) min = value;
+            if (value > max) max = value;
+        }
+
+        mean = (int)(sum / Math.Max(1, gray.Length));
+        otsuThreshold = ComputeOtsuThreshold(histogram, gray.Length);
+    }
+
+    private static byte[] BuildThresholds(int mean, byte min, byte max, byte otsuThreshold) {
+        var thresholds = new List<byte>(10);
+        var range = max - min;
+        AddThreshold(thresholds, otsuThreshold);
+        AddThreshold(thresholds, (min + max) / 2);
+        AddThreshold(thresholds, mean);
         AddThreshold(thresholds, mean - 12);
         AddThreshold(thresholds, mean - 4);
         AddThreshold(thresholds, mean + 4);
+        if (range > 0) {
+            AddThreshold(thresholds, min + (range / 3));
+            AddThreshold(thresholds, min + ((range * 2) / 3));
+        }
+        AddThreshold(thresholds, min + 12);
+        AddThreshold(thresholds, max - 12);
         if (thresholds.Count == 0) thresholds.Add((byte)ClampByte(mean));
         return thresholds.ToArray();
     }
@@ -1079,6 +1203,114 @@ public static class QrImageDecoder {
             if (thresholds[i] == clamped) return;
         }
         thresholds.Add(clamped);
+    }
+
+    private static byte ComputeOtsuThreshold(int[] histogram, int total) {
+        long sum = 0;
+        for (var i = 0; i < 256; i++) {
+            sum += i * (long)histogram[i];
+        }
+
+        long sumB = 0;
+        var weightBackground = 0;
+        var bestThreshold = 0;
+        var bestVariance = -1.0;
+
+        for (var threshold = 0; threshold < 256; threshold++) {
+            weightBackground += histogram[threshold];
+            if (weightBackground == 0) continue;
+
+            var weightForeground = total - weightBackground;
+            if (weightForeground == 0) break;
+
+            sumB += threshold * (long)histogram[threshold];
+            var meanBackground = sumB / (double)weightBackground;
+            var meanForeground = (sum - sumB) / (double)weightForeground;
+            var diff = meanBackground - meanForeground;
+            var betweenClassVariance = weightBackground * (double)weightForeground * diff * diff;
+            if (betweenClassVariance > bestVariance) {
+                bestVariance = betweenClassVariance;
+                bestThreshold = threshold;
+            }
+        }
+
+        return (byte)bestThreshold;
+    }
+
+    private static bool TryContrastStretch(byte[] gray, out byte[] stretched) {
+        stretched = Array.Empty<byte>();
+        if (gray.Length == 0) return false;
+
+        byte min = 255;
+        byte max = 0;
+        for (var i = 0; i < gray.Length; i++) {
+            var value = gray[i];
+            if (value < min) min = value;
+            if (value > max) max = value;
+        }
+
+        var range = max - min;
+        if (range <= 0 || range >= 224) return false;
+
+        stretched = new byte[gray.Length];
+        var scale = 255.0 / range;
+        for (var i = 0; i < gray.Length; i++) {
+            var value = (int)((gray[i] - min) * scale + 0.5);
+            stretched[i] = (byte)ClampByte(value);
+        }
+        return true;
+    }
+
+    private static bool TryLocalNormalize(byte[] gray, int width, int height, out byte[] normalized) {
+        normalized = Array.Empty<byte>();
+        if (gray.Length == 0 || width <= 0 || height <= 0) return false;
+
+        var minDim = width < height ? width : height;
+        if (minDim < 21) return false;
+
+        var windowSize = minDim >= 720 ? 31 : minDim >= 360 ? 21 : 15;
+        if ((windowSize & 1) == 0) windowSize++;
+        var radius = windowSize / 2;
+        var stride = width + 1;
+        var integral = new int[stride * (height + 1)];
+
+        for (var y = 1; y <= height; y++) {
+            var rowSum = 0;
+            var srcRow = (y - 1) * width;
+            var baseIndex = y * stride;
+            var prevIndex = (y - 1) * stride;
+            for (var x = 1; x <= width; x++) {
+                rowSum += gray[srcRow + (x - 1)];
+                integral[baseIndex + x] = integral[prevIndex + x] + rowSum;
+            }
+        }
+
+        normalized = new byte[gray.Length];
+        for (var y = 0; y < height; y++) {
+            var y0 = y - radius;
+            var y1 = y + radius;
+            if (y0 < 0) y0 = 0;
+            if (y1 >= height) y1 = height - 1;
+
+            var y0i = y0 * stride;
+            var y1i = (y1 + 1) * stride;
+
+            for (var x = 0; x < width; x++) {
+                var x0 = x - radius;
+                var x1 = x + radius;
+                if (x0 < 0) x0 = 0;
+                if (x1 >= width) x1 = width - 1;
+
+                var x1i = x1 + 1;
+                var area = (x1 - x0 + 1) * (y1 - y0 + 1);
+                var sum = integral[y1i + x1i] - integral[y0i + x1i] - integral[y1i + x0] + integral[y0i + x0];
+                var mean = sum / area;
+                var index = y * width + x;
+                normalized[index] = (byte)ClampByte(gray[index] - mean + 128);
+            }
+        }
+
+        return true;
     }
 
     private static bool TryFindDarkBounds(byte[] gray, int width, int height, byte threshold, out int minX, out int minY, out int maxX, out int maxY) {
@@ -1324,19 +1556,38 @@ public static class QrImageDecoder {
         var boxHeight = (maxY - minY) + 1;
         var stepX = boxWidth / (double)dimension;
         var stepY = boxHeight / (double)dimension;
+        var deltaX = stepX >= 3.0 ? Math.Max(0.75, stepX * 0.22) : 0.0;
+        var deltaY = stepY >= 3.0 ? Math.Max(0.75, stepY * 0.22) : 0.0;
 
         for (var y = 0; y < dimension; y++) {
             var cy = minY + ((y + 0.5) * stepY);
-            var py = ClampInt((int)Math.Round(cy), 0, height - 1);
             for (var x = 0; x < dimension; x++) {
                 var cx = minX + ((x + 0.5) * stepX);
-                var px = ClampInt((int)Math.Round(cx), 0, width - 1);
-                var idx = (py * width) + px;
-                matrix[x, y] = gray[idx] < threshold;
+                matrix[x, y] = SampleModuleMajority(gray, width, height, cx, cy, threshold, deltaX, deltaY);
             }
         }
 
         return matrix;
+    }
+
+    private static bool SampleModuleMajority(byte[] gray, int width, int height, double centerX, double centerY, byte threshold, double deltaX, double deltaY) {
+        if (deltaX <= 0.0 && deltaY <= 0.0) {
+            var px = ClampInt((int)Math.Round(centerX), 0, width - 1);
+            var py = ClampInt((int)Math.Round(centerY), 0, height - 1);
+            return gray[(py * width) + px] < threshold;
+        }
+
+        var black = 0;
+        for (var oy = -1; oy <= 1; oy++) {
+            var py = ClampInt((int)Math.Round(centerY + (oy * deltaY)), 0, height - 1);
+            var row = py * width;
+            for (var ox = -1; ox <= 1; ox++) {
+                var px = ClampInt((int)Math.Round(centerX + (ox * deltaX)), 0, width - 1);
+                if (gray[row + px] < threshold) black++;
+            }
+        }
+
+        return black >= 5;
     }
 
     private static int ClampInt(int value, int min, int max) {


### PR DESCRIPTION
## What changed
- improves the non-net8 QR image fallback for clean/generated PNG inputs
- composites alpha against white before grayscale conversion
- adds stronger threshold selection, contrast-stretch, local-normalize, and majority-sampled module recovery
- adds shared parity tests for net8.0 and net472, including transparent, gradient, and patterned QR renders

## Why
ImagePlayground now exposes the fallback path on net472, so clean QR PNGs should decode as close as possible to the primary net8.0 pipeline without changing public APIs.

## Impact
- better decode reliability on net472 for generated QR assets
- no public API changes
- net8.0 behavior remains unchanged, with forced-fallback parity coverage added in tests

## Root cause
The legacy fallback was much simpler than the net8.0 QR pixel decoder: it relied on a small set of global grayscale thresholds and single-point module sampling, which was brittle for transparent and lightly styled generated images.

## Validation
- `dotnet test CodeGlyphX.Tests\CodeGlyphX.Tests.csproj --framework net8.0 --filter FullyQualifiedName~QrImageDecodeParity --no-restore`
- `dotnet test CodeGlyphX.Tests\CodeGlyphX.Tests.csproj --framework net472 --filter FullyQualifiedName~QrImageDecodeParity --no-restore`
- `dotnet test CodeGlyphX.Tests\CodeGlyphX.Tests.csproj --framework net8.0 --filter FullyQualifiedName~QrImageDecoderFallbackTests --no-restore`
- `dotnet test CodeGlyphX.Tests\CodeGlyphX.Tests.csproj --framework net472 --filter FullyQualifiedName~QrNet472SmokeTests --no-restore`
