### PR TITLE
Fix Code 39 standard character patterns

### DIFF
--- a/CodeGlyphX.Tests/BarcodeDecoderTests.cs
+++ b/CodeGlyphX.Tests/BarcodeDecoderTests.cs
@@ -95,7 +95,7 @@ public sealed class BarcodeDecoderTests {
 
     [Fact]
     public void Decode_Code39_FromPixels() {
-        var barcode = BarcodeEncoder.EncodeCode39("ABC123", includeChecksum: true, fullAsciiMode: false);
+        var barcode = BarcodeEncoder.EncodeCode39("HELLO-123", includeChecksum: true, fullAsciiMode: false);
         var pixels = BarcodePngRenderer.RenderPixels(barcode, new BarcodePngRenderOptions {
             ModuleSize = 3,
             QuietZone = 10,
@@ -107,7 +107,7 @@ public sealed class BarcodeDecoderTests {
         };
         Assert.True(BarcodeDecoder.TryDecode(pixels, width, height, stride, PixelFormat.Rgba32, options, out var decoded));
         Assert.Equal(BarcodeType.Code39, decoded.Type);
-        Assert.Equal("ABC123", decoded.Text);
+        Assert.Equal("HELLO-123", decoded.Text);
     }
 
     [Fact]

--- a/CodeGlyphX.Tests/Code39StandardsTests.cs
+++ b/CodeGlyphX.Tests/Code39StandardsTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using CodeGlyphX.Code39;
+using Xunit;
+
+namespace CodeGlyphX.Tests;
+
+public sealed class Code39StandardsTests {
+    public static IEnumerable<object[]> StandardCharacterPatterns() {
+        const string alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%";
+        var patterns = new[] {
+            0x034, 0x121, 0x061, 0x160, 0x031, 0x130, 0x070, 0x025, 0x124, 0x064,
+            0x109, 0x049, 0x148, 0x019, 0x118, 0x058, 0x00D, 0x10C, 0x04C, 0x01C,
+            0x103, 0x043, 0x142, 0x013, 0x112, 0x052, 0x007, 0x106, 0x046, 0x016,
+            0x181, 0x0C1, 0x1C0, 0x091, 0x190, 0x0D0, 0x085, 0x184, 0x0C4, 0x0A8,
+            0x0A2, 0x08A, 0x02A
+        };
+
+        for (var i = 0; i < alphabet.Length; i++) {
+            yield return new object[] { alphabet[i], patterns[i] };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(StandardCharacterPatterns))]
+    public void Encode_UsesStandardWideNarrowPattern(char character, int expectedPattern) {
+        var barcode = Code39Encoder.Encode(character.ToString(), includeChecksum: false, fullAsciiMode: false);
+        var modules = ExpandModules(barcode);
+
+        Assert.Equal(38, modules.Length);
+        Assert.Equal(ExpandWidePattern(expectedPattern), modules[13..25]);
+    }
+
+    [Fact]
+    public void Encode_UsesStandardStartStopPattern() {
+        var barcode = Code39Encoder.Encode(string.Empty, includeChecksum: false, fullAsciiMode: false);
+        var modules = ExpandModules(barcode);
+        var expected = ExpandWidePattern(0x094);
+
+        Assert.Equal(25, modules.Length);
+        Assert.Equal(expected, modules[..12]);
+        Assert.False(modules[12]);
+        Assert.Equal(expected, modules[13..]);
+    }
+
+    private static bool[] ExpandModules(Barcode1D barcode) {
+        var modules = new List<bool>(barcode.TotalModules);
+        foreach (var segment in barcode.Segments) {
+            for (var i = 0; i < segment.Modules; i++) {
+                modules.Add(segment.IsBar);
+            }
+        }
+        return modules.ToArray();
+    }
+
+    private static bool[] ExpandWidePattern(int pattern) {
+        var modules = new bool[12];
+        var offset = 0;
+        var isBar = true;
+
+        for (var mask = 1 << 8; mask != 0; mask >>= 1) {
+            var width = (pattern & mask) != 0 ? 2 : 1;
+            for (var i = 0; i < width; i++) {
+                modules[offset++] = isBar;
+            }
+            isBar = !isBar;
+        }
+
+        return modules;
+    }
+}

--- a/CodeGlyphX/Code39/Code39Tables.cs
+++ b/CodeGlyphX/Code39/Code39Tables.cs
@@ -1,54 +1,56 @@
+using System;
 using System.Collections.Generic;
 
 namespace CodeGlyphX.Code39;
 
 internal static class Code39Tables {
-    public static readonly IReadOnlyDictionary<char, (int value, bool[] data)> EncodingTable = new Dictionary<char, (int, bool[])> {
-        { '0', (0, new[] { true, false, true, false, false, true, true, false, true, true, false, true }) },
-        { '1', (1, new[] { true, true, false, true, false, false, true, false, true, false, true, true }) },
-        { '2', (2, new[] { true, false, true, true, false, false, true, false, true, false, true, true }) },
-        { '3', (3, new[] { true, true, false, true, true, false, false, true, false, true, false, true }) },
-        { '4', (4, new[] { true, false, true, false, false, true, true, false, true, false, true, true }) },
-        { '5', (5, new[] { true, true, false, true, false, false, true, true, false, true, false, true }) },
-        { '6', (6, new[] { true, false, true, true, false, false, true, true, false, true, false, true }) },
-        { '7', (7, new[] { true, false, true, false, false, true, false, true, true, false, true, true }) },
-        { '8', (8, new[] { true, true, false, true, false, false, true, false, true, true, false, true }) },
-        { '9', (9, new[] { true, false, true, true, false, false, true, false, true, true, false, true }) },
-        { 'A', (10, new[] { true, true, false, true, false, true, false, false, true, false, true, true }) },
-        { 'B', (11, new[] { true, false, true, true, false, true, false, false, true, false, true, true }) },
-        { 'C', (12, new[] { true, true, false, true, true, false, true, false, false, true, false, true }) },
-        { 'D', (13, new[] { true, false, true, false, true, true, false, false, true, false, true, true }) },
-        { 'E', (14, new[] { true, true, false, true, false, true, true, false, false, true, false, true }) },
-        { 'F', (15, new[] { true, false, true, true, false, true, true, false, false, true, false, true }) },
-        { 'G', (16, new[] { true, false, true, false, true, false, false, true, true, false, true, true }) },
-        { 'H', (17, new[] { true, true, false, true, false, true, false, false, true, true, false, true }) },
-        { 'I', (18, new[] { true, false, true, true, false, true, false, false, true, true, false, true }) },
-        { 'J', (19, new[] { true, false, true, false, true, true, false, false, true, true, false, true }) },
-        { 'K', (20, new[] { true, true, false, true, false, true, false, true, false, false, true, true }) },
-        { 'L', (21, new[] { true, false, true, true, false, true, false, true, false, false, true, true }) },
-        { 'M', (22, new[] { true, true, false, true, true, false, true, false, true, false, false, true }) },
-        { 'N', (23, new[] { true, false, true, false, true, true, false, true, false, false, true, true }) },
-        { 'O', (24, new[] { true, true, false, true, false, true, true, false, true, false, false, true }) },
-        { 'P', (25, new[] { true, false, true, true, false, true, true, false, true, false, false, true }) },
-        { 'Q', (26, new[] { true, false, true, false, true, true, false, true, true, false, false, true }) },
-        { 'R', (27, new[] { true, true, false, true, false, true, false, true, true, false, false, true }) },
-        { 'S', (28, new[] { true, false, true, true, false, true, false, true, true, false, false, true }) },
-        { 'T', (29, new[] { true, false, true, false, true, true, false, true, true, false, false, true }) },
-        { 'U', (30, new[] { true, true, false, false, true, false, true, false, true, false, true, true }) },
-        { 'V', (31, new[] { true, false, true, false, true, false, true, false, true, false, true, true }) },
-        { 'W', (32, new[] { true, true, false, false, true, false, true, true, false, true, false, true }) },
-        { 'X', (33, new[] { true, false, true, false, true, false, true, true, false, true, false, true }) },
-        { 'Y', (34, new[] { true, false, true, false, true, false, false, true, true, false, true, true }) },
-        { 'Z', (35, new[] { true, true, false, false, true, false, true, false, true, true, false, true }) },
-        { '-', (36, new[] { true, false, false, true, false, true, false, true, false, true, true, true }) },
-        { '.', (37, new[] { true, true, false, true, false, true, false, true, false, true, false, true }) },
-        { ' ', (38, new[] { true, false, false, true, false, true, false, true, true, false, true, true }) },
-        { '$', (39, new[] { true, false, false, false, true, false, false, true, false, true, true, true }) },
-        { '/', (40, new[] { true, false, false, false, true, false, true, false, false, true, true, true }) },
-        { '+', (41, new[] { true, false, false, true, false, false, false, true, false, true, true, true }) },
-        { '%', (42, new[] { true, false, true, false, false, true, false, false, true, false, false, true }) },
-        { '*', (-1, new[] { true, false, false, true, false, true, true, false, true, true, false, true }) }
+    private const string Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%";
+    private const int AsteriskWidePattern = 0x094;
+
+    // The nine low bits describe the alternating bars and spaces. A set bit is
+    // wide (two modules); an unset bit is narrow (one module).
+    private static readonly int[] WidePatterns = {
+        0x034, 0x121, 0x061, 0x160, 0x031, 0x130, 0x070, 0x025, 0x124, 0x064,
+        0x109, 0x049, 0x148, 0x019, 0x118, 0x058, 0x00D, 0x10C, 0x04C, 0x01C,
+        0x103, 0x043, 0x142, 0x013, 0x112, 0x052, 0x007, 0x106, 0x046, 0x016,
+        0x181, 0x0C1, 0x1C0, 0x091, 0x190, 0x0D0, 0x085, 0x184, 0x0C4, 0x0A8,
+        0x0A2, 0x08A, 0x02A
     };
+
+    public static readonly IReadOnlyDictionary<char, (int value, bool[] data)> EncodingTable = CreateEncodingTable();
+
+    private static IReadOnlyDictionary<char, (int value, bool[] data)> CreateEncodingTable() {
+        var table = new Dictionary<char, (int value, bool[] data)>(Alphabet.Length + 1);
+        for (var i = 0; i < Alphabet.Length; i++) {
+            table.Add(Alphabet[i], (i, ExpandWidePattern(WidePatterns[i])));
+        }
+        table.Add('*', (-1, ExpandWidePattern(AsteriskWidePattern)));
+        return table;
+    }
+
+    private static bool[] ExpandWidePattern(int pattern) {
+        var wideElements = 0;
+        for (var mask = 1 << 8; mask != 0; mask >>= 1) {
+            if ((pattern & mask) != 0) wideElements++;
+        }
+        if (wideElements != 3 || (pattern & ~0x1FF) != 0) {
+            throw new InvalidOperationException("A Code 39 pattern must contain nine elements with exactly three wide elements.");
+        }
+
+        var modules = new bool[12];
+        var offset = 0;
+        var isBar = true;
+
+        for (var mask = 1 << 8; mask != 0; mask >>= 1) {
+            var width = (pattern & mask) != 0 ? 2 : 1;
+            for (var i = 0; i < width; i++) {
+                modules[offset++] = isBar;
+            }
+            isBar = !isBar;
+        }
+
+        return modules;
+    }
 
     public static readonly IReadOnlyDictionary<char, string> ExtendedTable = new Dictionary<char, string> {
         { '\u0000', "%U" },


### PR DESCRIPTION
## Summary

- replace hand-expanded Code 39 module arrays with the canonical nine-bit wide/narrow table
- correct the 12 mismapped symbols found by the full-table audit: `Q`, `V`, `W`, `X`, `Y`, `Z`, `-`, `.`, space, `$`, `/`, and `+`
- validate every base character and the start/stop pattern, and exercise the documented `HELLO-123` pixel path

## Why

CodeGlyphX 2.0.0 could emit non-standard symbols that either failed independent decoding or decoded as the wrong character. The shared table was also used by the built-in decoder, so self-round-trip tests masked the interoperability defect.

## Validation

The multi-target build, focused net8/net10 tests, net10 regression suite, net472 suite, package contract, and NativeAOT smoke pass. A locally packed NuGet was decoded by ZXing.Net for all 43 base characters and the full ASCII range.

Fixes #186