### PR TITLE
Refresh website workflows to latest PowerForge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,13 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,15 +16,15 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,11 +15,11 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 06fbc3f015c2da91bb1b49e1a1323c21aced7cdf
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- update website CI, deploy, and maintenance workflows to the current PSPublishModule reusable workflow SHA 263eb3ccc4e6948132a5bdd3df9a084501291f68
- move package-mode website runs to PowerForgeWeb-v1.0.0-preview-202603311925
- keep website automation aligned with the newer PowerForge bits before the Magick bump becomes a blocker

## Notes
- this is scoped to website pipeline targeting only