### PR TITLE
Repin PowerForge recovery manifest

### DIFF
--- a/.github/workflows/server-backup.yml
+++ b/.github/workflows/server-backup.yml
@@ -19,7 +19,7 @@ jobs:
     environment: production
     steps:
       - name: Capture and publish encrypted recovery state
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-backup@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-backup@c6451c9d264a81c7f179b38f6e4d2b62f0784037
         with:
           manifest-path: deploy/linux/codeglyphx.serverrecovery.json
           server-host: ${{ secrets.DEPLOYMENT_HOST }}

--- a/.github/workflows/server-recovery-ci.yml
+++ b/.github/workflows/server-recovery-ci.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Validate recovery manifest and generated plans
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-recovery-validate@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-recovery-validate@c6451c9d264a81c7f179b38f6e4d2b62f0784037
         with:
           manifest-path: deploy/linux/codeglyphx.serverrecovery.json
           capture-user: powerforge-codeglyphx-backup

--- a/deploy/linux/codeglyphx.serverrecovery.json
+++ b/deploy/linux/codeglyphx.serverrecovery.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/da070b9e11e9ba1c77a76cca4b9d8878c90aa087/Schemas/powerforge.web.serverrecovery.schema.json",
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/c6451c9d264a81c7f179b38f6e4d2b62f0784037/Schemas/powerforge.web.serverrecovery.schema.json",
   "schemaVersion": 2,
   "name": "codeglyphx-production-ovh",
   "description": "Recovery manifest for the CodeGlyphX static website.",
@@ -36,7 +36,7 @@
       "url": "https://github.com/EvotecIT/PSPublishModule.git",
       "path": "/srv/evotec/PSPublishModule",
       "branch": "main",
-      "ref": "da070b9e11e9ba1c77a76cca4b9d8878c90aa087",
+      "ref": "c6451c9d264a81c7f179b38f6e4d2b62f0784037",
       "required": true
     }
   ],


### PR DESCRIPTION
Repins the recovery action, its manifest schema URL, and the manifest deployment-engine reference to PSPublishModule `c6451c9`. That immutable owner revision has a green build and resolves the Magick.NET 14.14.0 audit failure.