### PR TITLE
Refresh generated website inputs automatically

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -5,7 +5,14 @@ on:
     branches: [master]
     paths:
       - "Website/**"
+      - "CodeGlyphX/**"
+      - "CodeGlyphX.Playground/**"
+      - "CodeGlyphX.Website/**"
+      - "Directory.Build.props"
+      - "NuGet.config"
       - ".github/workflows/website-deploy.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -28,15 +28,16 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@870eb98104b4cbf191956a28acfe877adde1da75
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@52642e72bd740b6ec7a5ea482d26c02adef65b0f
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
+      source_ref: ${{ github.event_name == 'release' && 'master' || '' }}
       engine_mode: source
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 60
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 870eb98104b4cbf191956a28acfe877adde1da75
+      powerforge_ref: 52642e72bd740b6ec7a5ea482d26c02adef65b0f
       report_artifact_name: codeglyphx-website-deploy-reports
       site_artifact_name: powerforge-site-codeglyphx.com
       site_artifact_retention_days: 7
@@ -53,9 +54,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.build.outputs.source_sha }}
 
       - name: Apply managed Cloudflare cache policy
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-cache-policy@74e782630c3766a5e73b2f796e64213f43ddc466
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-cache-policy@52642e72bd740b6ec7a5ea482d26c02adef65b0f
         with:
           site-config: Website/site.json
           zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
@@ -73,7 +76,7 @@ jobs:
       contents: read
     steps:
       - name: Deploy validated website artifact
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-linux-site-deploy@870eb98104b4cbf191956a28acfe877adde1da75
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-linux-site-deploy@52642e72bd740b6ec7a5ea482d26c02adef65b0f
         with:
           artifact-name: powerforge-site-codeglyphx.com
           deployment-site: codeglyphx.com
@@ -86,7 +89,7 @@ jobs:
           deployment-cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflare-zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           source-repository: ${{ github.repository }}
-          source-sha: ${{ github.sha }}
+          source-sha: ${{ needs.build.outputs.source_sha }}
           engine-mode: ${{ needs.build.outputs.engine_mode }}
           engine-repository: ${{ needs.build.outputs.engine_repository }}
           engine-ref: ${{ needs.build.outputs.engine_ref }}


### PR DESCRIPTION
## Summary
- deploy when the CodeGlyphX library, Playground, Blazor website, shared MSBuild, or NuGet inputs change
- refresh the release hub when a GitHub release is published
- build release-triggered refreshes from current `master`, not the release tag commit
- carry the exact build SHA through cache-policy checkout and deployment provenance
- pin all shared website workflow/action calls to the accepted PowerForge commit

## Why
The PowerForge pipeline generates API documentation and the browser Playground from projects outside `Website/`. Limiting the production trigger to `Website/**` could leave generated content stale even though deployment remained healthy. GitHub release events can also point at an older tag; production refreshes must query that release while still building the current website source.

The caller remains declarative. Source selection, exact provenance, cache policy, protected deployment, rollback, and recovery behavior stay in the shared PowerForge owner.