### PR TITLE
Fix website CSS flash during load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,14 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@10757f12978162b54ac314b512a3a77e227502fd
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
+      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@10757f12978162b54ac314b512a3a77e227502fd
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -25,7 +25,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
+      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,12 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@10757f12978162b54ac314b512a3a77e227502fd
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 10757f12978162b54ac314b512a3a77e227502fd
+      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/content/pages/showcase.md
+++ b/Website/content/pages/showcase.md
@@ -11,7 +11,6 @@ meta.data_mode: override
 meta.social: true
 meta.social_description: See CodeGlyphX in action powering real-world applications.
 meta.structured_data: true
-meta.extra_scripts_file: showcase.scripts.html
 canonical: https://codeglyphx.com/showcase/
 ---
 

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -215,6 +215,7 @@
       "siteRoot": "./_site",
       "config": "./site.json",
       "criticalCss": "./themes/codeglyphx/critical.css",
+      "cssStrategy": "blocking",
       "minifyHtml": true,
       "minifyCss": true,
       "minifyJs": true,

--- a/Website/pipeline.website-ci.json
+++ b/Website/pipeline.website-ci.json
@@ -195,6 +195,7 @@
       "siteRoot": "./_site",
       "config": "./site.json",
       "criticalCss": "./themes/codeglyphx/critical.css",
+      "cssStrategy": "blocking",
       "minifyHtml": true,
       "minifyCss": true,
       "minifyJs": true,


### PR DESCRIPTION
## Summary
- update CodeGlyphX website reusable workflows to the current PowerForge.Web engine SHA
- make critical-CSS optimization explicitly keep `/css/app.css` as a blocking stylesheet
- remove stale showcase page script metadata that the current verifier correctly rejects

## Root Cause
The live deploy workflow was pinned to an older PSPublishModule/PowerForge.Web commit. That engine could still rewrite the main stylesheet into a preload/onload pattern during optimize, so the page could briefly render unstyled code before the full stylesheet applied.

## Validation
- `git diff --cached --check`
- `powerforge-web verify --config .\site.json --fail-on-nav-lint --fail-on-theme-contract` from `Website/` (passed with one release-hub warning because `data/release-hub.json` is generated and not checked in)
- targeted local optimize with current PowerForge.Web confirmed generated `index.html` contains `critical-css` and `rel=stylesheet href=/css/app.css` without the preload/onload path
- browser check against `http://localhost:8080/` confirmed `appCssIsBlocking: true`

## Notes
Two unrelated local edits were already present and intentionally left out of this PR: `Build/Artefacts/ProjectBuild/project.build.plan.json` and `CodeGlyphX/CodeGlyphX.csproj`.
