### PR TITLE
Add matrix barcode render helpers

### DIFF
--- a/CodeGlyphX.Tests/MatrixApiTests.cs
+++ b/CodeGlyphX.Tests/MatrixApiTests.cs
@@ -1,10 +1,40 @@
 using CodeGlyphX.Pdf417;
 using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace CodeGlyphX.Tests;
 
 public sealed class MatrixApiTests {
+    public static IEnumerable<object[]> MatrixFormats {
+        get {
+            yield return new object[] { OutputFormat.Png, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Svg, OutputKind.Text };
+            yield return new object[] { OutputFormat.Svgz, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Html, OutputKind.Text };
+            yield return new object[] { OutputFormat.Jpeg, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Webp, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Bmp, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Gif, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Tiff, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Ppm, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Pbm, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Pgm, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Pam, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Xbm, OutputKind.Text };
+            yield return new object[] { OutputFormat.Xpm, OutputKind.Text };
+            yield return new object[] { OutputFormat.Tga, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Ico, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Pdf, OutputKind.Binary };
+            yield return new object[] { OutputFormat.Eps, OutputKind.Text };
+            yield return new object[] { OutputFormat.Ascii, OutputKind.Text };
+        }
+    }
+
     [Fact]
     public void DataMatrixCode_Png_RoundTrip() {
         var png = DataMatrixCode.Render("DM-HELLO", OutputFormat.Png).Data;
@@ -51,5 +81,159 @@ public sealed class MatrixApiTests {
         Assert.Equal("123", decoded.Macro!.FileId);
         Assert.True(decoded.Macro.IsLastSegment);
         Assert.Equal("macro.txt", decoded.Macro.FileName);
+    }
+
+    [Fact]
+    public void MatrixBarcode_Save_DataMatrix_ByExtension() {
+        var path = Path.Combine(Path.GetTempPath(), "codeglyphx-matrix-barcode-" + Guid.NewGuid().ToString("N") + ".png");
+        try {
+            MatrixBarcode.Save(BarcodeType.DataMatrix, "DM-FACADE", path);
+
+            Assert.True(File.Exists(path));
+            Assert.True(DataMatrixCode.TryDecodePngFile(path, out var text));
+            Assert.Equal("DM-FACADE", text);
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void MatrixBarcode_Render_Pdf417_AsSvg() {
+        var output = MatrixBarcode.Render(BarcodeType.PDF417, "PDF-FACADE", OutputFormat.Svg);
+
+        Assert.Equal(OutputKind.Text, output.Kind);
+        Assert.Contains("<svg", output.GetText(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [MemberData(nameof(MatrixFormats))]
+    public void MatrixBarcode_Render_AllSupportedFormats_ProducesExpectedKind(OutputFormat format, OutputKind kind) {
+        var options = new MatrixOptions {
+            ModuleSize = 2,
+            QuietZone = 1,
+            JpegQuality = 75,
+            WebpQuality = 80,
+            IcoSizes = new[] { 16 },
+            IcoPreserveAspectRatio = false,
+            HtmlEmailSafeTable = true
+        };
+
+        var output = MatrixBarcode.Render(BarcodeType.DataMatrix, "DM-FORMATS", format, options);
+
+        Assert.Equal(format, output.Format);
+        Assert.Equal(kind, output.Kind);
+        Assert.NotEmpty(output.Data);
+    }
+
+    [Theory]
+    [InlineData(OutputFormat.Svg, OutputKind.Text)]
+    [InlineData(OutputFormat.Html, OutputKind.Text)]
+    [InlineData(OutputFormat.Ico, OutputKind.Binary)]
+    public void DataMatrixCode_Render_UsesSharedMatrixOptions(OutputFormat format, OutputKind kind) {
+        var output = DataMatrixCode.Render("DM-OPTIONS", format, options: new MatrixOptions {
+            ModuleSize = 2,
+            QuietZone = 1,
+            IcoSizes = new[] { 16 },
+            HtmlEmailSafeTable = true
+        });
+
+        Assert.Equal(kind, output.Kind);
+        Assert.NotEmpty(output.Data);
+    }
+
+    [Theory]
+    [InlineData(OutputFormat.Svg, OutputKind.Text)]
+    [InlineData(OutputFormat.Html, OutputKind.Text)]
+    [InlineData(OutputFormat.Ico, OutputKind.Binary)]
+    public void Pdf417Code_Render_UsesSharedMatrixOptions(OutputFormat format, OutputKind kind) {
+        var output = Pdf417Code.Render("PDF-OPTIONS", format, renderOptions: new MatrixOptions {
+            ModuleSize = 2,
+            QuietZone = 1,
+            IcoSizes = new[] { 16 },
+            HtmlEmailSafeTable = true
+        });
+
+        Assert.Equal(kind, output.Kind);
+        Assert.NotEmpty(output.Data);
+    }
+
+    [Fact]
+    public void MatrixBarcode_Render_AsAscii_HonorsMatrixQuietZone() {
+        var modules = MatrixBarcode.Encode(BarcodeType.DataMatrix, "DM-ASCII");
+        var output = MatrixBarcode.Render(modules, OutputFormat.Ascii, new MatrixOptions { QuietZone = 0 });
+        var lines = SplitLines(output.GetText());
+
+        Assert.Equal(OutputKind.Text, output.Kind);
+        Assert.Equal(modules.Height, lines.Length);
+        Assert.All(lines, line => Assert.Equal(modules.Width * 2, line.Length));
+    }
+
+    [Fact]
+    public void AztecCode_Render_AsAscii_HonorsMatrixQuietZone() {
+        var modules = AztecCode.Encode("AZTEC-ASCII");
+        var output = AztecCode.Render("AZTEC-ASCII", OutputFormat.Ascii, renderOptions: new MatrixOptions { QuietZone = 0 });
+        var lines = SplitLines(output.GetText());
+
+        Assert.Equal(modules.Height, lines.Length);
+        Assert.All(lines, line => Assert.Equal(modules.Width * 2, line.Length));
+    }
+
+    [Fact]
+    public void MatrixBarcode_Render_AsAscii_PreservesExplicitAsciiOptions() {
+        var modules = MatrixBarcode.Encode(BarcodeType.DataMatrix, "DM-ASCII-EXTRAS");
+        var extras = new RenderExtras {
+            MatrixAscii = new MatrixAsciiRenderOptions {
+                QuietZone = 1,
+                ModuleWidth = 1,
+                Dark = "X",
+                Light = "."
+            }
+        };
+
+        var output = MatrixBarcode.Render(modules, OutputFormat.Ascii, new MatrixOptions { QuietZone = 0 }, extras);
+        var lines = SplitLines(output.GetText());
+
+        Assert.Equal(modules.Height + 2, lines.Length);
+        Assert.All(lines, line => Assert.Equal(modules.Width + 2, line.Length));
+        Assert.True(lines.First().All(c => c == '.'));
+    }
+
+    [Fact]
+    public void MatrixBarcode_Render_Html_WrapsTitle() {
+        var output = MatrixBarcode.Render(
+            BarcodeType.DataMatrix,
+            "DM-HTML",
+            OutputFormat.Html,
+            extras: new RenderExtras { HtmlTitle = "Matrix title" });
+
+        Assert.Equal(OutputKind.Text, output.Kind);
+        Assert.Contains("<title>Matrix title</title>", output.GetText(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MatrixBarcode_Save_Stream_WritesTextFormat() {
+        using var stream = new MemoryStream();
+
+        MatrixBarcode.Save(BarcodeType.PDF417, "PDF-STREAM", stream, OutputFormat.Svg);
+
+        Assert.True(stream.Length > 0);
+    }
+
+    [Fact]
+    public void MatrixBarcode_Render_RejectsNullModules() {
+        Assert.Throws<ArgumentNullException>(() => MatrixBarcode.Render(null!, OutputFormat.Png));
+    }
+
+    [Fact]
+    public void MatrixBarcode_Render_RejectsUnknownFormat() {
+        var modules = MatrixBarcode.Encode(BarcodeType.DataMatrix, "DM-UNKNOWN");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => MatrixBarcode.Render(modules, OutputFormat.Unknown));
+    }
+
+    private static string[] SplitLines(string text) {
+        return text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
     }
 }

--- a/CodeGlyphX/AztecCode.Render.cs
+++ b/CodeGlyphX/AztecCode.Render.cs
@@ -1,26 +1,6 @@
 using System;
 using CodeGlyphX.Aztec;
 using CodeGlyphX.Rendering;
-using CodeGlyphX.Rendering.Ascii;
-using CodeGlyphX.Rendering.Bmp;
-using CodeGlyphX.Rendering.Eps;
-using CodeGlyphX.Rendering.Gif;
-using CodeGlyphX.Rendering.Html;
-using CodeGlyphX.Rendering.Ico;
-using CodeGlyphX.Rendering.Jpeg;
-using CodeGlyphX.Rendering.Pam;
-using CodeGlyphX.Rendering.Pbm;
-using CodeGlyphX.Rendering.Pdf;
-using CodeGlyphX.Rendering.Pgm;
-using CodeGlyphX.Rendering.Ppm;
-using CodeGlyphX.Rendering.Png;
-using CodeGlyphX.Rendering.Svg;
-using CodeGlyphX.Rendering.Svgz;
-using CodeGlyphX.Rendering.Tga;
-using CodeGlyphX.Rendering.Tiff;
-using CodeGlyphX.Rendering.Webp;
-using CodeGlyphX.Rendering.Xbm;
-using CodeGlyphX.Rendering.Xpm;
 
 namespace CodeGlyphX;
 
@@ -34,73 +14,6 @@ public static partial class AztecCode {
     }
 
     private static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? renderOptions, RenderExtras? extras) {
-        if (modules is null) throw new ArgumentNullException(nameof(modules));
-        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
-
-        var pngOptions = ToPngOptions(renderOptions);
-        switch (format) {
-            case OutputFormat.Png:
-                return RenderedOutput.FromBinary(format, MatrixPngRenderer.Render(modules, pngOptions));
-            case OutputFormat.Svg:
-                return RenderedOutput.FromText(format, MatrixSvgRenderer.Render(modules, ToSvgOptions(renderOptions)));
-            case OutputFormat.Svgz:
-                return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, ToSvgOptions(renderOptions)));
-            case OutputFormat.Html: {
-                var html = MatrixHtmlRenderer.Render(modules, ToHtmlOptions(renderOptions));
-                var title = extras?.HtmlTitle;
-                if (!string.IsNullOrEmpty(title)) {
-                    html = html.WrapHtml(title);
-                }
-                return RenderedOutput.FromText(format, html);
-            }
-            case OutputFormat.Jpeg: {
-                var jpegOptions = renderOptions?.JpegOptions;
-                var data = jpegOptions is null
-                    ? MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85)
-                    : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
-                return RenderedOutput.FromBinary(format, data);
-            }
-            case OutputFormat.Webp: {
-                var quality = renderOptions?.WebpQuality ?? 100;
-                if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {
-                    return RenderedOutput.FromBinary(format, webp);
-                }
-                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
-            }
-            case OutputFormat.Bmp:
-                return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
-            case OutputFormat.Gif: {
-                if (RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)) {
-                    return RenderedOutput.FromBinary(format, gif);
-                }
-                return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));
-            }
-            case OutputFormat.Tiff:
-                return RenderedOutput.FromBinary(format, MatrixTiffRenderer.Render(modules, pngOptions, extras?.TiffCompression ?? TiffCompressionMode.Auto));
-            case OutputFormat.Ppm:
-                return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pbm:
-                return RenderedOutput.FromBinary(format, MatrixPbmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pgm:
-                return RenderedOutput.FromBinary(format, MatrixPgmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pam:
-                return RenderedOutput.FromBinary(format, MatrixPamRenderer.Render(modules, pngOptions));
-            case OutputFormat.Xbm:
-                return RenderedOutput.FromText(format, MatrixXbmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Xpm:
-                return RenderedOutput.FromText(format, MatrixXpmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Tga:
-                return RenderedOutput.FromBinary(format, MatrixTgaRenderer.Render(modules, pngOptions));
-            case OutputFormat.Ico:
-                return RenderedOutput.FromBinary(format, MatrixIcoRenderer.Render(modules, pngOptions, ToIcoOptions(renderOptions)));
-            case OutputFormat.Pdf:
-                return RenderedOutput.FromBinary(format, MatrixPdfRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
-            case OutputFormat.Eps:
-                return RenderedOutput.FromText(format, MatrixEpsRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
-            case OutputFormat.Ascii:
-                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(modules, extras?.MatrixAscii ?? new MatrixAsciiRenderOptions()));
-            default:
-                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
-        }
+        return MatrixOutputRenderer.Render(modules, format, renderOptions, extras);
     }
 }

--- a/CodeGlyphX/DataMatrixCode.Decode.cs
+++ b/CodeGlyphX/DataMatrixCode.Decode.cs
@@ -764,42 +764,19 @@ public static partial class DataMatrixCode {
     }
 
     private static MatrixPngRenderOptions BuildPngOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new MatrixPngRenderOptions {
-            ModuleSize = opts.ModuleSize,
-            QuietZone = opts.QuietZone,
-            Foreground = opts.Foreground,
-            Background = opts.Background
-        };
+        return MatrixRenderOptionsBuilder.BuildPng(options);
     }
 
     private static IcoRenderOptions BuildIcoOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new IcoRenderOptions {
-            Sizes = opts.IcoSizes ?? new[] { 16, 32, 48, 64, 128, 256 },
-            PreserveAspectRatio = opts.IcoPreserveAspectRatio
-        };
+        return MatrixRenderOptionsBuilder.BuildIco(options);
     }
 
     private static MatrixSvgRenderOptions BuildSvgOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new MatrixSvgRenderOptions {
-            ModuleSize = opts.ModuleSize,
-            QuietZone = opts.QuietZone,
-            DarkColor = ColorUtils.ToCss(opts.Foreground),
-            LightColor = ColorUtils.ToCss(opts.Background)
-        };
+        return MatrixRenderOptionsBuilder.BuildSvg(options);
     }
 
     private static MatrixHtmlRenderOptions BuildHtmlOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new MatrixHtmlRenderOptions {
-            ModuleSize = opts.ModuleSize,
-            QuietZone = opts.QuietZone,
-            DarkColor = ColorUtils.ToCss(opts.Foreground),
-            LightColor = ColorUtils.ToCss(opts.Background),
-            EmailSafeTable = opts.HtmlEmailSafeTable
-        };
+        return MatrixRenderOptionsBuilder.BuildHtml(options);
     }
 
 }

