### PR TITLE
Fix CI runner-context validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,20 @@ jobs:
     timeout-minutes: 20
     env:
       # The default all-format DataBar corpus scan needs a larger budget on Linux runners.
-      CODEGLYPHX_TEST_BUDGET_MULTIPLIER: ${{ runner.os == 'Linux' && '4' || '1' }}
+      CODEGLYPHX_TEST_BUDGET_MULTIPLIER: ${{ matrix.testBudgetMultiplier }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             selfHostedRunner: '["self-hosted","linux"]'
+            testBudgetMultiplier: '4'
           - os: macos-latest
             selfHostedRunner: '["self-hosted","macOS"]'
+            testBudgetMultiplier: '1'
           - os: windows-latest
             selfHostedRunner: '["self-hosted","windows"]'
+            testBudgetMultiplier: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- define the test-budget multiplier as matrix data available during job evaluation
- retain the existing 4x Linux budget and 1x macOS/Windows budgets

The current job-level `runner.os` expression is evaluated before a runner exists, so GitHub rejects the workflow without creating a job.