### PR TITLE
Enable agent readiness for CodeGlyphX website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,9 @@ jobs:
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
+      engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,7 @@ jobs:
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
     secrets:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,8 +22,9 @@ jobs:
       pipeline_config: Website/pipeline.json
       site_output_path: Website/_site
       post_deploy_pipeline_config: Website/pipeline.cloudflare.json
+      engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -21,6 +21,7 @@ jobs:
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -19,7 +19,8 @@ jobs:
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
+      engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -232,9 +232,20 @@
       "reportPath": "./_reports/optimize-report.json"
     },
     {
+      "task": "agent-ready",
+      "id": "agent-ready",
+      "dependsOn": "optimize-site",
+      "skipModes": ["dev"],
+      "operation": "prepare",
+      "config": "./site.json",
+      "siteRoot": "./_site",
+      "output": "./_reports/agent-ready.json",
+      "failOnFailures": true
+    },
+    {
       "task": "doctor",
       "id": "doctor-site",
-      "dependsOn": "optimize-site",
+      "dependsOn": "agent-ready",
       "skipModes": ["dev"],
       "config": "./site.json",
       "siteRoot": "./_site",

--- a/Website/pipeline.website-ci.json
+++ b/Website/pipeline.website-ci.json
@@ -210,6 +210,17 @@
       "cacheHeaders": true,
       "cacheHeadersOut": "_headers",
       "reportPath": "./_reports/optimize-report.json"
+    },
+    {
+      "task": "agent-ready",
+      "id": "agent-ready",
+      "dependsOn": "optimize-site",
+      "modes": ["ci"],
+      "operation": "prepare",
+      "config": "./site.json",
+      "siteRoot": "./_site",
+      "output": "./_reports/agent-ready.json",
+      "failOnFailures": true
     }
   ]
 }

--- a/Website/site.json
+++ b/Website/site.json
@@ -36,6 +36,9 @@
       { "Rel": "apple-touch-icon", "Href": "/codeglyphx-qr-icon.png" },
       { "Rel": "preconnect", "Href": "https://img.shields.io", "Crossorigin": "anonymous" },
       { "Rel": "dns-prefetch", "Href": "https://img.shields.io" }
+    ],
+    "Meta": [
+      { "Name": "robots", "Content": "index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1" }
     ]
   },
   "Social": {
@@ -61,6 +64,77 @@
     ],
     "OrganizationEmail": "support@evotec.xyz",
     "OrganizationContactUrl": "/faq/"
+  },
+  "AgentReadiness": {
+    "Enabled": true,
+    "HeadersPath": "_headers",
+    "LinkHeaders": true,
+    "Robots": true,
+    "SecurityHeaders": {
+      "Enabled": true,
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    },
+    "ContentSignals": {
+      "Enabled": true,
+      "Search": true,
+      "AiInput": true,
+      "AiTrain": false
+    },
+    "BotRules": [
+      { "UserAgent": "GPTBot", "Allow": "/" },
+      { "UserAgent": "ChatGPT-User", "Allow": "/" },
+      { "UserAgent": "OAI-SearchBot", "Allow": "/" },
+      { "UserAgent": "ClaudeBot", "Allow": "/" },
+      { "UserAgent": "Claude-SearchBot", "Allow": "/" },
+      { "UserAgent": "Claude-User", "Allow": "/" },
+      { "UserAgent": "PerplexityBot", "Allow": "/" },
+      { "UserAgent": "Perplexity-User", "Allow": "/" },
+      { "UserAgent": "Google-Extended", "Allow": "/" },
+      { "UserAgent": "Applebot-Extended", "Allow": "/" },
+      { "UserAgent": "Meta-ExternalAgent", "Allow": "/" },
+      { "UserAgent": "Amazonbot", "Allow": "/" },
+      { "UserAgent": "CCBot", "Allow": "/" }
+    ],
+    "ApiCatalog": {
+      "Enabled": true,
+      "Entries": [
+        { "Anchor": "/api/", "ServiceDesc": "/api/index.json", "ServiceDoc": "/api/", "Title": "CodeGlyphX API Reference" }
+      ]
+    },
+    "AgentSkills": {
+      "Enabled": true,
+      "Skills": [
+        {
+          "Name": "codeglyphx-site-assistant",
+          "Type": "skill-md",
+          "Description": "Use CodeGlyphX documentation, API reference, sitemap, and llms files.",
+          "Content": "---\nname: codeglyphx-site-assistant\ndescription: Use CodeGlyphX documentation, API reference, sitemap, and llms resources.\n---\n\n# CodeGlyphX Site Assistant\n\nUse this skill when answering questions about CodeGlyphX.\n\n- Prefer canonical pages from https://codeglyphx.com.\n- Use `/docs/` for product and workflow guidance.\n- Use `/api/` for .NET API reference.\n- Check `/llms.txt`, `/llms.json`, and `/llms-full.txt` when present for agent-readable summaries.\n- Check `/.well-known/api-catalog` before assuming API documentation paths.\n- Respect `/robots.txt` and Content-Signal preferences.\n"
+        }
+      ]
+    },
+    "AgentsJson": {
+      "Enabled": true,
+      "Description": "Agent-facing discovery metadata for CodeGlyphX documentation, API reference, and support resources."
+    },
+    "A2AAgentCard": {
+      "Enabled": true,
+      "Name": "CodeGlyphX Documentation Discovery",
+      "Description": "Discover CodeGlyphX documentation, API reference, llms summaries, sitemap, and project resources.",
+      "Url": "/",
+      "DocumentationUrl": "/docs/",
+      "Skills": [
+        {
+          "Id": "documentation-discovery",
+          "Name": "Documentation discovery",
+          "Description": "Find CodeGlyphX product documentation, API reference, release resources, and support pages.",
+          "Tags": ["documentation", "api-reference", "sitemap", "llms"]
+        }
+      ]
+    },
+    "McpServerCard": { "Enabled": false },
+    "OpenApi": { "Enabled": false },
+    "WebMcp": false,
+    "MarkdownNegotiation": true
   },
   "EditLinks": {
     "Enabled": true,

--- a/Website/site.json
+++ b/Website/site.json
@@ -72,7 +72,7 @@
     "Robots": true,
     "SecurityHeaders": {
       "Enabled": true,
-      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     },
     "ContentSignals": {
       "Enabled": true,


### PR DESCRIPTION
## Summary
- Enable PowerForge agent readiness for CodeGlyphX with robots, Content-Signal, Link headers, security headers, API catalog, Agent Skills, agents.json, A2A card, and markdown negotiation config.
- Add agent-ready preparation to deployment and PR website pipelines.
- Run website workflows in source engine mode against the updated PowerForge agent-readiness implementation.

## Validation
- Parsed Website/site.json, Website/pipeline.json, and Website/pipeline.website-ci.json with ConvertFrom-Json.
- Ran git diff --check.
- Ran agent-ready prepare against the current built _site successfully.
- Ran a temp PowerForge build and confirmed the robots meta renders.