--- a/CodeGlyphX/DataMatrixCode.Render.cs
+++ b/CodeGlyphX/DataMatrixCode.Render.cs
@@ -1,26 +1,6 @@
 using System;
 using CodeGlyphX.DataMatrix;
 using CodeGlyphX.Rendering;
-using CodeGlyphX.Rendering.Ascii;
-using CodeGlyphX.Rendering.Bmp;
-using CodeGlyphX.Rendering.Eps;
-using CodeGlyphX.Rendering.Gif;
-using CodeGlyphX.Rendering.Html;
-using CodeGlyphX.Rendering.Ico;
-using CodeGlyphX.Rendering.Jpeg;
-using CodeGlyphX.Rendering.Pam;
-using CodeGlyphX.Rendering.Pbm;
-using CodeGlyphX.Rendering.Pdf;
-using CodeGlyphX.Rendering.Pgm;
-using CodeGlyphX.Rendering.Ppm;
-using CodeGlyphX.Rendering.Png;
-using CodeGlyphX.Rendering.Svg;
-using CodeGlyphX.Rendering.Svgz;
-using CodeGlyphX.Rendering.Tga;
-using CodeGlyphX.Rendering.Tiff;
-using CodeGlyphX.Rendering.Webp;
-using CodeGlyphX.Rendering.Xbm;
-using CodeGlyphX.Rendering.Xpm;
 
 namespace CodeGlyphX;
 
