### PR TITLE
Upgrade CodeGlyphX to the managed Cloudflare site policy

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -44,7 +44,7 @@ jobs:
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
 
-  cache-policy:
+  site-policy:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -57,15 +57,15 @@ jobs:
         with:
           ref: ${{ needs.build.outputs.source_sha }}
 
-      - name: Apply managed Cloudflare cache policy
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-cache-policy@683531aed9652851a03b1301624b9c769ce62d52
+      - name: Apply managed Cloudflare site policy
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-site-policy@683531aed9652851a03b1301624b9c769ce62d52
         with:
           site-config: Website/site.json
           zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
           api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   deploy:
-    needs: [build, cache-policy]
+    needs: [build, site-policy]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -98,3 +98,25 @@ jobs:
           engine-sha: ${{ needs.build.outputs.engine_sha }}
           engine-asset: ${{ needs.build.outputs.engine_asset }}
           engine-asset-sha256: ${{ needs.build.outputs.engine_asset_sha256 }}
+
+  post-deploy:
+    needs: [build, deploy]
+    permissions:
+      actions: write
+      contents: read
+      packages: read
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@683531aed9652851a03b1301624b9c769ce62d52
+    with:
+      website_root: Website
+      pipeline_config: Website/pipeline.cloudflare.json
+      source_ref: ${{ needs.build.outputs.source_sha }}
+      engine_mode: source
+      runner_labels_json: '["ubuntu-latest"]'
+      timeout_minutes: 30
+      powerforge_repository: EvotecIT/PSPublishModule
+      powerforge_ref: 683531aed9652851a03b1301624b9c769ce62d52
+      report_artifact_name: codeglyphx-cloudflare-post-deploy-reports
+      use_playwright_cache: false
+    secrets:
+      cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID_CODEGLYPHX }}

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.pipelinespec.schema.json",
+  "steps": [
+    {
+      "task": "cloudflare",
+      "id": "purge-cache",
+      "operation": "purge",
+      "siteConfig": "./site.json",
+      "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
+      "tokenEnv": "CLOUDFLARE_API_TOKEN"
+    },
+    {
+      "task": "cloudflare",
+      "id": "verify-cache",
+      "dependsOn": "purge-cache",
+      "operation": "verify",
+      "siteConfig": "./site.json",
+      "warmupRequests": 1,
+      "paths": [
+        "/",
+        "/docs/",
+        "/api/",
+        "/api/index.json",
+        "/playground/",
+        "/agents.json",
+        "/.well-known/api-catalog",
+        "/llms.txt",
+        "/favicon.svg"
+      ],
+      "allowStatuses": "HIT,REVALIDATED,EXPIRED,STALE",
+      "reportPath": "./_reports/cloudflare-cache.json",
+      "summaryPath": "./_reports/cloudflare-cache.md"
+    }
+  ]
+}

--- a/Website/site.json
+++ b/Website/site.json
@@ -72,6 +72,7 @@
     "Robots": true,
     "SecurityHeaders": {
       "Enabled": true,
+      "Hsts": true,
       "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     },
     "ContentSignals": {
@@ -135,6 +136,12 @@
     "OpenApi": { "Enabled": false },
     "WebMcp": false,
     "MarkdownNegotiation": true
+  },
+  "Cloudflare": {
+    "Cache": {
+      "EdgeTtlSeconds": 604800
+    },
+    "PurgeMode": "hostname"
   },
   "EditLinks": {
     "Enabled": true,

--- a/Website/site.json
+++ b/Website/site.json
@@ -82,19 +82,19 @@
       "AiTrain": false
     },
     "BotRules": [
-      { "UserAgent": "GPTBot", "Allow": "/" },
+      { "UserAgent": "GPTBot", "Disallow": "/" },
       { "UserAgent": "ChatGPT-User", "Allow": "/" },
       { "UserAgent": "OAI-SearchBot", "Allow": "/" },
-      { "UserAgent": "ClaudeBot", "Allow": "/" },
+      { "UserAgent": "ClaudeBot", "Disallow": "/" },
       { "UserAgent": "Claude-SearchBot", "Allow": "/" },
       { "UserAgent": "Claude-User", "Allow": "/" },
       { "UserAgent": "PerplexityBot", "Allow": "/" },
       { "UserAgent": "Perplexity-User", "Allow": "/" },
-      { "UserAgent": "Google-Extended", "Allow": "/" },
-      { "UserAgent": "Applebot-Extended", "Allow": "/" },
-      { "UserAgent": "Meta-ExternalAgent", "Allow": "/" },
-      { "UserAgent": "Amazonbot", "Allow": "/" },
-      { "UserAgent": "CCBot", "Allow": "/" }
+      { "UserAgent": "Google-Extended", "Disallow": "/" },
+      { "UserAgent": "Applebot-Extended", "Disallow": "/" },
+      { "UserAgent": "Meta-ExternalAgent", "Disallow": "/" },
+      { "UserAgent": "Amazonbot", "Disallow": "/" },
+      { "UserAgent": "CCBot", "Disallow": "/" }
     ],
     "ApiCatalog": {
       "Enabled": true,
@@ -117,21 +117,7 @@
       "Enabled": true,
       "Description": "Agent-facing discovery metadata for CodeGlyphX documentation, API reference, and support resources."
     },
-    "A2AAgentCard": {
-      "Enabled": true,
-      "Name": "CodeGlyphX Documentation Discovery",
-      "Description": "Discover CodeGlyphX documentation, API reference, llms summaries, sitemap, and project resources.",
-      "Url": "/",
-      "DocumentationUrl": "/docs/",
-      "Skills": [
-        {
-          "Id": "documentation-discovery",
-          "Name": "Documentation discovery",
-          "Description": "Find CodeGlyphX product documentation, API reference, release resources, and support pages.",
-          "Tags": ["documentation", "api-reference", "sitemap", "llms"]
-        }
-      ]
-    },
+    "A2AAgentCard": { "Enabled": false },
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
     "WebMcp": false,


### PR DESCRIPTION
## Summary

- replace the older cache-only action with the current managed PowerForge site policy
- move successful static-site responses to a seven-day edge TTL while respecting origin browser caching
- add an exact post-deploy Cloudflare purge and verification pipeline
- align crawler rules with the declared no-training preference and stop advertising an A2A service that is not hosted
- preserve the site's existing HSTS policy explicitly

## Validation

- PowerForge site planning and the full 20-step website pipeline passed
- generated agent artifacts block training crawlers, preserve search/user agents, and omit the A2A card
- the managed policy and exact post-deploy pipeline passed against production, with representative requests reaching Cloudflare HIT and the expected security and discovery headers