### PR TITLE
Skip cache-status verification after Pages deploy

### DIFF
--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -8,16 +8,6 @@
       "siteConfig": "./site.json",
       "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
       "tokenEnv": "CLOUDFLARE_API_TOKEN"
-    },
-    {
-      "task": "cloudflare",
-      "id": "verify-cache",
-      "dependsOn": "purge-cache",
-      "operation": "verify",
-      "siteConfig": "./site.json",
-      "warmupRequests": 1,
-      "reportPath": "./_reports/cloudflare-cache.json",
-      "summaryPath": "./_reports/cloudflare-cache.md"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- remove the post-deploy Cloudflare cache-status verify step because codeglyphx.com is currently served directly by GitHub Pages and does not emit cf-cache-status headers
- keep the Cloudflare purge step, which succeeded in the failed deploy run

## Validation
- validated Website/pipeline.cloudflare.json parses as JSON
- confirmed live post-deploy URLs return HTTP 200 from GitHub.com with no cf-cache-status header
- confirmed the prior deploy passed guardrails, build, artifact upload, and Deploy to GitHub Pages before failing only on cache-status verification