### PR TITLE
Pin CodeGlyphX recovery to current PowerForge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,14 +120,14 @@ jobs:
       actions: read
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@3b895c68d3125fab4146e2ded3a30852de789393
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@161a22a7a91b6f05b7bf9268287ff69f44ea204a
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1f634b17e21f935ab6b8c052322497d814ce6c8c
+      powerforge_ref: 161a22a7a91b6f05b7bf9268287ff69f44ea204a
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/server-backup.yml
+++ b/.github/workflows/server-backup.yml
@@ -19,7 +19,7 @@ jobs:
     environment: production
     steps:
       - name: Capture and publish encrypted recovery state
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-backup@71fdfa7e1b767aff6c505ee7dbcb01b3dfc4b51b
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-backup@161a22a7a91b6f05b7bf9268287ff69f44ea204a
         with:
           manifest-path: deploy/linux/codeglyphx.serverrecovery.json
           server-host: ${{ secrets.DEPLOYMENT_HOST }}

--- a/.github/workflows/server-recovery-ci.yml
+++ b/.github/workflows/server-recovery-ci.yml
@@ -22,7 +22,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Validate recovery manifest and generated plans
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-recovery-validate@71fdfa7e1b767aff6c505ee7dbcb01b3dfc4b51b
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-recovery-validate@161a22a7a91b6f05b7bf9268287ff69f44ea204a
         with:
           manifest-path: deploy/linux/codeglyphx.serverrecovery.json
+          capture-user: powerforge-codeglyphx-backup
           fail-on-warnings: true

--- a/deploy/linux/codeglyphx.serverrecovery.json
+++ b/deploy/linux/codeglyphx.serverrecovery.json
@@ -21,6 +21,14 @@
       "required": true
     },
     {
+      "role": "recovery-configuration",
+      "url": "https://github.com/EvotecIT/CodeGlyphX.git",
+      "path": "/srv/evotec/CodeGlyphXRecovery",
+      "branch": "master",
+      "ref": "0410ddab72d4cf346b725402d59f57d200b4be62",
+      "required": true
+    },
+    {
       "role": "deployment-engine",
       "url": "https://github.com/EvotecIT/PSPublishModule.git",
       "path": "/srv/evotec/PSPublishModule",
@@ -242,7 +250,7 @@
     {
       "id": "backup-sudoers",
       "path": "/etc/sudoers.d/powerforge-codeglyphx-backup",
-      "source": "/srv/evotec/CodeGlyphX/deploy/linux/powerforge-codeglyphx-backup.sudoers",
+      "source": "/srv/evotec/CodeGlyphXRecovery/deploy/linux/powerforge-codeglyphx-backup.sudoers",
       "kind": "file",
       "owner": "root",
       "group": "root",

--- a/deploy/linux/codeglyphx.serverrecovery.json
+++ b/deploy/linux/codeglyphx.serverrecovery.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/71fdfa7e1b767aff6c505ee7dbcb01b3dfc4b51b/Schemas/powerforge.web.serverrecovery.schema.json",
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/161a22a7a91b6f05b7bf9268287ff69f44ea204a/Schemas/powerforge.web.serverrecovery.schema.json",
   "schemaVersion": 2,
   "name": "codeglyphx-production-ovh",
   "description": "Recovery manifest for the CodeGlyphX static website.",
@@ -33,7 +33,7 @@
       "url": "https://github.com/EvotecIT/PSPublishModule.git",
       "path": "/srv/evotec/PSPublishModule",
       "branch": "main",
-      "ref": "71fdfa7e1b767aff6c505ee7dbcb01b3dfc4b51b",
+      "ref": "161a22a7a91b6f05b7bf9268287ff69f44ea204a",
       "required": true
     }
   ],


### PR DESCRIPTION
## Summary
- Pin the recovery configuration checkout to an immutable CodeGlyphX commit so bootstrap can install the backup sudo policy independently of the deployed static-site checkout.
- Pin the recovery schema, deployment engine, backup action, and credential-free validation action to the current shared PowerForge merge.
- Validate the dedicated non-root backup account through the shared action.
- Repin PR website CI to the same shared merge, replacing the stale PowerForge source that NuGet rejected for a vulnerable AngleSharp dependency.

## Scope
This PR keeps all behavior in shared PowerForge actions and workflows. It changes the recovery manifest, two thin recovery workflows, and two exact SHA values in the existing PR-only website CI job. Website deployment, secrets, and Cloudflare behavior are untouched.

After merge, the server bootstrap/verify lane must apply the pinned sudo policy before the encrypted-backup canary is rerun; the current scheduled backup still sees the older host policy.