@@ -52,73 +32,6 @@ public static partial class DataMatrixCode {
 #endif
 
     private static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? options, RenderExtras? extras) {
-        if (modules is null) throw new ArgumentNullException(nameof(modules));
-        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
-
-        var pngOptions = BuildPngOptions(options);
-        switch (format) {
-            case OutputFormat.Png:
-                return RenderedOutput.FromBinary(format, MatrixPngRenderer.Render(modules, pngOptions));
-            case OutputFormat.Svg:
-                return RenderedOutput.FromText(format, MatrixSvgRenderer.Render(modules, BuildSvgOptions(options)));
-            case OutputFormat.Svgz:
-                return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, BuildSvgOptions(options)));
-            case OutputFormat.Html: {
-                var html = MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(options));
-                var title = extras?.HtmlTitle;
-                if (!string.IsNullOrEmpty(title)) {
-                    html = html.WrapHtml(title);
-                }
-                return RenderedOutput.FromText(format, html);
-            }
-            case OutputFormat.Jpeg: {
-                var jpegOptions = options?.JpegOptions;
-                var data = jpegOptions is null
-                    ? MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85)
-                    : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
-                return RenderedOutput.FromBinary(format, data);
-            }
-            case OutputFormat.Webp: {
-                var quality = options?.WebpQuality ?? 100;
-                if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {
-                    return RenderedOutput.FromBinary(format, webp);
-                }
-                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
-            }
-            case OutputFormat.Bmp:
-                return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
-            case OutputFormat.Gif: {
-                if (RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)) {
-                    return RenderedOutput.FromBinary(format, gif);
-                }
-                return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));
-            }
-            case OutputFormat.Tiff:
-                return RenderedOutput.FromBinary(format, MatrixTiffRenderer.Render(modules, pngOptions, extras?.TiffCompression ?? TiffCompressionMode.Auto));
-            case OutputFormat.Ppm:
-                return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pbm:
-                return RenderedOutput.FromBinary(format, MatrixPbmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pgm:
-                return RenderedOutput.FromBinary(format, MatrixPgmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pam:
-                return RenderedOutput.FromBinary(format, MatrixPamRenderer.Render(modules, pngOptions));
-            case OutputFormat.Xbm:
-                return RenderedOutput.FromText(format, MatrixXbmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Xpm:
-                return RenderedOutput.FromText(format, MatrixXpmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Tga:
-                return RenderedOutput.FromBinary(format, MatrixTgaRenderer.Render(modules, pngOptions));
-            case OutputFormat.Ico:
-                return RenderedOutput.FromBinary(format, MatrixIcoRenderer.Render(modules, pngOptions, BuildIcoOptions(options)));
-            case OutputFormat.Pdf:
-                return RenderedOutput.FromBinary(format, MatrixPdfRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
-            case OutputFormat.Eps:
-                return RenderedOutput.FromText(format, MatrixEpsRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
-            case OutputFormat.Ascii:
-                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(modules, extras?.MatrixAscii ?? new MatrixAsciiRenderOptions()));
-            default:
-                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
-        }
+        return MatrixOutputRenderer.Render(modules, format, options, extras);
     }
 }

--- a/CodeGlyphX/MatrixBarcode.cs
+++ b/CodeGlyphX/MatrixBarcode.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using CodeGlyphX.Rendering;
+
+namespace CodeGlyphX;
+
+/// <summary>
+/// Simple helpers for matrix and stacked barcode symbologies.
+/// </summary>
+/// <remarks>
+/// Use <see cref="Save(CodeGlyphX.BarcodeType,string,string,CodeGlyphX.MatrixOptions,CodeGlyphX.Rendering.RenderExtras)"/> to pick the output format by file extension.
+/// </remarks>
+/// <example>
+/// <code>
+/// using CodeGlyphX;
+/// MatrixBarcode.Save(BarcodeType.DataMatrix, "ORDER-12345", "datamatrix.png");
+/// MatrixBarcode.Save(BarcodeType.PDF417, "DOCUMENT-12345", "pdf417.svg");
+/// </code>
+/// </example>
+public static class MatrixBarcode {
+    /// <summary>
+    /// Encodes a matrix or stacked barcode.
+    /// </summary>
+    public static BitMatrix Encode(BarcodeType type, string content) {
+        return MatrixBarcodeEncoder.Encode(type, content);
+    }
+
+    /// <summary>
+    /// Renders a matrix or stacked barcode to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(BarcodeType type, string content, OutputFormat format, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var modules = Encode(type, content);
+        return Render(modules, format, options, extras);
+    }
+
+    /// <summary>
+    /// Renders a matrix or stacked barcode to the requested output format.
+    /// </summary>
+    public static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? options = null, RenderExtras? extras = null) {
+        return MatrixOutputRenderer.Render(modules, format, options, extras);
+    }
+
+    /// <summary>
+    /// Saves a matrix or stacked barcode to a file based on the file extension.
+    /// Defaults to PNG when no extension is provided.
+    /// </summary>
+    public static string Save(BarcodeType type, string content, string path, MatrixOptions? options = null, RenderExtras? extras = null) {
+        var format = OutputFormatInfo.Resolve(path, OutputFormat.Png);
+        var output = Render(type, content, format, options, extras);
+        return OutputWriter.Write(path, output);
+    }
+
+    /// <summary>
+    /// Saves a matrix or stacked barcode to a stream using the requested output format.
+    /// </summary>
+    public static void Save(BarcodeType type, string content, Stream stream, OutputFormat format, MatrixOptions? options = null, RenderExtras? extras = null) {
+        if (stream is null) throw new ArgumentNullException(nameof(stream));
+        var output = Render(type, content, format, options, extras);
+        OutputWriter.Write(stream, output);
+    }
+
+}

