### PR TITLE
Repin PowerForge website workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
+      packages: read
     uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     with:
       website_root: Website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,14 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     permissions:
       actions: write
       contents: read
@@ -26,7 +26,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       require_seo_doctor_guardrail: false
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
@@ -57,7 +57,7 @@ jobs:
 
   cloudflare-post-deploy:
     needs: cloudflare-cache-rules
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     permissions:
       actions: write
       contents: read
@@ -70,7 +70,7 @@ jobs:
       dotnet_version: 10.0.x
       report_artifact_name: powerforge-website-post-deploy-reports
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       pipeline_mode: ci
       use_playwright_cache: false
     secrets:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      packages: read
       pages: write
       id-token: write
     with:
@@ -61,6 +62,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      packages: read
     with:
       website_root: Website
       pipeline_config: Website/pipeline.cloudflare.json

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: write
   contents: read
+  packages: read
 
 concurrency:
   group: website-maintenance-${{ github.ref }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,12 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4ed420f8b83a2c66d4f474658ee5be8ff6aa68ce
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## What changed
- Repins the website reusable workflows to PSPublishModule `9d9f2d2c0fde07aaeb76518a787b52b49fbe5700`.
- Keeps the change scoped to workflow references and `powerforge_ref` values.
- Picks up the shared Magick.NET and Scriban package-audit fixes already merged in PSPublishModule.

## Notes
No product code changed. This is the downstream pin update for the scheduled Website Maintenance package-audit failures.