### PR TITLE
fix(ci): repin PowerForge website workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,14 @@ jobs:
       actions: read
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 455ae22ec1b1405e6b719e377f1cd8258891fc93
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -37,7 +37,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 60
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 455ae22ec1b1405e6b719e377f1cd8258891fc93
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       report_artifact_name: codeglyphx-website-deploy-reports
       site_artifact_name: powerforge-site-codeglyphx.com
       site_artifact_retention_days: 7
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ needs.build.outputs.source_sha }}
 
       - name: Apply managed Cloudflare cache policy
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-cache-policy@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-cache-policy@c6451c9d264a81c7f179b38f6e4d2b62f0784037
         with:
           site-config: Website/site.json
           zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
@@ -76,7 +76,7 @@ jobs:
       contents: read
     steps:
       - name: Deploy validated website artifact
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-linux-site-deploy@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-linux-site-deploy@c6451c9d264a81c7f179b38f6e4d2b62f0784037
         with:
           artifact-name: powerforge-site-codeglyphx.com
           deployment-site: codeglyphx.com

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,12 +16,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@da070b9e11e9ba1c77a76cca4b9d8878c90aa087
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 455ae22ec1b1405e6b719e377f1cd8258891fc93
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
Repins the website CI, deployment, and maintenance callers to the verified PowerForge commit c6451c9d264a81c7f179b38f6e4d2b62f0784037.\n\nThis shared revision resolves the Magick.NET 14.14.0 audit failures seen in the scheduled website maintenance run, while keeping the existing workflow configuration intact.