--- a/CodeGlyphX/MatrixOutputRenderer.cs
+++ b/CodeGlyphX/MatrixOutputRenderer.cs
@@ -1,0 +1,87 @@
+using System;
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Bmp;
+using CodeGlyphX.Rendering.Eps;
+using CodeGlyphX.Rendering.Gif;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Jpeg;
+using CodeGlyphX.Rendering.Pam;
+using CodeGlyphX.Rendering.Pbm;
+using CodeGlyphX.Rendering.Pdf;
+using CodeGlyphX.Rendering.Pgm;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Ppm;
+using CodeGlyphX.Rendering.Svg;
+using CodeGlyphX.Rendering.Svgz;
+using CodeGlyphX.Rendering.Tga;
+using CodeGlyphX.Rendering.Tiff;
+using CodeGlyphX.Rendering.Webp;
+using CodeGlyphX.Rendering.Xbm;
+using CodeGlyphX.Rendering.Xpm;
+
+namespace CodeGlyphX;
+
+internal static class MatrixOutputRenderer {
+    public static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? options, RenderExtras? extras) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
+
+        var png = MatrixRenderOptionsBuilder.BuildPng(options);
+        return format switch {
+            OutputFormat.Png => Binary(format, MatrixPngRenderer.Render(modules, png)),
+            OutputFormat.Svg => Text(format, MatrixSvgRenderer.Render(modules, MatrixRenderOptionsBuilder.BuildSvg(options))),
+            OutputFormat.Svgz => Binary(format, MatrixSvgzRenderer.Render(modules, MatrixRenderOptionsBuilder.BuildSvg(options))),
+            OutputFormat.Html => Text(format, RenderHtml(modules, options, extras)),
+            OutputFormat.Jpeg => Binary(format, RenderJpeg(modules, png, options)),
+            OutputFormat.Webp => Binary(format, RenderWebp(modules, png, options, extras)),
+            OutputFormat.Bmp => Binary(format, MatrixBmpRenderer.Render(modules, png)),
+            OutputFormat.Gif => Binary(format, RenderGif(modules, png, extras)),
+            OutputFormat.Tiff => Binary(format, MatrixTiffRenderer.Render(modules, png, extras?.TiffCompression ?? TiffCompressionMode.Auto)),
+            OutputFormat.Ppm => Binary(format, MatrixPpmRenderer.Render(modules, png)),
+            OutputFormat.Pbm => Binary(format, MatrixPbmRenderer.Render(modules, png)),
+            OutputFormat.Pgm => Binary(format, MatrixPgmRenderer.Render(modules, png)),
+            OutputFormat.Pam => Binary(format, MatrixPamRenderer.Render(modules, png)),
+            OutputFormat.Xbm => Text(format, MatrixXbmRenderer.Render(modules, png)),
+            OutputFormat.Xpm => Text(format, MatrixXpmRenderer.Render(modules, png)),
+            OutputFormat.Tga => Binary(format, MatrixTgaRenderer.Render(modules, png)),
+            OutputFormat.Ico => Binary(format, MatrixIcoRenderer.Render(modules, png, MatrixRenderOptionsBuilder.BuildIco(options))),
+            OutputFormat.Pdf => Binary(format, MatrixPdfRenderer.Render(modules, png, extras?.VectorMode ?? RenderMode.Vector)),
+            OutputFormat.Eps => Text(format, MatrixEpsRenderer.Render(modules, png, extras?.VectorMode ?? RenderMode.Vector)),
+            OutputFormat.Ascii => Text(format, MatrixAsciiRenderer.Render(modules, MatrixRenderOptionsBuilder.BuildAscii(options, extras))),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.")
+        };
+    }
+
+    private static RenderedOutput Binary(OutputFormat format, byte[] data) => RenderedOutput.FromBinary(format, data);
+
+    private static RenderedOutput Text(OutputFormat format, string text) => RenderedOutput.FromText(format, text);
+
+    private static string RenderHtml(BitMatrix modules, MatrixOptions? options, RenderExtras? extras) {
+        var html = MatrixHtmlRenderer.Render(modules, MatrixRenderOptionsBuilder.BuildHtml(options));
+        var title = extras?.HtmlTitle;
+        return string.IsNullOrEmpty(title) ? html : html.WrapHtml(title);
+    }
+
+    private static byte[] RenderJpeg(BitMatrix modules, MatrixPngRenderOptions pngOptions, MatrixOptions? options) {
+        var jpegOptions = options?.JpegOptions;
+        return jpegOptions is null
+            ? MatrixJpegRenderer.Render(modules, pngOptions, options?.JpegQuality ?? 85)
+            : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
+    }
+
+    private static byte[] RenderWebp(BitMatrix modules, MatrixPngRenderOptions pngOptions, MatrixOptions? options, RenderExtras? extras) {
+        var quality = options?.WebpQuality ?? 100;
+        return RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)
+            ? webp
+            : MatrixWebpRenderer.Render(modules, pngOptions, quality);
+    }
+
+    private static byte[] RenderGif(BitMatrix modules, MatrixPngRenderOptions pngOptions, RenderExtras? extras) {
+        return RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)
+            ? gif
+            : MatrixGifRenderer.Render(modules, pngOptions);
+    }
+
+}

