### PR TITLE
Pin hardened PowerForge server backup action

### DIFF
--- a/.github/workflows/server-backup.yml
+++ b/.github/workflows/server-backup.yml
@@ -19,7 +19,7 @@ jobs:
     environment: production
     steps:
       - name: Capture and publish encrypted recovery state
-        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-backup@2dd1c901e40f22186593e7919652a899b19c11fd
+        uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-backup@f9afb61e17c34efd80b44e5c0d89e12624e5d582
         with:
           manifest-path: deploy/linux/codeglyphx.serverrecovery.json
           server-host: ${{ secrets.DEPLOYMENT_HOST }}


### PR DESCRIPTION
## Summary

- Pin the encrypted server-backup workflow to the merged PowerForge owner fix from [EvotecIT/PSPublishModule#848](https://github.com/EvotecIT/PSPublishModule/pull/848).
- Activate bounded retry handling for transient Git transport failures without duplicating backup behavior in CodeGlyphX.

## Validation

- Confirmed this is a scalar, full-commit-SHA workflow pin change.
- `git diff --check`

The owning PowerForge change is already merged, so this consumer update has no unpublished dependency.
