### PR TITLE
Pin PowerForge workflows to current PSPublishModule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,14 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
     permissions:
       actions: write
       contents: read
@@ -26,7 +26,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
       require_seo_doctor_guardrail: false
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
@@ -57,7 +57,7 @@ jobs:
 
   cloudflare-post-deploy:
     needs: cloudflare-cache-rules
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
     permissions:
       actions: write
       contents: read
@@ -70,7 +70,7 @@ jobs:
       dotnet_version: 10.0.x
       report_artifact_name: powerforge-website-post-deploy-reports
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
       pipeline_mode: ci
       use_playwright_cache: false
     secrets:

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,12 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 2f2a6d96e9c562040e3e844d6511c0b6a26971fc
+      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- repin PowerForge website CI, deploy/run, and maintenance workflow calls to PSPublishModule 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
- use the same stable PowerForge ref for source checkout inputs

## Validation
- git diff --check
- matched run 26703342389 and PR website build failure to stale PowerForge audit dependencies
- dispatched Website Maintenance on the PR branch for live validation