### PR TITLE
Fix DataMatrix generation

### DIFF
--- a/CodeGlyphX.Tests/DataMatrixDecoderTests.cs
+++ b/CodeGlyphX.Tests/DataMatrixDecoderTests.cs
@@ -7,6 +7,35 @@ namespace CodeGlyphX.Tests;
 
 public class DataMatrixDecoderTests {
     [Fact]
+    public void DataMatrix_Encode_SingleCharacter_UsesIsoTimingPattern() {
+        var matrix = DataMatrixEncoder.Encode("A");
+
+        Assert.Equal(10, matrix.Width);
+        Assert.Equal(10, matrix.Height);
+
+        for (var x = 0; x < matrix.Width; x++) {
+            Assert.Equal((x & 1) == 0, matrix[x, 0]);
+            Assert.True(matrix[x, matrix.Height - 1]);
+        }
+
+        for (var y = 1; y < matrix.Height - 1; y++) {
+            Assert.True(matrix[0, y]);
+            Assert.Equal((y & 1) != 0, matrix[matrix.Width - 1, y]);
+        }
+
+        Assert.True(DataMatrixDecoder.TryDecode(matrix, out var text));
+        Assert.Equal("A", text);
+    }
+
+    [Fact]
+    public void DataMatrix_ReedSolomon_ForSingleAsciiSymbol_UsesIso16022Roots() {
+        var divisor = DataMatrixReedSolomon.ComputeDivisor(5);
+        var ecc = DataMatrixReedSolomon.ComputeRemainder(new byte[] { 66, 129, 71 }, divisor);
+
+        Assert.Equal(new byte[] { 180, 133, 93, 98, 187 }, ecc);
+    }
+
+    [Fact]
     public void DataMatrix_Decode_C40_Basic() {
         var codewords = EncodeTripletMode(230, 14, 15, 16, 5, 6, 7); // ABC123
         var text = DataMatrixDecoder.DecodeDataCodewords(codewords);

--- a/CodeGlyphX/DataMatrix/DataMatrixEncoder.cs
+++ b/CodeGlyphX/DataMatrix/DataMatrixEncoder.cs
@@ -297,9 +297,11 @@ public static class DataMatrixEncoder {
                     matrix[startCol + x, startRow + regionTotalRows - 1] = true;
                 }
                 // Left border (solid) + Right border (alternating)
+                // Right column: dark at odd y (continues the clock track from the top timing row,
+                // which ends light at x=N-1 for all even-width ECC200 symbols).
                 for (var y = 1; y < regionTotalRows - 1; y++) {
                     matrix[startCol, startRow + y] = true;
-                    matrix[startCol + regionTotalCols - 1, startRow + y] = (y & 1) == 0;
+                    matrix[startCol + regionTotalCols - 1, startRow + y] = (y & 1) != 0;
                 }
 
                 for (var y = 0; y < regionDataRows; y++) {

--- a/CodeGlyphX/DataMatrix/DataMatrixReedSolomon.cs
+++ b/CodeGlyphX/DataMatrix/DataMatrixReedSolomon.cs
@@ -25,7 +25,7 @@ internal static class DataMatrixReedSolomon {
         var result = new byte[degree];
         result[degree - 1] = 1;
 
-        byte root = 1;
+        byte root = 2; // ISO 16022: generator roots start at α¹, not α⁰
         for (var i = 0; i < degree; i++) {
             for (var j = 0; j < result.Length; j++) {
                 result[j] = Multiply(result[j], root);

--- a/CodeGlyphX/DataMatrix/DataMatrixReedSolomonDecoder.cs
+++ b/CodeGlyphX/DataMatrix/DataMatrixReedSolomonDecoder.cs
@@ -12,7 +12,7 @@ internal static class DataMatrixReedSolomonDecoder {
         var hasError = false;
         for (var i = 0; i < eccLen; i++) {
             var eval = (byte)0;
-            var x = DataMatrixReedSolomon.ExpOf(i);
+            var x = DataMatrixReedSolomon.ExpOf(i + 1); // ISO 16022: evaluate at α¹…α^n, not α⁰…α^(n-1)
             for (var j = 0; j < codewords.Length; j++) eval = (byte)(DataMatrixReedSolomon.Multiply(eval, x) ^ codewords[j]);
             syndromes[i] = eval;
             if (eval != 0) hasError = true;
@@ -104,7 +104,7 @@ internal static class DataMatrixReedSolomonDecoder {
         // Verify
         for (var i = 0; i < eccLen; i++) {
             var eval = (byte)0;
-            var x = DataMatrixReedSolomon.ExpOf(i);
+            var x = DataMatrixReedSolomon.ExpOf(i + 1); // ISO 16022: evaluate at α¹…α^n, not α⁰…α^(n-1)
             for (var j = 0; j < codewords.Length; j++) eval = (byte)(DataMatrixReedSolomon.Multiply(eval, x) ^ codewords[j]);
             if (eval != 0) return false;
         }


### PR DESCRIPTION
- Reed-Solomon generator polynomial used wrong roots
- All ECC200 symbols have even width, so the top timing row always ends light at the top-right corner


Fixes #144.
