### PR TITLE
Align CodeGlyphX backup account verification

### DIFF
--- a/deploy/linux/codeglyphx.serverrecovery.json
+++ b/deploy/linux/codeglyphx.serverrecovery.json
@@ -520,7 +520,7 @@
       },
       {
         "id": "backup-account",
-        "command": "id -u powerforge-codeglyphx-backup >/dev/null && sudo -n test -s /var/lib/powerforge-codeglyphx-backup/.ssh/authorized_keys && test \"$(sudo -n stat -c '%U:%G %a' /var/lib/powerforge-codeglyphx-backup/.ssh/authorized_keys)\" = 'powerforge-codeglyphx-backup:powerforge-codeglyphx-backup 600' && sudo -n visudo -cf /etc/sudoers.d/powerforge-codeglyphx-backup",
+        "command": "id -u powerforge-codeglyphx-backup >/dev/null && sudo -n test -s /var/lib/powerforge-codeglyphx-backup/.ssh/authorized_keys && test \"$(sudo -n stat -c '%U:%G %a' /var/lib/powerforge-codeglyphx-backup/.ssh/authorized_keys)\" = 'root:root 644' && sudo -n visudo -cf /etc/sudoers.d/powerforge-codeglyphx-backup",
         "required": true
       },
       {


### PR DESCRIPTION
## Summary

- align the recovery verifier with the root-controlled backup account contract already declared by the manifest
- expect the managed authorized key to remain root-owned and mode 644

## Validation

- exact pinned PowerForge bootstrap plan: 46 steps, zero warnings
- JSON parse and git diff checks passed
- managed sudoers source passed visudo