### PR TITLE
Authorize hardened CodeGlyphX backup capture

### DIFF
--- a/deploy/linux/powerforge-codeglyphx-backup.sudoers
+++ b/deploy/linux/powerforge-codeglyphx-backup.sudoers
@@ -1,5 +1,5 @@
 Cmnd_Alias CODEGLYPHX_BACKUP_PLAIN = /usr/bin/tar -czf - /etc/apache2/sites-available/codeglyphx-com.conf /etc/apache2/sites-available/codeglyphx-com-le-ssl.conf /etc/apache2/conf-available/powerforge-cloudflare-origin.conf /etc/systemd/system/powerforge-cloudflare-origin-sync.service /etc/systemd/system/powerforge-cloudflare-origin-sync.timer /etc/systemd/system/powerforge-site-reconcile.service /etc/systemd/system/powerforge-site-reconcile.timer /etc/powerforge/sites/codeglyphx.com.env /etc/sudoers.d/powerforge-codeglyphx /etc/sudoers.d/powerforge-codeglyphx-backup /etc/letsencrypt/renewal/codeglyphx.com.conf /etc/letsencrypt/options-ssl-apache.conf
-Cmnd_Alias CODEGLYPHX_BACKUP_ENCRYPTED = /usr/bin/tar -czf - /etc/letsencrypt/accounts /etc/letsencrypt/archive/codeglyphx.com /etc/letsencrypt/live/codeglyphx.com
+Cmnd_Alias CODEGLYPHX_BACKUP_ENCRYPTED = /usr/local/sbin/powerforge-server-encrypted-capture --recipient age1v4aw3yj7l4u9t5436ppy8hgem46lfy7wte9ww9ehfkhcwzldx4psd94wk6 -- /etc/letsencrypt/accounts /etc/letsencrypt/archive/codeglyphx.com /etc/letsencrypt/live/codeglyphx.com
 Cmnd_Alias CODEGLYPHX_BACKUP_INSPECT = /usr/sbin/apachectl -S
 
 powerforge-codeglyphx-backup ALL=(root) NOPASSWD: CODEGLYPHX_BACKUP_PLAIN, CODEGLYPHX_BACKUP_ENCRYPTED, CODEGLYPHX_BACKUP_INSPECT


### PR DESCRIPTION
## Summary
- replace the legacy direct-`tar` encrypted backup allowance with the hardened PowerForge encryption helper
- bind the allowance to the exact public age recipient and exact encrypted recovery paths
- retain the existing least-privilege backup account and `NOPASSWD` alias structure

## Why
The first schema v2 backup canary reached the correct protected host but failed because this committed sudoers source still authorized the pre-hardening command.

## Validation
- `visudo -cf` passed under Linux
- all 16 managed recovery sources pass the new pinned-source and exact-command consistency check when pinned to this commit
- no workflow, website, manifest, or Cloudflare file changed