### PR TITLE
Enable NuGet Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      nuget-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- add NuGet Dependabot version updates for the repository root
- run updates weekly
- group minor and patch NuGet updates to reduce PR noise while leaving major updates visible separately

## Validation
- `git diff --check`
- configuration-only change; no build required