### PR TITLE
Make project manifest checks deterministic

### DIFF
--- a/.github/workflows/project-manifest.yml
+++ b/.github/workflows/project-manifest.yml
@@ -2,6 +2,14 @@ name: Project Manifest
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - "Build/Export-ProjectManifest.ps1"
+      - "CodeGlyphX/**/*.csproj"
+      - "WebsiteArtifacts/project-manifest.json"
   push:
     branches:
       - master

--- a/Build/Export-ProjectManifest.ps1
+++ b/Build/Export-ProjectManifest.ps1
@@ -26,6 +26,14 @@ function Resolve-Version {
         [Parameter(Mandatory)][string] $RepoPath
     )
 
+    $ProjectPath = Join-Path $RepoPath 'CodeGlyphX/CodeGlyphX.csproj'
+    if (Test-Path -LiteralPath $ProjectPath) {
+        $VersionPrefix = Select-String -Path $ProjectPath -Pattern '<VersionPrefix>([^<]+)</VersionPrefix>' -AllMatches | Select-Object -First 1
+        if ($VersionPrefix -and $VersionPrefix.Matches.Count -gt 0) {
+            return $VersionPrefix.Matches[0].Groups[1].Value
+        }
+    }
+
     $Tag = Get-GitValue -RepoPath $RepoPath -Arguments @('describe', '--tags', '--abbrev=0')
     if ($Tag) {
         $Normalized = [string]$Tag
@@ -33,14 +41,6 @@ function Resolve-Version {
         $Normalized = $Normalized -replace '^v', ''
         if ($Normalized) {
             return $Normalized
-        }
-    }
-
-    $ProjectPath = Join-Path $RepoPath 'CodeGlyphX/CodeGlyphX.csproj'
-    if (Test-Path -LiteralPath $ProjectPath) {
-        $VersionPrefix = Select-String -Path $ProjectPath -Pattern '<VersionPrefix>([^<]+)</VersionPrefix>' -AllMatches | Select-Object -First 1
-        if ($VersionPrefix -and $VersionPrefix.Matches.Count -gt 0) {
-            return $VersionPrefix.Matches[0].Groups[1].Value
         }
     }
 
@@ -59,19 +59,15 @@ if (-not (Test-Path -LiteralPath $OutputDirectory)) {
 }
 
 $Version = Resolve-Version -RepoPath $RepoRootResolved
-$Commit = Get-GitValue -RepoPath $RepoRootResolved -Arguments @('rev-parse', '--short', 'HEAD')
-$GeneratedAt = Get-GitValue -RepoPath $RepoRootResolved -Arguments @('show', '-s', '--format=%cI', 'HEAD')
-if (-not $GeneratedAt) {
-    $GeneratedAt = (Get-Date).ToUniversalTime().ToString('o')
-}
 
+# This manifest is committed and verified in pull requests, so it must contain
+# only deterministic project metadata. Build and deployment layers own runtime
+# provenance such as the generating commit and timestamp.
 $Manifest = [ordered]@{
     slug        = 'codeglyphx'
     name        = 'CodeGlyphX'
     mode        = 'hub-full'
     version     = $Version
-    generatedAt = [string]$GeneratedAt
-    commit      = [string]$Commit
     description = 'No-deps QR & barcode toolkit for .NET.'
     surfaces    = [ordered]@{
         docs          = $true
@@ -97,5 +93,4 @@ if ($PSCmdlet.ShouldProcess($OutputPathResolved, 'Write project-manifest.json'))
 [PSCustomObject]@{
     outputPath = $OutputPathResolved
     version    = $Version
-    commit     = $Commit
 }

--- a/WebsiteArtifacts/project-manifest.json
+++ b/WebsiteArtifacts/project-manifest.json
@@ -2,9 +2,7 @@
   "slug": "codeglyphx",
   "name": "CodeGlyphX",
   "mode": "hub-full",
-  "version": "1.2.0",
-  "generatedAt": "2026-03-01T08:09:33+01:00",
-  "commit": "ab4e3a3",
+  "version": "2.0.0",
   "description": "No-deps QR & barcode toolkit for .NET.",
   "surfaces": {
     "docs": true,


### PR DESCRIPTION
## Summary

- use `CodeGlyphX.csproj` as the primary manifest version source, with Git tags only as a fallback
- keep the committed project manifest deterministic by leaving runtime commit and timestamp provenance to build/deployment layers
- verify manifest freshness in pull requests instead of discovering stale output only after merge
- refresh the tracked manifest to version 2.0.0

## Why

The merge of #163 exposed two conflicting outputs: a full clone resolved the old 1.6.0 tag, while GitHub's shallow checkout resolved the 2.0.0 project version. The exporter also embedded `HEAD` provenance in a file expected to match its own committed generation. Those rules made the check environment-dependent and self-referential.

The updated exporter produces the same manifest with or without Git metadata and remains byte-identical across repeated runs.

Follow-up to the failed post-merge [Project Manifest run](https://github.com/EvotecIT/CodeGlyphX/actions/runs/29337752555).