--- a/CodeGlyphX/MatrixRenderOptionsBuilder.cs
+++ b/CodeGlyphX/MatrixRenderOptionsBuilder.cs
@@ -1,0 +1,61 @@
+using CodeGlyphX.Rendering;
+using CodeGlyphX.Rendering.Ascii;
+using CodeGlyphX.Rendering.Html;
+using CodeGlyphX.Rendering.Ico;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+
+namespace CodeGlyphX;
+
+internal static class MatrixRenderOptionsBuilder {
+    public static MatrixPngRenderOptions BuildPng(MatrixOptions? options) {
+        var opts = options ?? new MatrixOptions();
+        return new MatrixPngRenderOptions {
+            ModuleSize = opts.ModuleSize,
+            QuietZone = opts.QuietZone,
+            Foreground = opts.Foreground,
+            Background = opts.Background
+        };
+    }
+
+    public static IcoRenderOptions BuildIco(MatrixOptions? options) {
+        var opts = options ?? new MatrixOptions();
+        return new IcoRenderOptions {
+            Sizes = opts.IcoSizes ?? new[] { 16, 32, 48, 64, 128, 256 },
+            PreserveAspectRatio = opts.IcoPreserveAspectRatio
+        };
+    }
+
+    public static MatrixSvgRenderOptions BuildSvg(MatrixOptions? options) {
+        var opts = options ?? new MatrixOptions();
+        return new MatrixSvgRenderOptions {
+            ModuleSize = opts.ModuleSize,
+            QuietZone = opts.QuietZone,
+            DarkColor = ColorUtils.ToCss(opts.Foreground),
+            LightColor = ColorUtils.ToCss(opts.Background)
+        };
+    }
+
+    public static MatrixHtmlRenderOptions BuildHtml(MatrixOptions? options) {
+        var opts = options ?? new MatrixOptions();
+        return new MatrixHtmlRenderOptions {
+            ModuleSize = opts.ModuleSize,
+            QuietZone = opts.QuietZone,
+            DarkColor = ColorUtils.ToCss(opts.Foreground),
+            LightColor = ColorUtils.ToCss(opts.Background),
+            EmailSafeTable = opts.HtmlEmailSafeTable
+        };
+    }
+
+    public static MatrixAsciiRenderOptions BuildAscii(MatrixOptions? options, RenderExtras? extras) {
+        var ascii = extras?.MatrixAscii;
+        if (ascii != null) {
+            return ascii;
+        }
+
+        var opts = options ?? new MatrixOptions();
+        return new MatrixAsciiRenderOptions {
+            QuietZone = opts.QuietZone
+        };
+    }
+}

