### PR TITLE
Enable WebMCP site search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,14 @@ jobs:
       actions: read
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.website-ci.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
       report_artifact_name: powerforge-website-reports
 
   coverage:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -37,7 +37,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 60
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
       report_artifact_name: codeglyphx-website-deploy-reports
       site_artifact_name: powerforge-site-codeglyphx.com
       site_artifact_retention_days: 7
@@ -105,7 +105,7 @@ jobs:
       actions: write
       contents: read
       packages: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-run.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.cloudflare.json
@@ -114,7 +114,7 @@ jobs:
       runner_labels_json: '["ubuntu-latest"]'
       timeout_minutes: 30
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
       report_artifact_name: codeglyphx-cloudflare-post-deploy-reports
       use_playwright_cache: false
     secrets:

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,12 +16,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9052036dad21f656d4e0ee61a1201788c6bee73d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 9052036dad21f656d4e0ee61a1201788c6bee73d
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -84,19 +84,6 @@
       "config": "./site.json"
     },
     {
-      "task": "verify",
-      "id": "verify-ci",
-      "dependsOn": "build-site",
-      "modes": ["ci"],
-      "config": "./site.json",
-      "baseline": "./.powerforge/verify-baseline.json",
-      "failOnNewWarnings": true,
-      "failOnNavLint": true,
-      "failOnThemeContract": true,
-      "warningPreviewCount": 10,
-      "errorPreviewCount": 10
-    },
-    {
       "task": "dotnet-build",
       "id": "build-library",
       "dependsOn": "verify-site",

--- a/Website/site.json
+++ b/Website/site.json
@@ -120,7 +120,16 @@
     "A2AAgentCard": { "Enabled": false },
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
-    "WebMcp": false,
+    "WebMcp": true,
+    "WebMcpTools": [
+      {
+        "Name": "search_site",
+        "Route": "/search/",
+        "Description": "Search CodeGlyphX documentation, API references, examples, and product pages.",
+        "Kind": "site-search",
+        "ReadOnly": true
+      }
+    ],
     "MarkdownNegotiation": false
   },
   "Cloudflare": {


### PR DESCRIPTION
## Summary

- enable the shared read-only `search_site` WebMCP tool for CodeGlyphX documentation
- pin website CI, maintenance, preview, and production deployment to PowerForge owner commit `9052036dad21f656d4e0ee61a1201788c6bee73d`
- keep strict rendered-artifact verification after the complete site and API overlay are available

## Validation

- the complete 20-step website pipeline passed locally
- agent-readiness reported 40 checks and 0 failures
- the artifact pipeline completed API generation, overlay, optimization, audit, and doctor checks

## Dependency

The reusable runtime, verification, asset hardening, and safety policy are owned by [EvotecIT/PSPublishModule#865](https://github.com/EvotecIT/PSPublishModule/pull/865), now merged. CodeGlyphX remains a configuration-only consumer.
