### PR TITLE
Pin website workflows to merged PowerForge engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,14 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@10757f12978162b54ac314b512a3a77e227502fd
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
+      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@10757f12978162b54ac314b512a3a77e227502fd
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -25,8 +25,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
+      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,13 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@10757f12978162b54ac314b512a3a77e227502fd
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
+      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- pin PowerForge website reusable workflows to PSPublishModule merge commit 10757f12978162b54ac314b512a3a77e227502fd
- pin source-mode website runs to the same engine commit
- remove stale PowerForgeWeb binary tag inputs where source mode is explicit

## Validation
- git diff --check