--- a/CodeGlyphX/Pdf417Code.Decode.cs
+++ b/CodeGlyphX/Pdf417Code.Decode.cs
@@ -786,42 +786,19 @@ public static partial class Pdf417Code {
     }
 
     private static MatrixPngRenderOptions BuildPngOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new MatrixPngRenderOptions {
-            ModuleSize = opts.ModuleSize,
-            QuietZone = opts.QuietZone,
-            Foreground = opts.Foreground,
-            Background = opts.Background
-        };
+        return MatrixRenderOptionsBuilder.BuildPng(options);
     }
 
     private static IcoRenderOptions BuildIcoOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new IcoRenderOptions {
-            Sizes = opts.IcoSizes ?? new[] { 16, 32, 48, 64, 128, 256 },
-            PreserveAspectRatio = opts.IcoPreserveAspectRatio
-        };
+        return MatrixRenderOptionsBuilder.BuildIco(options);
     }
 
     private static MatrixSvgRenderOptions BuildSvgOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new MatrixSvgRenderOptions {
-            ModuleSize = opts.ModuleSize,
-            QuietZone = opts.QuietZone,
-            DarkColor = ColorUtils.ToCss(opts.Foreground),
-            LightColor = ColorUtils.ToCss(opts.Background)
-        };
+        return MatrixRenderOptionsBuilder.BuildSvg(options);
     }
 
     private static MatrixHtmlRenderOptions BuildHtmlOptions(MatrixOptions? options) {
-        var opts = options ?? new MatrixOptions();
-        return new MatrixHtmlRenderOptions {
-            ModuleSize = opts.ModuleSize,
-            QuietZone = opts.QuietZone,
-            DarkColor = ColorUtils.ToCss(opts.Foreground),
-            LightColor = ColorUtils.ToCss(opts.Background),
-            EmailSafeTable = opts.HtmlEmailSafeTable
-        };
+        return MatrixRenderOptionsBuilder.BuildHtml(options);
     }
 
 }

