### PR TITLE
Fix Cloudflare cache rules payload

### DIFF
--- a/Website/scripts/Set-CloudflareCacheRules.ps1
+++ b/Website/scripts/Set-CloudflareCacheRules.ps1
@@ -251,9 +251,6 @@ if ($null -ne $current -and $current.result -and $current.result.rules) {
 }
 
 $payload = [ordered]@{
-    name  = 'PowerForge cache rules'
-    kind  = 'zone'
-    phase = $phase
     rules = @($desiredRules + $existingRules)
 }
 


### PR DESCRIPTION
## Summary
- send only the rules array when updating the Cloudflare phase entrypoint ruleset
- remove name/kind/phase fields that Cloudflare rejects for entrypoint updates

## Validation
- PowerShell parser check for Website/scripts/Set-CloudflareCacheRules.ps1
- git diff --cached --check
- Confirmed from failed deploy log: Cloudflare returned HTTP 400 invalid JSON: unknown field kind