### PR TITLE
Bypass website deploy SEO guardrail

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,7 @@ jobs:
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+      require_seo_doctor_guardrail: false
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- opt the CodeGlyphX deploy caller out of the new PowerForge SEO-doctor deploy guardrail
- keep the current PowerForge.Web engine SHA for the actual website build/deploy

## Root Cause
The deploy failed before the website build started. The updated reusable PowerForge deploy workflow runs a guardrail script that passes an empty `HashSet` into a mandatory PowerShell parameter, which fails parameter binding before the pipeline can be inspected.

CodeGlyphX currently uses the existing `doctor`/`agent-ready` pipeline gates, not a `seo-doctor` deploy gate, so this opts out of that new guardrail until the site adopts it or the reusable workflow guardrail is fixed upstream.

## Validation
- inspected failed deploy run `25984920492`
- confirmed failure happened in `website-deploy / guardrails`, before build/deploy jobs
- `git diff --check -- .github/workflows/pages.yml`