--- a/CodeGlyphX/Pdf417Code.Render.cs
+++ b/CodeGlyphX/Pdf417Code.Render.cs
@@ -1,26 +1,6 @@
 using System;
 using CodeGlyphX.Pdf417;
 using CodeGlyphX.Rendering;
-using CodeGlyphX.Rendering.Ascii;
-using CodeGlyphX.Rendering.Bmp;
-using CodeGlyphX.Rendering.Eps;
-using CodeGlyphX.Rendering.Gif;
-using CodeGlyphX.Rendering.Html;
-using CodeGlyphX.Rendering.Ico;
-using CodeGlyphX.Rendering.Jpeg;
-using CodeGlyphX.Rendering.Pam;
-using CodeGlyphX.Rendering.Pbm;
-using CodeGlyphX.Rendering.Pdf;
-using CodeGlyphX.Rendering.Pgm;
-using CodeGlyphX.Rendering.Ppm;
-using CodeGlyphX.Rendering.Png;
-using CodeGlyphX.Rendering.Svg;
-using CodeGlyphX.Rendering.Svgz;
-using CodeGlyphX.Rendering.Tga;
-using CodeGlyphX.Rendering.Tiff;
-using CodeGlyphX.Rendering.Webp;
-using CodeGlyphX.Rendering.Xbm;
-using CodeGlyphX.Rendering.Xpm;
 
 namespace CodeGlyphX;
 
