### PR TITLE
Codify Smart Tiered Cache for CodeGlyphX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,14 @@ jobs:
       actions: read
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,14 @@ jobs:
       actions: read
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -37,7 +37,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 60
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       report_artifact_name: codeglyphx-website-deploy-reports
       site_artifact_name: powerforge-site-codeglyphx.com
       site_artifact_retention_days: 7
@@ -105,7 +105,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.cloudflare.json
@@ -114,7 +114,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 30
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       report_artifact_name: codeglyphx-cloudflare-post-deploy-reports
       use_playwright_cache: false
     secrets:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -37,7 +37,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 60
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       report_artifact_name: codeglyphx-website-deploy-reports
       site_artifact_name: powerforge-site-codeglyphx.com
       site_artifact_retention_days: 7
@@ -105,7 +105,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.cloudflare.json
@@ -114,7 +114,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 30
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       report_artifact_name: codeglyphx-cloudflare-post-deploy-reports
       use_playwright_cache: false
     secrets:

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,12 +16,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,12 +16,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -3,16 +3,7 @@
   "steps": [
     {
       "task": "cloudflare",
-      "id": "purge-cache",
-      "operation": "purge",
-      "siteConfig": "./site.json",
-      "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
-      "tokenEnv": "CLOUDFLARE_API_TOKEN"
-    },
-    {
-      "task": "cloudflare",
       "id": "verify-cache",
-      "dependsOn": "purge-cache",
       "operation": "verify",
       "siteConfig": "./site.json",
       "warmupRequests": 1,
@@ -30,6 +21,14 @@
       "allowStatuses": "HIT,REVALIDATED,EXPIRED,STALE",
       "reportPath": "./_reports/cloudflare-cache.json",
       "summaryPath": "./_reports/cloudflare-cache.md"
+    },
+    {
+      "task": "agent-ready",
+      "id": "verify-agent-readiness-live",
+      "dependsOn": "verify-cache",
+      "operation": "scan",
+      "config": "./site.json",
+      "failOnFailures": true
     }
   ]
 }

--- a/Website/site.json
+++ b/Website/site.json
@@ -127,7 +127,8 @@
     "Cache": {
       "EdgeTtlSeconds": 604800
     },
-    "PurgeMode": "hostname"
+    "PurgeMode": "hostname",
+    "SmartTieredCache": true
   },
   "EditLinks": {
     "Enabled": true,

--- a/Website/site.json
+++ b/Website/site.json
@@ -121,7 +121,7 @@
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
     "WebMcp": false,
-    "MarkdownNegotiation": true
+    "MarkdownNegotiation": false
   },
   "Cloudflare": {
     "Cache": {


### PR DESCRIPTION
## Summary

- record Smart Tiered Cache in the managed CodeGlyphX site policy
- pin website CI, deployment verification, and maintenance to the current shared PowerForge owner
- retain hostname purge until the custom Linux deployment path provides the same manifest and deployment-continuity contract
- remove the redundant post-deploy purge and add fail-gated live agent and security verification
- stop advertising unsupported Markdown negotiation

The existing seven-day edge TTL and HSTS-enabled OVH posture remain unchanged.