@@ -60,73 +40,6 @@ public static partial class Pdf417Code {
 #endif
 
     private static RenderedOutput Render(BitMatrix modules, OutputFormat format, MatrixOptions? renderOptions, RenderExtras? extras) {
-        if (modules is null) throw new ArgumentNullException(nameof(modules));
-        if (format == OutputFormat.Unknown) throw new ArgumentOutOfRangeException(nameof(format));
-
-        var pngOptions = BuildPngOptions(renderOptions);
-        switch (format) {
-            case OutputFormat.Png:
-                return RenderedOutput.FromBinary(format, MatrixPngRenderer.Render(modules, pngOptions));
-            case OutputFormat.Svg:
-                return RenderedOutput.FromText(format, MatrixSvgRenderer.Render(modules, BuildSvgOptions(renderOptions)));
-            case OutputFormat.Svgz:
-                return RenderedOutput.FromBinary(format, MatrixSvgzRenderer.Render(modules, BuildSvgOptions(renderOptions)));
-            case OutputFormat.Html: {
-                var html = MatrixHtmlRenderer.Render(modules, BuildHtmlOptions(renderOptions));
-                var title = extras?.HtmlTitle;
-                if (!string.IsNullOrEmpty(title)) {
-                    html = html.WrapHtml(title);
-                }
-                return RenderedOutput.FromText(format, html);
-            }
-            case OutputFormat.Jpeg: {
-                var jpegOptions = renderOptions?.JpegOptions;
-                var data = jpegOptions is null
-                    ? MatrixJpegRenderer.Render(modules, pngOptions, renderOptions?.JpegQuality ?? 85)
-                    : MatrixJpegRenderer.Render(modules, pngOptions, jpegOptions);
-                return RenderedOutput.FromBinary(format, data);
-            }
-            case OutputFormat.Webp: {
-                var quality = renderOptions?.WebpQuality ?? 100;
-                if (RenderAnimationHelpers.TryRenderMatrixWebp(extras, pngOptions, quality, out var webp)) {
-                    return RenderedOutput.FromBinary(format, webp);
-                }
-                return RenderedOutput.FromBinary(format, MatrixWebpRenderer.Render(modules, pngOptions, quality));
-            }
-            case OutputFormat.Bmp:
-                return RenderedOutput.FromBinary(format, MatrixBmpRenderer.Render(modules, pngOptions));
-            case OutputFormat.Gif: {
-                if (RenderAnimationHelpers.TryRenderMatrixGif(extras, pngOptions, out var gif)) {
-                    return RenderedOutput.FromBinary(format, gif);
-                }
-                return RenderedOutput.FromBinary(format, MatrixGifRenderer.Render(modules, pngOptions));
-            }
-            case OutputFormat.Tiff:
-                return RenderedOutput.FromBinary(format, MatrixTiffRenderer.Render(modules, pngOptions, extras?.TiffCompression ?? TiffCompressionMode.Auto));
-            case OutputFormat.Ppm:
-                return RenderedOutput.FromBinary(format, MatrixPpmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pbm:
-                return RenderedOutput.FromBinary(format, MatrixPbmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pgm:
-                return RenderedOutput.FromBinary(format, MatrixPgmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Pam:
-                return RenderedOutput.FromBinary(format, MatrixPamRenderer.Render(modules, pngOptions));
-            case OutputFormat.Xbm:
-                return RenderedOutput.FromText(format, MatrixXbmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Xpm:
-                return RenderedOutput.FromText(format, MatrixXpmRenderer.Render(modules, pngOptions));
-            case OutputFormat.Tga:
-                return RenderedOutput.FromBinary(format, MatrixTgaRenderer.Render(modules, pngOptions));
-            case OutputFormat.Ico:
-                return RenderedOutput.FromBinary(format, MatrixIcoRenderer.Render(modules, pngOptions, BuildIcoOptions(renderOptions)));
-            case OutputFormat.Pdf:
-                return RenderedOutput.FromBinary(format, MatrixPdfRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
-            case OutputFormat.Eps:
-                return RenderedOutput.FromText(format, MatrixEpsRenderer.Render(modules, pngOptions, extras?.VectorMode ?? RenderMode.Vector));
-            case OutputFormat.Ascii:
-                return RenderedOutput.FromText(format, MatrixAsciiRenderer.Render(modules, extras?.MatrixAscii ?? new MatrixAsciiRenderOptions()));
-            default:
-                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported output format.");
-        }
+        return MatrixOutputRenderer.Render(modules, format, renderOptions, extras);
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,3 @@
-# Reduce duplication noise for generated/large stylesheet bundles
 sonar.cpd.exclusions=Website/static/css/**/*.css
 
 # Exclude website sources/outputs from analysis (static content generates high duplication)


### PR DESCRIPTION
## Summary
- Add a public MatrixBarcode facade for Data Matrix and PDF417 rendering/saving by OutputFormat or file extension
- Share the matrix render pipeline with DataMatrixCode, Pdf417Code, and AztecCode so format handling stays in one place
- Honor MatrixOptions quiet-zone settings for ASCII output unless explicit MatrixAscii options are supplied
- Add facade coverage for file save, SVG, ASCII quiet zones, HTML wrapping, stream writes, and error handling

## Validation
- dotnet test CodeGlyphX.Tests\CodeGlyphX.Tests.csproj -c Debug --filter "FullyQualifiedName~MatrixApiTests|FullyQualifiedName~AztecTests|FullyQualifiedName~Barcode2DTests"
- dotnet build CodeGlyphX\CodeGlyphX.csproj -c Debug
- git diff --check